### PR TITLE
Trust new APT and RPM keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Role Variables
 `datadog_checks` instead)
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_key_url` - Override default url to Datadog `apt` key
+- `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
 
 Dependencies
 ------------

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,6 +1,12 @@
 ---
 - apt: name=apt-transport-https state=latest
 
+- apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE keyserver=hkp://keyserver.ubuntu.com:80 state=present
+  when: datadog_apt_key_url_new is not defined
+
+- apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
+  when: datadog_apt_key_url_new is defined
+
 - apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
   when: datadog_apt_key_url is not defined
 

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,4 +1,13 @@
 ---
+- name: Download new RPM key
+  get_url:
+    url: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
+
+- name: Import new RPM key
+  rpm_key: key=/tmp/DATADOG_RPM_KEY_E09422B3.public state=present
+
 - name: Copy repo file into place
   template: src=datadog.repo.j2 dest=/etc/yum.repos.d/datadog.repo owner=root group=root mode=0644
 


### PR DESCRIPTION
Make the pkg managers trust the new keys in addition to the current keys. Similar approach as what's described in https://github.com/DataDog/chef-datadog/pull/365.
### APT
-  Straightforward with the `apt_key` module
- Allow customizing the URL with `datadog_apt_key_url_new` (for users
  with local apt mirrors)
### RPM
- Download the new key through plain HTTP for best compatibility (since
  SSL only works when the managed nodes have a recent version of python)
- Ensure the integrity of the downloaded file using a sha-256 sum. We use
  the `sha256sum` option instead of `checksum` since `checksum` was only
  added in Ansible 2.0
- The `rpm_key` module has a good idempotent behavior so no need to have
  extra steps to check whether the key is already imported.
### Testing

Tested manually w/ Ansible `1.9.2` and `2.1.1`, against Ubuntu 14.04 and CentOS 6
