### PR TITLE
ensure apt update happens as part of install process

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -35,6 +35,7 @@
     name: datadog-agent={{ datadog_agent_version }}
     state: present
     force: "{{ datadog_agent_allow_downgrade }}"
+    update_cache: yes
   when: datadog_agent_version != ""
 
 - name: Ensure Datadog agent is installed


### PR DESCRIPTION
During the agent installation step, apt complains that the package cannot be found. The repository for the agent is added, but `apt update` still needs to run to get the package lists. `update_cache` in the `apt_repository` tasks seems to be insufficient to get the package lists up to date.