### PR TITLE
Ansible lint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+---
+language: python
+python: "2.7"
+
+install:
+  - pip install ansible-lint
+
+script:
+  - ansible-lint $(find tests -name *yml) -x ANSIBLE0010

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,17 +14,20 @@
   notify: restart datadog-agent
 
 # DEPRECATED: Remove specific handling of the process check for next major release
-- template: src=process.yaml.j2 dest=/etc/dd-agent/conf.d/process.yaml
+- name: Add process check configuration
+  template: src=process.yaml.j2 dest=/etc/dd-agent/conf.d/process.yaml
   when: datadog_process_checks is defined
   notify: restart datadog
 
 - debug: 'msg="[DEPRECATION NOTICE] Using `datadog_process_checks` is deprecated, use `process` under `datadog_checks` instead"'
   when: datadog_process_checks is defined
 
-- service: name=datadog-agent state=started enabled=yes
+- name: Ensure service is running
+  service: name=datadog-agent state=started enabled=yes
   when: datadog_enabled
 
-- service: name=datadog-agent state=stopped enabled=no
+- name: Ensure service is not running
+  service: name=datadog-agent state=stopped enabled=no
   when: not datadog_enabled
 
 - name: Create a configuration file for each Datadog check

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,18 +1,25 @@
 ---
-- apt: name=apt-transport-https state=present
+- name: Install apt-transport-https
+  apt: name=apt-transport-https state=present
 
-- apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE keyserver=hkp://keyserver.ubuntu.com:80 state=present
+- name: Install ubuntu apt-key server
+  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE keyserver=hkp://keyserver.ubuntu.com:80 state=present
   when: datadog_apt_key_url_new is not defined
 
-- apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
+- name: Install Datadog apt-key
+  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
   when: datadog_apt_key_url_new is defined
 
-- apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
+- name: Ensure ubuntu apt-key server is present
+  apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
   when: datadog_apt_key_url is not defined
 
-- apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
+- name: Ensure Datadog apt-key is present
+  apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
   when: datadog_apt_key_url is defined
 
-- apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
+- name: Ensure Datadog repository is up-to-date
+  apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
 
-- apt: name=datadog-agent state=latest
+- name: Ensure Datadog agent is installed
+  apt: name=datadog-agent state=latest

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,0 +1,4 @@
+---
+- hosts: localhost
+  roles:
+  - { role: Datadog.datadog, become: yes }


### PR DESCRIPTION
This is a proposition to activate a kind of Ansible check-style enforcement using `ansible-lint`. It currently only ignores `[EANSIBLE0010] Package installs should not use latest` since I'm not sure how you'd like to fix it.

Please share your thoughts.