### PR TITLE
Allowing for custom yum repo

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,11 @@ datadog_group: root
 # default apt repo
 datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
 
+# default yum repo and keys
+datadog_yum_repo: "https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/"
+datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_rpm_gpgkey: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,8 +16,8 @@ datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
 
 # default yum repo and keys
 datadog_yum_repo: "https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/"
-datadog_yum_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
-datadog_rpm_gpgkey: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_yum_gpgkey_new: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -16,7 +16,7 @@ datadog_apt_repo: "deb http://apt.datadoghq.com/ stable main"
 
 # default yum repo and keys
 datadog_yum_repo: "https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/"
-datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_yum_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
 datadog_rpm_gpgkey: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 
 # Pin agent to a version. Highly recommended.

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download new RPM key
   get_url:
-    url: "{{ datadog_rpm_gpgkey }}"
+    url: "{{ datadog_yum_gpgkey_new }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
 

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,7 +1,7 @@
 ---
 - name: Download new RPM key
   get_url:
-    url: "http://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+    url: "{{ datadog_rpm_gpgkey }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
 

--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -1,6 +1,6 @@
 [datadog]
-name = Datadog, Inc.
-baseurl = https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}/
+name=Datadog, Inc.
+baseurl={{ datadog_yum_repo }}
 enabled=1
 gpgcheck=1
-gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
+gpgkey={{ datadog_yum_gpgkey }}

--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -3,4 +3,4 @@ name=Datadog, Inc.
 baseurl={{ datadog_yum_repo }}
 enabled=1
 gpgcheck=1
-gpgkey={{ datadog_yum_gpgkey }}
+gpgkey={{ datadog_yum_gpgkey_new}}

--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -3,4 +3,4 @@ name=Datadog, Inc.
 baseurl={{ datadog_yum_repo }}
 enabled=1
 gpgcheck=1
-gpgkey={{ datadog_yum_gpgkey_new}}
+gpgkey={{ datadog_yum_gpgkey }}


### PR DESCRIPTION
/etc/yum.repos.d/datadog.repo is still being created, but its URL content is customizable
Repo name and filename remain 
