### PR TITLE
Adding Agent6 (beta) support on debianoids

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,26 @@ Role Variables
 - `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
 
+Agent 6 (beta)
+--------------
+
+To upgrade or install agent6, you need to:
+
+- set `datadog_agent6` to true
+- either set `datadog_agent_version` to an existing agent6 version
+  (recommended) or leave it empty to always install the latest version.
+
+To downgrade from agent6 to agent5, you need to:
+
+- set `datadog_agent6` to false
+- pin `datadog_agent_version` to an existing agent5 version
+- set `datadog_agent_allow_downgrade` to yes
+
+Variables:
+
+- `datadog_agent6` - install an agent6 instead of agent5 (default to `false`)
+- `datadog_agent6_apt_repo` - Override default Datadog `apt` repository for agent6
+
 Dependencies
 ------------
 None

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Role Variables
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_key_url` - Override default url to Datadog `apt` key
 - `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
-- `datadog_allow_agent_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
+- `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,3 +25,29 @@ datadog_agent_version: ""
 # Set this to `yes` to allow agent downgrades on apt-based platforms.
 # Internally, this uses `apt-get`'s `--force-yes` option. Use with caution.
 datadog_agent_allow_downgrade: no
+
+########################################################################
+###            Beta-Agent6-only attributes, experimental             ###
+###   These attributes are not part of the stable API of the role    ###
+###   Subject to breaking changes between bugfix/minor versions      ###
+###                Only works on debianoids for now                  ###
+
+# Set to true to install an agent6 instead of agent5.
+#
+# To upgrade from agent5 to agent6, you need to:
+# * set 'datadog_agent6' to true, and
+# * either set 'datadog_agent_version' to an existing agent6 version
+#   (recommended) or leave it empty to always install the latest version.
+#
+# To downgrade from agent6 to agent5, you need to:
+# * 'datadog_set agent6' to false, and
+# * pin 'datadog_agent_version' to an existing agent5 version
+# * set 'datadog_agent_allow_downgrade' to yes
+datadog_agent6: no
+
+# beta APT repo where datadog-agent v6 packages are available
+datadog_agent6_apt_repo: "deb http://apt.datadoghq.com beta main"
+
+###           End of Beta-Agent6-only experimental attributes        ###
+########################################################################
+

--- a/tasks/agent5.yml
+++ b/tasks/agent5.yml
@@ -1,0 +1,34 @@
+---
+- name: Create main Datadog agent configuration file
+  template:
+    src: datadog.conf.j2
+    dest: /etc/dd-agent/datadog.conf
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  notify: restart datadog-agent
+
+# DEPRECATED: Remove specific handling of the process check for next major release
+- name: Add process check configuration
+  template: src=process.yaml.j2 dest=/etc/dd-agent/conf.d/process.yaml
+  when: datadog_process_checks is defined
+  notify: restart datadog-agent
+
+- debug: 'msg="[DEPRECATION NOTICE] Using `datadog_process_checks` is deprecated, use `process` under `datadog_checks` instead"'
+  when: datadog_process_checks is defined
+
+- name: Ensure datadog-agent is running
+  service: name=datadog-agent state=started enabled=yes
+  when: datadog_enabled
+
+- name: Ensure datadog-agent is not running
+  service: name=datadog-agent state=stopped enabled=no
+  when: not datadog_enabled
+
+- name: Create a configuration file for each Datadog check
+  template:
+    src: checks.yaml.j2
+    dest: /etc/dd-agent/conf.d/{{ item }}.yaml
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  with_items: '{{ datadog_checks|list }}'
+  notify: restart datadog-agent

--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -1,0 +1,44 @@
+---
+- name: Create main Datadog agant yaml configuration file (beta)
+  template:
+    src: datadog.yaml.j2
+    dest: /etc/datadog-agent/datadog.yaml
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  notify: restart datadog-agent
+
+- debug: 'msg="Using deprecated `datadog_process_checks` is no longer supported in agent6, use `process` under `datadog_checks` instead"'
+  when: datadog_process_checks is defined
+
+- name: Create a configuration file for each Datadog check
+  template:
+    src: checks.yaml.j2
+    dest: "/etc/datadog-agent/conf.d/{{ item }}.yaml"
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  with_items: '{{ datadog_checks|list }}'
+  notify: restart datadog-agent
+
+- name: Create trace agent configuration file
+  template:
+    src: datadog.conf.j2
+    dest: /etc/datadog-agent/trace-agent.conf
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  notify: restart datadog-agent
+
+- name: Create process agent configuration file
+  template:
+    src: datadog.conf.j2
+    dest: /etc/datadog-agent/process-agent.conf
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  notify: restart datadog-agent
+
+- name: Ensure datadog-agent is running
+  service: name=datadog-agent state=started enabled=yes
+  when: datadog_enabled
+
+- name: Ensure datadog-agent is not running
+  service: name=datadog-agent state=stopped enabled=no
+  when: not datadog_enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,36 +5,8 @@
 - include: pkg-redhat.yml
   when: ansible_os_family == "RedHat"
 
-- name: Create main Datadog agent configuration file
-  template:
-    src: datadog.conf.j2
-    dest: /etc/dd-agent/datadog.conf
-    owner: '{{ datadog_user }}'
-    group: '{{ datadog_group }}'
-  notify: restart datadog-agent
+- include: agent5.yml
+  when: not datadog_agent6
 
-# DEPRECATED: Remove specific handling of the process check for next major release
-- name: Add process check configuration
-  template: src=process.yaml.j2 dest=/etc/dd-agent/conf.d/process.yaml
-  when: datadog_process_checks is defined
-  notify: restart datadog-agent
-
-- debug: 'msg="[DEPRECATION NOTICE] Using `datadog_process_checks` is deprecated, use `process` under `datadog_checks` instead"'
-  when: datadog_process_checks is defined
-
-- name: Ensure datadog-agent is running
-  service: name=datadog-agent state=started enabled=yes
-  when: datadog_enabled
-
-- name: Ensure datadog-agent is not running
-  service: name=datadog-agent state=stopped enabled=no
-  when: not datadog_enabled
-
-- name: Create a configuration file for each Datadog check
-  template:
-    src: checks.yaml.j2
-    dest: /etc/dd-agent/conf.d/{{ item }}.yaml
-    owner: '{{ datadog_user }}'
-    group: '{{ datadog_group }}'
-  with_items: '{{ datadog_checks|list }}'
-  notify: restart datadog-agent
+- include: agent6.yml
+  when: datadog_agent6

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -19,7 +19,16 @@
   when: datadog_apt_key_url is defined
 
 - name: Ensure Datadog repository is up-to-date
-  apt_repository: repo='{{ datadog_apt_repo }}' state=present update_cache=yes
+  apt_repository:
+    repo: "{{ datadog_apt_repo }}"
+    state: "{% if datadog_agent6 %}absent{% else %}present{% endif %}"
+    update_cache: yes
+
+- name: Ensure Datadog repository is up-to-date (beta)
+  apt_repository:
+    repo: "{{ datadog_agent6_apt_repo }}"
+    state: "{% if datadog_agent6 %}present{% else %}absent{% endif %}"
+    update_cache: yes
 
 - name: Ensure pinned version of Datadog agent is installed
   apt:

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -1,0 +1,11 @@
+# Managed by Ansible
+
+{% if datadog_config["dd_url"] is not defined -%}
+dd_url: {{ datadog_url | default('https://app.datadoghq.com') }}
+{% endif %}
+
+{% if datadog_config["api_key"] is not defined -%}
+api_key: {{ datadog_api_key | default('youshouldsetthis') }}
+{% endif %}
+
+{{ datadog_config | to_nice_yaml }}


### PR DESCRIPTION
This PR allow users to install the Agent6 (beta agent) with ansible on debianoids system.