### PR TITLE
Convert to proper YAML formatting

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,10 @@
 
 - name: Create main Datadog agent configuration file
   template:
-    src=datadog.conf.j2
-    dest=/etc/dd-agent/datadog.conf
-    owner={{ datadog_user }}
-    group={{ datadog_group }}
+    src: datadog.conf.j2
+    dest: /etc/dd-agent/datadog.conf
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
   notify: restart datadog-agent
 
 # DEPRECATED: Remove specific handling of the process check for next major release
@@ -29,10 +29,10 @@
 
 - name: Create a configuration file for each Datadog check
   template:
-    src=checks.yaml.j2
-    dest=/etc/dd-agent/conf.d/{{ item }}.yaml
-    owner={{ datadog_user }}
-    group={{ datadog_group }}
+    src: checks.yaml.j2
+    dest: /etc/dd-agent/conf.d/{{ item }}.yaml
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
   with_items: '{{ datadog_checks.keys() }}'
   notify:
    - restart datadog-agent


### PR DESCRIPTION
Using separate lines of `key=value` format isn't proper YAML syntax. Yes, technically it's supported by Ansible. However, IIRC, when it's not proper YAML, it bypasses some Ansible sanity checks because those kv pairs are passed straight through to python as strings. Plus treating it as proper YAML doesn't break syntax highlighters.