### PR TITLE
log_enabled is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Example Playbooks
       tags: "mytag0, mytag1"
       log_level: INFO
       apm_enabled: "true" # has to be set as a string
-      log_enabled: true   # log collection is available on agent 6
+      logs_enabled: true   # log collection is available on agent 6
     datadog_config_ex:
       trace.config:
         env: dev


### PR DESCRIPTION
log_enabled: 'true' -> logs_enabled: 'true'
https://docs.datadoghq.com/logs/#getting-started-with-the-agent