### PR TITLE
install latest datadog-agent release

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,11 +1,11 @@
 ---
 - apt_key: id=C7A7DA52 keyserver=keyserver.ubuntu.com state=present
 
-- apt_repository: repo='deb http://apt.datadoghq.com/ unstable main' state=present update_cache=yes
+- apt_repository: repo='deb http://apt.datadoghq.com/ stable main' state=present update_cache=yes
 
-- apt: name=datadog-agent state=present
+- apt: name=datadog-agent state=latest
 
-- apt: name=python-psutil state=present
+- apt: name=python-psutil state=latest
 
 - template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog


### PR DESCRIPTION
These changes are required to install the latest 5.0 release of the agent that is not affected by POODLE.
I had to swtich to `stable`. I'm not sure why the latest release is not on `unstable`.
