### PR TITLE
Remove use_mount

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -8,9 +8,6 @@
 {% if datadog_config["api_key"] is not defined -%}
   api_key: {{ datadog_api_key | default('youshouldsetthis') }}
 {% endif %}
-{% if datadog_config["use_mount"] is not defined -%}
-  use_mount: {{ datadog_use_mount | default('no') }}
-{% endif %}
 
 {# These variables are free-style, passed through a hash -#}
 {% if datadog_config -%}


### PR DESCRIPTION
Using `use_mount` in datadog.conf has been deprecated in favor of `use_mount` in disk.yaml
