### PR TITLE
Avoid restarts from yum install workaround for resolved issue 20608

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -39,17 +39,6 @@
   when: (datadog_agent_version != "") and (not ansible_check_mode)
   notify: restart datadog-agent
 
-# Using `yum` directly to work around an Ansible bug:
-# https://github.com/ansible/ansible/issues/20608
-- name: Install latest datadog-agent package issue 20608 workaround
-  command: yum install -y datadog-agent
-  register: yum_install_result
-  changed_when: ( yum_install_result.stdout_lines | last ) != "Nothing to do"
-  when:
-  - datadog_agent_version == ""
-  - ansible_version is version_compare(2.3, '<')
-  notify: restart datadog-agent
-
 - name: Install latest datadog-agent package
   yum:
     name: datadog-agent
@@ -57,5 +46,4 @@
     state: latest
   when:
   - datadog_agent_version == ""
-  - ansible_version is version_compare(2.3, '>=')
   notify: restart datadog-agent

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -43,6 +43,8 @@
 # https://github.com/ansible/ansible/issues/20608
 - name: Install latest datadog-agent package issue 20608 workaround
   command: yum install -y datadog-agent
+  register: yum_install_result
+  changed_when: ( yum_install_result.stdout_lines | last ) != "Nothing to do"
   when:
   - datadog_agent_version == ""
   - ansible_version is version_compare(2.3, '<')

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -41,7 +41,19 @@
 
 # Using `yum` directly to work around an Ansible bug:
 # https://github.com/ansible/ansible/issues/20608
-- name: Install latest datadog-agent package
+- name: Install latest datadog-agent package issue 20608 workaround
   command: yum install -y datadog-agent
-  when: datadog_agent_version == ""
+  when:
+  - datadog_agent_version == ""
+  - ansible_version is version_compare(2.3, '<')
+  notify: restart datadog-agent
+
+- name: Install latest datadog-agent package
+  yum:
+    name: datadog-agent
+    update_cache: yes
+    state: latest
+  when:
+  - datadog_agent_version == ""
+  - ansible_version is version_compare(2.3, '>=')
   notify: restart datadog-agent


### PR DESCRIPTION
Would you please consider merging this as the bug was fixed a few versions ago. The workaround triggered datadog-agent to restart on every run and so I have fixed that too.

Thanks