### PR TITLE
adding support to install dd-agent on suse

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
 - include: pkg-redhat.yml
   when: ansible_os_family == "RedHat"
 
+- include: pkg-suse.yml
+  when: ansible_os_family == "Suse"
+
 - name: Create main Datadog agent configuration file
   template:
     src: datadog.conf.j2

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -1,0 +1,6 @@
+---
+- name: Copy repo file into place
+  template: src=datadog-suse.repo.j2 dest=/etc/zypp/repos.d/datadog.repo owner=root group=root mode=0644
+
+- name: Install datadog-agent package
+  zypper: name=datadog-agent state=latest update_cache=yes

--- a/templates/datadog-suse.repo.j2
+++ b/templates/datadog-suse.repo.j2
@@ -1,0 +1,8 @@
+[datadog]
+name=Datadog, Inc.
+enabled=1
+baseurl=https://yum.datadoghq.com/suse/rpm/x86_64
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0
+gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public


### PR DESCRIPTION
@olivielpeau Did I miss any content from what we put together earlier?

I set `gpgcheck=1` for now, although old zypper users may want that to be configurable. Not sure how many customers will not have the `repo_gpgcheck` variable available... Thoughts?