### PR TITLE
Issue #94: Fix configuration file deployment path for agent 6 checks

### DIFF
--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -12,13 +12,15 @@
     group: '{{ datadog_group }}'
   notify: restart datadog-agent
 
-- debug: 'msg="Using deprecated `datadog_process_checks` is no longer supported in agent6, use `process` under `datadog_checks` instead"'
+- debug:
+    msg: "Using deprecated `datadog_process_checks` is no longer supported in
+      agent6, use `process` under `datadog_checks` instead"
   when: datadog_process_checks is defined
 
 - name: Create a configuration file for each Datadog check
   template:
     src: checks.yaml.j2
-    dest: "/etc/datadog-agent/conf.d/{{ item }}.yaml"
+    dest: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml"
     owner: '{{ datadog_user }}'
     group: '{{ datadog_group }}'
   with_items: '{{ datadog_checks|list }}'


### PR DESCRIPTION
* Agent 6 stores conf files for checks in /etc/datadog-agent/conf.d/<integration>.d/conf.yaml
* Agent 5 stores conf files for checks in /etc/datadog-agent/conf.d/<integration>.yaml

https://github.com/DataDog/ansible-datadog/issues/94