### PR TITLE
Harmonize tasks names between agent5 and agent6

### DIFF
--- a/tasks/agent5.yml
+++ b/tasks/agent5.yml
@@ -1,5 +1,10 @@
 ---
-- name: Create main Datadog agent configuration file
+- name: (agent5) Create Datadog agent config directory
+  file:
+    dest: /etc/dd-agent
+    state: directory
+
+- name: (agent5) Create main Datadog agent configuration file
   template:
     src: datadog.conf.j2
     dest: /etc/dd-agent/datadog.conf
@@ -7,21 +12,21 @@
     group: "{{ datadog_group }}"
   notify: restart datadog-agent
 
-- name: Ensure datadog-agent is running
+- name: (agent5) Ensure datadog-agent is running
   service:
     name: datadog-agent
     state: started
     enabled: yes
   when: datadog_enabled and not ansible_check_mode
 
-- name: Ensure datadog-agent is not running
+- name: (agent5) Ensure datadog-agent is not running
   service:
     name: datadog-agent
     state: stopped
     enabled: no
   when: not datadog_enabled
 
-- name: Create a configuration file for each Datadog check
+- name: (agent5) Create a configuration file for each Datadog check
   template:
     src: checks.yaml.j2
     dest: "/etc/dd-agent/conf.d/{{ item }}.yaml"

--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -1,10 +1,10 @@
 ---
-- name: Create /etc/datadog-agent
+- name: Create Datadog agent config directory
   file:
     dest: /etc/datadog-agent
     state: directory
 
-- name: Create main Datadog agent yaml configuration file (beta)
+- name: Create main Datadog agent configuration file
   template:
     src: datadog.yaml.j2
     dest: /etc/datadog-agent/datadog.yaml


### PR DESCRIPTION
This PR aims to : 
- harmonize tasks name between v5 and v6 agent
- avoid using same name for multiple different tasks (to prevent breaking `--start-at-task` option) #135