### PR TITLE
Support Agent v6 on yum-based platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ install:
   - pip install ansible-lint
 
 script:
-  - ansible-lint -v $(find tests -name *yml) -x ANSIBLE0010
+  - ansible-lint -v $(find tests -name *yml) -x ANSIBLE0006,ANSIBLE0010

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 1.5.0 / 2018-01-05
+
+* [FEATURE] Add Agent6 (beta) support on RPM-based distros. See [#90][] (thanks [@brendanlong][])
+
 # 1.4.0 / 2017-10-30
 
 * [FEATURE] Allow specifying custom repo. See [#80][]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,8 +45,9 @@ datadog_agent_allow_downgrade: no
 # * set 'datadog_agent_allow_downgrade' to yes
 datadog_agent6: no
 
-# beta APT repo where datadog-agent v6 packages are available
+# beta repos where datadog-agent v6 packages are available
 datadog_agent6_apt_repo: "deb http://apt.datadoghq.com beta main"
+datadog_agent6_yum_repo: "https://yum.datadoghq.com/beta/{{ ansible_userspace_architecture }}/"
 
 ###           End of Beta-Agent6-only experimental attributes        ###
 ########################################################################

--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -1,5 +1,10 @@
 ---
-- name: Create main Datadog agent yaml configuration file (beta)
+- name: Create /etc/datadog-agent
+  file:
+    dest: /etc/datadog-agent
+    state: directory
+
+- name: Create main Datadog agant yaml configuration file (beta)
   template:
     src: datadog.yaml.j2
     dest: /etc/datadog-agent/datadog.yaml

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -8,17 +8,36 @@
 - name: Import new RPM key
   rpm_key: key=/tmp/DATADOG_RPM_KEY_E09422B3.public state=present
 
-- name: Copy repo file into place
-  template: src=datadog.repo.j2 dest=/etc/yum.repos.d/datadog.repo owner=root group=root mode=0644
+- name: Install DataDog yum repo
+  yum_repository:
+    name: datadog
+    description: Datadog, Inc.
+    baseurl: "{{ datadog_yum_repo }}"
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: "{{ datadog_yum_gpgkey }}"
+    state: "{% if datadog_agent6 %}absent{% else %}present{% endif %}"
+
+- name: Install DataDog yum repo (beta)
+  yum_repository:
+    name: datadog-beta
+    description: Datadog, Inc.
+    baseurl: "{{ datadog_agent6_yum_repo }}"
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: "{{ datadog_yum_gpgkey }}"
+    state: "{% if datadog_agent6 %}present{% else %}absent{% endif %}"
 
 - name: Install pinned datadog-agent package
   yum:
     name: datadog-agent-{{ datadog_agent_version }}
     state: present
   when: datadog_agent_version != ""
+  notify: restart datadog-agent
 
+# Using `yum` directly to work around an Ansible bug:
+# https://github.com/ansible/ansible/issues/20608
 - name: Install latest datadog-agent package
-  yum:
-    name: datadog-agent
-    state: latest
+  command: yum install -y datadog-agent
   when: datadog_agent_version == ""
+  notify: restart datadog-agent

--- a/templates/datadog.repo.j2
+++ b/templates/datadog.repo.j2
@@ -1,6 +1,0 @@
-[datadog]
-name=Datadog, Inc.
-baseurl={{ datadog_yum_repo }}
-enabled=1
-gpgcheck=1
-gpgkey={{ datadog_yum_gpgkey }}


### PR DESCRIPTION
 - Add the DataDog yum beta repo
 - Use `yum_repository` instead of manual files
 - Fix some places where we don't update or restart the agent
 - Create /etc/datadog