### PR TITLE
[yum] Check signature of the agent's RPM package

### DIFF
--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -1,5 +1,6 @@
 [datadog]
 name = Datadog, Inc.
-baseurl = http://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/
+baseurl = https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/
 enabled=1
-gpgcheck=0
+gpgcheck=1
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public


### PR DESCRIPTION
For Datadog Agent 5.5.0, the RPM package is signed with a GPG key. Let's
check the validity of this key when installing the RPM package with
Ansible.

FIXME: we'll have to switch the repo AND the public key URLs to HTTPS
when ready.