### PR TITLE
add support for configuring trace agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example Playbooks
       trace.config:
         env: dev
       trace.concentrator:
-	extra_aggregators: version
+        extra_aggregators: version
     datadog_checks:
       process:
         init_config:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Example Playbooks
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
+      apm_enabled: true
     datadog_config_ex:
       trace.config:
         env: dev

--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Role Variables
 
 - `datadog_api_key` - Your Datadog API key.
 - `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
-- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf` ini that go under `[Main]`.
-- `datadog_config_ex` - extra ini sections to go in `/etc/dd-agent/datadog.conf`.
+- `datadog_config` - Settings to place in the `/etc/dd-agent/datadog.conf` INI file that go under the `[Main]` section.
+- `datadog_config_ex` - Extra INI sections to go in `/etc/dd-agent/datadog.conf` (optional).
 - `datadog_process_checks` - Array of process checks and options (DEPRECATED: use `process` under
 `datadog_checks` instead)
 - `datadog_apt_repo` - Override default Datadog `apt` repository

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Role Variables
 
 - `datadog_api_key` - Your Datadog API key.
 - `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
-- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf`.
+- `datadog_config` - Settings to place in `/etc/dd-agent/datadog.conf` ini that go under `[Main]`.
+- `datadog_config_ex` - extra ini sections to go in `/etc/dd-agent/datadog.conf`.
 - `datadog_process_checks` - Array of process checks and options (DEPRECATED: use `process` under
 `datadog_checks` instead)
 - `datadog_apt_repo` - Override default Datadog `apt` repository
@@ -40,6 +41,11 @@ Example Playbooks
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
+    datadog_config_ex:
+      trace.config:
+        env: dev
+      trace.concentrator:
+	extra_aggregators: version
     datadog_checks:
       process:
         init_config:

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -18,8 +18,8 @@
 {% endif %}
 
 {% if datadog_config_ex is defined -%}
-{% for key, value in datadog_config_ex.iteritems() %}
-[{{ key }}]
-{{ value | to_nice_yaml }}
+{% for section, keyvals in datadog_config_ex.iteritems() %}
+[{{ section }}]
+{{ keyvals | to_nice_yaml }}
 {% endfor %}
 {% endif %}

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -16,3 +16,10 @@
 {% if datadog_config -%}
   {{ datadog_config | to_nice_yaml }}
 {% endif %}
+
+{% if datadog_config_ex is defined -%}
+{% for key, value in datadog_config_ex.iteritems() %}
+[{{ key }}]
+{{ value | to_nice_yaml }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
With 5.11.0, there are additional sections in datadog.conf observed
by the trace agent.

But changing the semantics of `datadog_config` will break backwards
compatibility with existing role users expecting that dictionary
to populate the [Main] section.

Instead, we add another nested dictionary to support extra
sections.