### PR TITLE
Fix datadog.yaml template when used with an empty conf

### DIFF
--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -8,4 +8,6 @@ dd_url: {{ datadog_url | default('https://app.datadoghq.com') }}
 api_key: {{ datadog_api_key | default('youshouldsetthis') }}
 {% endif %}
 
+{% if datadog_config -%}
 {{ datadog_config | to_nice_yaml }}
+{% endif %}


### PR DESCRIPTION
When no option are set in `datadog_config` the generated yaml would not be valid.

This should fix: #93 