### PR TITLE
Add a link to the role's Ansible Galaxy page in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 Ansible Datadog Role
 ========
+[![Ansible Galaxy](http://img.shields.io/badge/galaxy-Datadog.datadog-660198.svg)](https://galaxy.ansible.com/Datadog/datadog/)
 
 Install and configure Datadog base agent & checks.
 


### PR DESCRIPTION
It's helpful to link to a role's Ansible Galaxy page so that folks don't have to search for it themselves. This change adds such a link as a badge at the top of the [README](https://github.com/evnm/ansible-datadog/blob/add-galaxy-link-to-readme/README.md).
