### PR TITLE
Pipe datadog_checks through list for Python 3

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,6 @@
     dest: /etc/dd-agent/conf.d/{{ item }}.yaml
     owner: '{{ datadog_user }}'
     group: '{{ datadog_group }}'
-  with_items: '{{ datadog_checks.keys() }}'
+  with_items: '{{ datadog_checks|list }}'
   notify:
    - restart datadog-agent


### PR DESCRIPTION
I ran into [an issue described in Ansible on Python 3](https://github.com/ansible/ansible/issues/19514), in which the module fails when trying to iterate through keys:
```
TASK [Datadog.datadog : Create a configuration file for each Datadog check] ****
failed: [default] (item=dict_keys(['process'])) => {"failed": true, "item": "dict_keys(['process'])", "msg": "AnsibleUndefinedVariable: 'dict object' has no attribute \"dict_keys(['process'])\""}

PLAY RECAP *********************************************************************
default                    : ok=8    changed=6    unreachable=0    failed=1
```

Ansible developers recommend piping dicts through `list` to work around this issue. Trying this on my own Ansible 2.2.1.0/Python 3 environment, I was able to eliminate the issue. The discussion on the issue indicates that this is backward-compatible with lesser versions of Ansible and Python.