### PR TITLE
Fixing typo in yml file

### DIFF
--- a/tests/test_6_full.yml
+++ b/tests/test_6_full.yml
@@ -9,7 +9,7 @@
       log_level: INFO
       apm_enabled: "true" # has to be set as a string
       # logs related config
-      log_enabled: true
+      logs_enabled: true
       logset: main
     datadog_config_ex:
       trace.config:


### PR DESCRIPTION
Fixing typo in property name. It says `log_enabled`, but it should be `logs_enabled`.