### PR TITLE
Allow pinning the version of the Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Role Variables
 --------------
 
 - `datadog_api_key` - Your Datadog API key.
-- `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
+- `datadog_agent_version` - The pinned version of the Agent to install (optional, but highly recommended)
+  Examples: `1:5.12.3-1` on apt-based platforms, `5.12.3-1` on yum-based platforms- `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
 - `datadog_config` - Settings to place in the `/etc/dd-agent/datadog.conf` INI file that go under the `[Main]` section.
 - `datadog_config_ex` - Extra INI sections to go in `/etc/dd-agent/datadog.conf` (optional).
 - `datadog_process_checks` - Array of process checks and options (DEPRECATED: use `process` under
@@ -25,6 +26,7 @@ Role Variables
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_key_url` - Override default url to Datadog `apt` key
 - `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
+- `datadog_allow_agent_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
 
 Dependencies
 ------------
@@ -38,6 +40,7 @@ Example Playbooks
     - { role: Datadog.datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
   vars:
     datadog_api_key: "123456"
+    datadog_agent_version: "1:5.12.3-1" # for apt-based platforms, use a `5.12.3-1` format on yum-based platforms
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Role Variables
 
 - `datadog_api_key` - Your Datadog API key.
 - `datadog_agent_version` - The pinned version of the Agent to install (optional, but highly recommended)
-  Examples: `1:5.12.3-1` on apt-based platforms, `5.12.3-1` on yum-based platforms- `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
+  Examples: `1:5.12.3-1` on apt-based platforms, `5.12.3-1` on yum-based platforms
+- `datadog_checks` - YAML configuration for agent checks to drop into `/etc/dd-agent/conf.d`.
 - `datadog_config` - Settings to place in the `/etc/dd-agent/datadog.conf` INI file that go under the `[Main]` section.
 - `datadog_config_ex` - Extra INI sections to go in `/etc/dd-agent/datadog.conf` (optional).
 - `datadog_process_checks` - Array of process checks and options (DEPRECATED: use `process` under

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,3 +13,10 @@ datadog_group: root
 
 # default apt repo
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
+
+# Pin agent to a version. Highly recommended.
+datadog_agent_version: ""
+
+# Set this to `yes` to allow agent downgrades on apt-based platforms.
+# Internally, this uses `apt-get`'s `--force-yes` option. Use with caution.
+datadog_agent_allow_downgrade: no

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -21,5 +21,15 @@
 - name: Ensure Datadog repository is up-to-date
   apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
 
+- name: Ensure pinned version of Datadog agent is installed
+  apt:
+    name: datadog-agent={{ datadog_agent_version }}
+    state: present
+    force: "{{ datadog_agent_allow_downgrade }}"
+  when: datadog_agent_version != ""
+
 - name: Ensure Datadog agent is installed
-  apt: name=datadog-agent state=latest
+  apt:
+    name: datadog-agent
+    state: latest
+  when: datadog_agent_version == ""

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -11,5 +11,14 @@
 - name: Copy repo file into place
   template: src=datadog.repo.j2 dest=/etc/yum.repos.d/datadog.repo owner=root group=root mode=0644
 
-- name: Install datadog-agent package
-  yum: name=datadog-agent state=latest
+- name: Install pinned datadog-agent package
+  yum:
+    name: datadog-agent-{{ datadog_agent_version }}
+    state: present
+  when: datadog_agent_version != ""
+
+- name: Install latest datadog-agent package
+  yum:
+    name: datadog-agent
+    state: latest
+  when: datadog_agent_version == ""


### PR DESCRIPTION
And encourage users to pin the version. Addresses #57

By default we still auto-upgrade the agent, let's change this default behavior in the next major release of this role