### PR TITLE
Fixed broken large mysql queries

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -14,12 +14,12 @@
 
 {# These variables are free-style, passed through a hash -#}
 {% if datadog_config -%}
-  {{ datadog_config | to_nice_yaml }}
+  {{ datadog_config | to_yaml }}
 {% endif %}
 
 {% if datadog_config_ex is defined -%}
 {% for section, keyvals in datadog_config_ex.iteritems() %}
 [{{ section }}]
-{{ keyvals | to_nice_yaml }}
+{{ keyvals | to_yaml }}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Following long query stament on mysql check causes datadog to not start.
Check definition
```
datadog_checks:
    mysql:
        init_config: null
        instances:
        -   options:
                disable_innodb_metrics: false
                extra_innodb_metrics: true
                extra_performance_metrics: true
                extra_status_metrics: true
                galera_cluster: false
                replication: true
                schema_size_metrics: false
            pass: ***********
            queries:
            -  field: services_completed_in_prev_5_mins
                metric: app.services.completed_in_prev_5_mins
                query: SELECT COUNT(*) AS services_completed_in_prev_5_mins FROM companies.services WHERE created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE);
                type: guage
```

The result in datadog.yml:
```
            -   field: bookings_started_in_prev_5_mins
                metric: app.bookings.started_in_prev_5_mins
                query: SELECT COUNT(*) AS bookings_started_in_prev_5_mins FROM travelgroup.abandonedbookings
                    WHERE created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE);
                type: guage
```

The error:
`Couldn't initialize logging: File contains parsing errors: <???>
[line 26]: 'WHERE created_at > DATE_SUB(NOW(), INTERVAL 5 MINUTE);\n’`

Replacing `to_nice_yaml` on https://github.com/DataDog/ansible-datadog/blob/master/templates/datadog.conf.j2#L17 with `to_nice_yaml(width=200)` resolves it.