### PR TITLE
Add log example for Ansible configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Example Playbooks
       tags: "mytag0, mytag1"
       log_level: INFO
       apm_enabled: "true" # has to be set as a string
+      log_enabled: true 
     datadog_config_ex:
       trace.config:
         env: dev
@@ -106,6 +107,19 @@ Example Playbooks
           - nginx_status_url: http://example2.com:1234/nginx_status/
             tags:
               - instance:bar
+        logs:
+          - type: file
+            path: /var/log/access.log
+            service: myapp
+            source: nginx
+            sourcecategory: http_web_access
+    
+          - type: file
+            path: /var/log/error.log
+            service: nginx
+            source: nginx
+            sourcecategory: http_web_access
+         
 ```
 
 ```yml

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Example Playbooks
       tags: "mytag0, mytag1"
       log_level: INFO
       apm_enabled: "true" # has to be set as a string
-      log_enabled: true 
+      log_enabled: true   # log collection is available on agent 6
     datadog_config_ex:
       trace.config:
         env: dev
@@ -107,6 +107,7 @@ Example Playbooks
           - nginx_status_url: http://example2.com:1234/nginx_status/
             tags:
               - instance:bar
+        #Log collection is available on agent 6
         logs:
           - type: file
             path: /var/log/access.log


### PR DESCRIPTION
The agent 6 now support log collection so we need to update ansible configuration example with a log section.