### PR TITLE
Disable repo metadata signature check on SUSE/SLES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 2.3.1 / 2018-08-24
+
+* [FIX] Disabling repo metadata signature check for SUSE/SLES.
+
 # 2.3.0 / 2018-07-23
 
 * [FEATURE] Add support for SUSE/SLES (thanks to [@enarciso][]).

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -24,31 +24,27 @@
     state: present
   when: not ansible_check_mode
 
+# ansible don't allow repo_gpgcheck to be set, we have to create the repo file manually
 - name: Install DataDog zypper repo
-  zypper_repository:
-    name: datadog
-    description: Datadog, Inc.
-    repo: "{{ datadog_zypper_repo }}"
-    enabled: yes
-    auto_import_keys: yes
-    disable_gpg_check: "{% if ansible_distribution_version|int == 11 %}yes{% else %}no{% endif %}" # SLES11 considers datadog's repo as untrusted
-    state: "{% if datadog_agent5 %}absent{% else %}present{% endif %}"
+  template:
+    src: zypper.repo.j2
+    dest: /etc/zypp/repos.d/datadog.repo
+    owner: "root"
+    group: "root"
+  register: datadog_zypper_repo
 
-- name: (agent5) Install DataDog yum repo
-  zypper_repository:
-    name: datadog_5
-    description: Datadog, Inc.
-    repo: "{{ datadog_agent5_zypper_repo }}"
-    enabled: yes
-    auto_import_keys: yes
-    disable_gpg_check: "{% if ansible_distribution_version|int == 11 %}yes{% else %}no{% endif %}" # SLES11 considers datadog's repo as untrusted
-    state: "{% if datadog_agent5 %}present{% else %}absent{% endif %}"
+# refresh zypper repos only if the template changed
+- name: refresh Datadog zypper_repos
+  command: zypper refresh datadog
+  when: datadog_zypper_repo.changed and not ansible_check_mode
+  args:
+    warn: false # silence warning about using zypper directly
 
 - name: Install pinned datadog-agent package
   zypper:
     name: "datadog-agent={{ datadog_agent_version }}"
     state: present
-    force: "{{ datadog_agent_allow_downgrade }}"
+    oldpackage: "{{ datadog_agent_allow_downgrade }}"
   when: (datadog_agent_version != "") and (not ansible_check_mode)
   notify: restart datadog-agent
 

--- a/templates/zypper.repo.j2
+++ b/templates/zypper.repo.j2
@@ -1,0 +1,9 @@
+[datadog]
+name=Datadog, Inc.
+enabled=1
+autorefresh=1
+baseurl={% if datadog_agent5 %}{{ datadog_agent5_zypper_repo }}{% else %}{{ datadog_zypper_repo }}{% endif %}
+
+type=rpm-md
+gpgcheck=1
+repo_gpgcheck=0


### PR DESCRIPTION
**Why**

This fix fresh install on SUSE/SLES. It's also align Ansible and the install script from the website.