### PR TITLE
Retry on failure when pulling the gpg key from keyserver.ubuntu.com

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ datadog_group: root
 # default apt repo
 datadog_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_apt_cache_valid_time: 3600
+datadog_apt_key_retries: 5
 
 # default yum repo and keys
 datadog_yum_repo: "https://yum.datadoghq.com/stable/6/{{ ansible_userspace_architecture }}/"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -13,7 +13,7 @@
 # keyserver.ubuntu.com is a pool of server, we should retry if one of them is down
   register: result
   until: not result.failed is defined or not result.failed
-  retries: 5
+  retries: "{{ datadog_apt_key_retries }}"
   when: datadog_apt_key_url_new is not defined
 
 - name: Install Datadog apt-key

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -10,6 +10,10 @@
     id: A2923DFF56EDA6E76E55E492D3A80E30382E94DE
     keyserver: hkp://keyserver.ubuntu.com:80
     state: present
+# keyserver.ubuntu.com is a pool of server, we should retry if one of them is down
+  register: result
+  until: not result.failed is defined or not result.failed
+  retries: 5
   when: datadog_apt_key_url_new is not defined
 
 - name: Install Datadog apt-key


### PR DESCRIPTION
# Motivation

the keyservers are a pool of sks servers with squid in front of them, we should probably retry on failures.