### PR TITLE
Added feature - conf.d files from templates

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -5,13 +5,16 @@
 
 - apt: name=datadog-agent state=latest
 
-- template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
+- name: copy datadog.conf file
+  template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog
 
-- template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
-  with_items: "{{ datadog_conf_d_files }}"
-  when: datadog_conf_d_files is defined
+- name: copy conf.d files if set
+  template: src={{ item }}.j2 dest=/etc/dd-agent/conf.d/{{ item }}
+  with_items: 
+    - "{{ datadog_conf_d_files }}"
   notify: restart datadog
+  when: datadog_conf_d_files is defined
 
 - service: name=datadog-agent state=started
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,7 +9,7 @@
   notify: restart datadog
 
 - template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
-  with_items: {{ datadog_conf_d_files }}
+  with_items: "{{ datadog_conf_d_files }}"
   when: datadog_conf_d_files is defined
   notify: restart datadog
 

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -8,5 +8,10 @@
 - template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog
 
+- template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
+  with_items: {{ datadog_conf_d_files }}
+  when: datadog_conf_d_files is defined
+  notify: restart datadog
+
 - service: name=datadog-agent state=started
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -9,7 +9,7 @@
   notify: restart datadog
 
 - template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
-  with_items: {{ datadog_conf_d_files }}
+  with_items: "{{ datadog_conf_d_files }}"
   when: datadog_conf_d_files is defined
   notify: restart datadog
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -5,13 +5,16 @@
 - name: Install datadog-agent package
   yum: name=datadog-agent state=latest
 
-- template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
+- name: copy datadog.conf file
+  template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog
 
-- template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
-  with_items: "{{ datadog_conf_d_files }}"
-  when: datadog_conf_d_files is defined
+- name: copy conf.d files if set
+  template: src={{ item }}.j2 dest=/etc/dd-agent/conf.d/{{ item }}
+  with_items: 
+    - "{{ datadog_conf_d_files }}"
   notify: restart datadog
+  when: datadog_conf_d_files is defined
 
 - service: name=datadog-agent state=started
 

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -8,5 +8,10 @@
 - template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
   notify: restart datadog
 
+- template: src="{{ item }}".j2 dest="/etc/dd-agent/conf.d/{{ item }}"
+  with_items: {{ datadog_conf_d_files }}
+  when: datadog_conf_d_files is defined
+  notify: restart datadog
+
 - service: name=datadog-agent state=started
 


### PR DESCRIPTION
If "datadog_conf_d_files" is defined, expect a list of template files to be deployed to /etc/dd-agent/conf.d/

This allows using data dog plugins 

Tested on CentOS 6, should work identically in Debian systems
