### PR TITLE
Revert "Fix bug with duplicate sources.list entry"

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -11,9 +11,16 @@
   when: datadog_apt_key_url_new is defined
 
 - name: Ensure Datadog repository is up-to-date
-  template:
-    src: apt.list.j2
-    dest: /etc/apt/sources.list.d/apt_datadoghq_com.list
+  apt_repository:
+    repo: "{{ datadog_apt_repo }}"
+    state: "{% if datadog_agent5 %}absent{% else %}present{% endif %}"
+    update_cache: yes
+
+- name: Ensure Datadog repository is up-to-date (agent5)
+  apt_repository:
+    repo: "{{ datadog_agent5_apt_repo }}"
+    state: "{% if datadog_agent5 %}present{% else %}absent{% endif %}"
+    update_cache: yes
 
 - name: Ensure pinned version of Datadog agent is installed
   apt:

--- a/templates/apt.list.j2
+++ b/templates/apt.list.j2
@@ -1,5 +1,0 @@
-{% if datadog_agent5 %}
-{{ datadog_agent5_apt_repo }}
-{% else %}
-{{ datadog_apt_repo }}
-{% endif %}


### PR DESCRIPTION
Reverts DataDog/ansible-datadog#115

This actually remove the "update_cache: yes" so new install fails.