### PR TITLE
Avoids bare variables which is deprecated

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,6 @@
     dest=/etc/dd-agent/conf.d/{{ item }}.yaml
     owner={{ datadog_user }}
     group={{ datadog_group }}
-  with_items: datadog_checks.keys()
+  with_items: '{{ datadog_checks.keys() }}'
   notify:
    - restart datadog-agent


### PR DESCRIPTION
In the newer versions of Ansible a deprecation warning is thrown on this line because it is using a bare variable. I have updated the line to properly call the variable.
