### PR TITLE
[readme] Add quotes on `apm_enabled` value

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Example Playbooks
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
-      apm_enabled: true
+      apm_enabled: "true" # has to be set as a string
     datadog_config_ex:
       trace.config:
         env: dev


### PR DESCRIPTION
The only "truthy" value the trace agent currently understands
is `true`. A true boolean in the playbook yaml is printed as `True` in
the generated datadog.conf, so the value has to be a string explicitly.

Other conf values don't have this issue since `dd-agent` does a pretty
good job at normalizing values from datadog.conf.