### PR TITLE
Adds explicit file permissions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,3 +6,7 @@ datadog_config: {}
 
 # default checks enabled
 datadog_checks: {}
+
+# default user/group
+datadog_user: root
+datadog_group: root

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,5 +8,5 @@ datadog_config: {}
 datadog_checks: {}
 
 # default user/group
-datadog_user: root
+datadog_user: dd-agent
 datadog_group: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,8 +9,8 @@
   template:
     src=datadog.conf.j2
     dest=/etc/dd-agent/datadog.conf
-    owner=dd-agent
-    group=dd-agent
+    owner={{ datadog_user }}
+    group={{ datadog_group }}
   notify: restart datadog-agent
 
 # DEPRECATED: Remove specific handling of the process check for next major release
@@ -31,8 +31,8 @@
   template:
     src=checks.yaml.j2
     dest=/etc/dd-agent/conf.d/{{ item }}.yaml
-    owner=dd-agent
-    group=dd-agent
+    owner={{ datadog_user }}
+    group={{ datadog_group }}
   with_items: datadog_checks.keys()
   notify:
    - restart datadog-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,7 +6,11 @@
   when: ansible_os_family == "RedHat"
 
 - name: Create main Datadog agent configuration file
-  template: src=datadog.conf.j2 dest=/etc/dd-agent/datadog.conf
+  template:
+    src=datadog.conf.j2
+    dest=/etc/dd-agent/datadog.conf
+    owner=dd-agent
+    group=dd-agent
   notify: restart datadog-agent
 
 # DEPRECATED: Remove specific handling of the process check for next major release
@@ -27,6 +31,8 @@
   template:
     src=checks.yaml.j2
     dest=/etc/dd-agent/conf.d/{{ item }}.yaml
+    owner=dd-agent
+    group=dd-agent
   with_items: datadog_checks.keys()
   notify:
    - restart datadog-agent

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -4,7 +4,3 @@
 
 - name: Install datadog-agent package
   yum: name=datadog-agent state=latest
-
-- name: Override the dd-agent user/group
-  set_fact: datadog_user=dd-agent datadog_group=dd-agent
-  changed_when: false

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -4,3 +4,7 @@
 
 - name: Install datadog-agent package
   yum: name=datadog-agent state=latest
+
+- name: Override the dd-agent user/group
+  set_fact: datadog_user=dd-agent datadog_group=dd-agent
+  changed_when: false


### PR DESCRIPTION
This came about due to issues in the environment from which I work in.
We are bound by strict CIS rules which caused the files dropped by
ansible to have a mode of 0600 and owned by user/group root.  This prevents the
`dd-agent` user from reading the config files.

This PR simply enforces that user to own his the files such that he can
read them allowing the daemon to start.

Note that this PR assumes the user is dd-agent.  While this is true for
EL, I'm unaware of what the user is for Debian packages.