### PR TITLE
DRY up the apt-keys task using a default variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ datadog_group: root
 
 # default apt repo
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
+datadog_apt_key_url: "hkp://keyserver.ubuntu.com:80"
 
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -2,21 +2,16 @@
 - name: Install apt-transport-https
   apt: name=apt-transport-https state=present
 
-- name: Install ubuntu apt-key server
-  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE keyserver=hkp://keyserver.ubuntu.com:80 state=present
-  when: datadog_apt_key_url_new is not defined
-
-- name: Install Datadog apt-key
-  apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
-  when: datadog_apt_key_url_new is defined
-
-- name: Ensure ubuntu apt-key server is present
-  apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
-  when: datadog_apt_key_url is not defined
-
-- name: Ensure Datadog apt-key is present
-  apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
-  when: datadog_apt_key_url is defined
+- name: Ensure Datadog apt-keys are installed
+  apt_key:
+    id: "{{ item }}"
+    keyserver: "{{ datadog_apt_key_url }}"
+    state: present
+  with_items:
+    # New key
+    - A2923DFF56EDA6E76E55E492D3A80E30382E94DE
+    # Old key, will be removed in the future
+    - C7A7DA52
 
 - name: Ensure Datadog repository is up-to-date
   apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes


### PR DESCRIPTION
Uses a default var instead of repeating tasks.

Note that this changes the behavior slightly such that the same keyserver will be used for fetching both the old and new keys. Open to feedback on this, just the more I thought about it, I realized that anyone paranoid enough to run their own keyserver will likely be doing it for both keys (or simply comment out the key they don't want). 