### PR TITLE
Disable all datadog agent v6 services together

### DIFF
--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -54,14 +54,22 @@
 
 - name: Ensure datadog-agent is running
   service:
-    name: datadog-agent
+    name: "{{ item }}"
     state: started
     enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  with_list:
+    - datadog-agent
+    - datadog-agent-process
+    - datadog-agent-trace
 
 - name: Ensure datadog-agent is not running
   service:
-    name: datadog-agent
+    name: "{{ item }}"
     state: stopped
     enabled: no
   when: not datadog_skip_running_check and not datadog_enabled
+  with_list:
+    - datadog-agent
+    - datadog-agent-process
+    - datadog-agent-trace

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -54,16 +54,12 @@
 
 - name: Ensure datadog-agent is running
   service:
-    name: "{{ item }}"
+    name: datadog-agent
     state: started
     enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
-  with_list:
-    - datadog-agent
-    - datadog-agent-process
-    - datadog-agent-trace
 
-- name: Ensure datadog-agent is not running
+- name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
   service:
     name: "{{ item }}"
     state: stopped


### PR DESCRIPTION
This ensures that when `datadog_enabled` is set to `no`, the `datadog-agent` unit is disabled **and** not started by systemd as a dependency of the `datadog-agent-process` and `datadog-agent-trace` units.

Without this change, the `datadog-agent` unit, while disabled, is started on boot:

```
[pdecat@packer-5b866036-aaa8-542c-bca5-59e161e9413a]~ $ sudo systemctl status datadog-agent
● datadog-agent.service - "Datadog Agent"
   Loaded: loaded (/lib/systemd/system/datadog-agent.service; disabled; vendor preset: enabled)
   Active: active (running) since Wed 2018-08-29 08:58:52 UTC; 2min 31s ago
 Main PID: 646 (agent)
    Tasks: 8 (limit: 4915)
   CGroup: /system.slice/datadog-agent.service
           └─646 /opt/datadog-agent/bin/agent/agent run -p /opt/datadog-agent/run/agent.pid

[pdecat@packer-5b866036-aaa8-542c-bca5-59e161e9413a]~ $ sudo systemctl is-enabled datadog-agent.service
disabled

[pdecat@packer-5b866036-aaa8-542c-bca5-59e161e9413a]~ $ sudo systemctl is-enabled datadog-agent-trace.service
enabled

[pdecat@packer-5b866036-aaa8-542c-bca5-59e161e9413a]~ $ sudo systemctl is-enabled datadog-agent-process.service
enabled
```

This is tested on debian stretch with ansible 2.6.3 and systemd 232.