### PR TITLE
Bugfix: Removes legacy http apt repos pre-dating #5adf2f1

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -10,6 +10,15 @@
   apt_key: id=A2923DFF56EDA6E76E55E492D3A80E30382E94DE url={{ datadog_apt_key_url_new }} state=present
   when: datadog_apt_key_url_new is defined
 
+- name: Ensure Datadog non-https repositories are deprecated
+  apt_repository:
+    repo: "{{ item }}"
+    state: "absent"
+    update_cache: yes
+  with_items:
+    - "deb http://apt.datadoghq.com/ stable main"
+    - "deb http://apt.datadoghq.com/ stable 6"
+
 - name: Ensure Datadog repository is up-to-date
   apt_repository:
     repo: "{{ datadog_apt_repo }}"


### PR DESCRIPTION
Due to the changing of the Debian APT Repos from HTTP to HTTP, without removing of stale repos which have been created in old installs of this role, this causes problems when trying to update from v5 to v6, as the stale v5 APT sources repo still exists. This adds a task to explicitly delete both v5 and v6 Datadog APT sources.list references.