### PR TITLE
[datadog.conf] Fix ini format of the file

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -14,12 +14,16 @@
 
 {# These variables are free-style, passed through a hash -#}
 {% if datadog_config -%}
-  {{ datadog_config | to_nice_yaml }}
+{% for key, value in datadog_config.items() -%}
+{{ key }}: {{ value }}
+{% endfor -%}
 {% endif %}
 
 {% if datadog_config_ex is defined -%}
 {% for section, keyvals in datadog_config_ex.items() %}
 [{{ section }}]
-{{ keyvals | to_nice_yaml }}
+{% for key, value in keyvals.items() -%}
+{{ key }}: {{ value }}
+{% endfor -%}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Using the `to_nice_yaml` filter can break the `ini` format of the file.

Use manual formatting instead since there's no filter that offers `ini` formatting
out-of-the-box.

Should fix #49