### PR TITLE
Changed keyserver to use port 80

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,7 +1,7 @@
 ---
 - apt: name=apt-transport-https state=latest
 
-- apt_key: id=C7A7DA52 keyserver=keyserver.ubuntu.com state=present
+- apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
 
 - apt_repository: repo='deb http://apt.datadoghq.com/ stable main' state=present update_cache=yes
 


### PR DESCRIPTION
Changed the keyserver to utilize the supported port 80 instead of the
default 11371 for use on networks that block/firewall non-standard
ports. When specifying a port number, you need to prepend the URL with
“hkp://“.