### PR TITLE
[ansible-lint] Use repository name as role name for linting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install ansible-lint
 
 script:
-  - ansible-lint $(find tests -name *yml) -x ANSIBLE0010
+  - ansible-lint -v $(find tests -name *yml) -x ANSIBLE0010

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,4 +1,4 @@
 ---
 - hosts: localhost
   roles:
-  - { role: Datadog.datadog, become: yes }
+  - { role: ansible-datadog, become: yes }


### PR DESCRIPTION
The name of the current local directory is what should be used so that
ansible-lint lints the correct task files

(Using `Datadog.datadog` would only look for installed roles, not
the role in the current directory)

Follow-up to #50, cc @eplanet 