### PR TITLE
allow different checks for different host groups

### DIFF
--- a/tasks/agent5.yml
+++ b/tasks/agent5.yml
@@ -30,5 +30,6 @@
     dest: /etc/dd-agent/conf.d/{{ item }}.yaml
     owner: '{{ datadog_user }}'
     group: '{{ datadog_group }}'
+  when: item.inventory_groups is not defined or (group_names | intersect(item.inventory_groups) | length)
   with_items: '{{ datadog_checks|list }}'
   notify: restart datadog-agent


### PR DESCRIPTION
This adds a condition to the task that creates the checks to allow deploying different checks to different host groups:
```
datadog_checks:
  ssh_check:   # gets deployed to all hosts since 'inventory_groups' is not defined
    ....
  nginx:  # only gets deployed to hosts in the 'nginx' group
    inventory_groups: 
      - nginx
    ....
```