### PR TITLE
add custom conf.d files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Role Variables
 - `datadog_apt_key_url` - Override default url to Datadog `apt` key
 - `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
 - `datadog_allow_agent_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
+- `custom_confd` - Put custom yaml files into conf.d (build a new directory in your repo with your yaml, and define custom_confd = your_custom_direcotry/)
 
 Dependencies
 ------------

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,3 +38,12 @@
     group: '{{ datadog_group }}'
   with_items: '{{ datadog_checks|list }}'
   notify: restart datadog-agent
+
+- name: copy such custom configuration file to conf.d
+  copy:
+    src: "{{ custom_confd }}"
+    dest: /etc/dd-agent/conf.d
+    owner: '{{ datadog_user }}'
+    group: '{{ datadog_group }}'
+  when: custom_confd is defined
+  notify: restart datadog-agent


### PR DESCRIPTION
# Motivation:
I have different projects with different conf.d, and I want to use the same datadog.yaml playbook

I have put new var as custom conf.d directory, the bar must finish with a slash '/'
example:
`my_custom_confd/`