### PR TITLE
[apt] Add apt-transport-https to the debian install

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,4 +1,6 @@
 ---
+- apt: name=apt-transport-https state=latest
+
 - apt_key: id=C7A7DA52 keyserver=keyserver.ubuntu.com state=present
 
 - apt_repository: repo='deb http://apt.datadoghq.com/ stable main' state=present update_cache=yes


### PR DESCRIPTION
In preparation for HTTPS repo.

See also https://github.com/DataDog/dd-agent/pull/1779