### PR TITLE
[datadog.conf] Use `items()` instead of `iteritems()` for py3 support

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -18,7 +18,7 @@
 {% endif %}
 
 {% if datadog_config_ex is defined -%}
-{% for section, keyvals in datadog_config_ex.iteritems() %}
+{% for section, keyvals in datadog_config_ex.items() %}
 [{{ section }}]
 {{ keyvals | to_nice_yaml }}
 {% endfor %}


### PR DESCRIPTION
We should aim at supporting python 3 now that Ansible supports it.

`iteritems` doesn't exist in python3. We're dealing with a dict that'll
always be relatively small so switching to `items` is painless.