### PR TITLE
Fix bug with duplicate sources.list entry

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -11,16 +11,9 @@
   when: datadog_apt_key_url_new is defined
 
 - name: Ensure Datadog repository is up-to-date
-  apt_repository:
-    repo: "{{ datadog_apt_repo }}"
-    state: "{% if datadog_agent5 %}absent{% else %}present{% endif %}"
-    update_cache: yes
-
-- name: Ensure Datadog repository is up-to-date (agent5)
-  apt_repository:
-    repo: "{{ datadog_agent5_apt_repo }}"
-    state: "{% if datadog_agent5 %}present{% else %}absent{% endif %}"
-    update_cache: yes
+  template:
+    src: apt.list.j2
+    dest: /etc/apt/sources.list.d/apt_datadoghq_com.list
 
 - name: Ensure pinned version of Datadog agent is installed
   apt:

--- a/templates/apt.list.j2
+++ b/templates/apt.list.j2
@@ -1,0 +1,5 @@
+{% if datadog_agent5 %}
+{{ datadog_agent5_apt_repo }}
+{% else %}
+{{ datadog_apt_repo }}
+{% endif %}


### PR DESCRIPTION
# Original bug

The script on `master` branch can lead to an inconsistent state for Datadog APT repositories. The `apt_datadoghq_com.list` can look like this:

```
deb http://apt.datadoghq.com/ stable main
deb https://apt.datadoghq.com/ stable 6
```

Such a state can be reached if a previous version of the script was used (earlier than 5adf2f1) and added `deb http://apt.datadoghq.com/ stable main`. When running a more recent version of the script, it would try to remove the HTTPS repo `deb https://apt.datadoghq.com/ stable main` (which does not exist) and would add `deb https://apt.datadoghq.com/ stable 6`, thus leading to this duplicate entry.

It leads to an `apt update` error: `Duplicate sources.list entry https://apt.datadoghq.com stable Release`

This issue is mentioned in #108 

# Proposed solution

Instead of keeping track of which repositories to add/remove, we can simply declare the repository state we want to reach by using a template file for `apt_datadoghq_com.list`.