### PR TITLE
[apt] Remove expired key from role

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,7 @@ Role Variables
 - `datadog_config_ex` - Extra INI sections to go in `/etc/dd-agent/datadog.conf` (optional).
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_cache_valid_time` - Override the default apt cache expiration time (default 1 hour)
-- `datadog_apt_key_url` - Override default url to Datadog `apt` key
-- `datadog_apt_key_url_new` - Override default url to the new Datadog `apt` key (in the near future the `apt` repo will have to be checked against this new key instead of the current key)
+- `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details)
 
 Agent 5 (older version)

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -10,14 +10,6 @@
   apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
   when: datadog_apt_key_url_new is defined
 
-- name: Ensure ubuntu apt-key server is present
-  apt_key: id=C7A7DA52 keyserver=hkp://keyserver.ubuntu.com:80 state=present
-  when: datadog_apt_key_url is not defined
-
-- name: Ensure Datadog apt-key is present
-  apt_key: id=C7A7DA52 url={{ datadog_apt_key_url }} state=present
-  when: datadog_apt_key_url is defined
-
 - name: Ensure Datadog repository is up-to-date
   apt_repository:
     repo: "{{ datadog_apt_repo }}"


### PR DESCRIPTION
Was breaking runs since Ansible ignores expired keys, and therefore
doesn't detect the import was successful.

Fixes #103