### PR TITLE
Force apt cache update unless updated within the hour

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,5 +1,5 @@
 ---
-- apt: name=apt-transport-https state=latest
+- apt: name=apt-transport-https update_cache=yes cache_valid_time=3600 state=latest
 
 - apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
   when: datadog_apt_key_url is not defined


### PR DESCRIPTION
Unless a recent apt update has been performed, there's a real chance that installing the latest version of this package will fail. To avoid making an update when one has been performed recently, I check the cache is fairly recent.