### PR TITLE
Add a backup keyserver in case the main one is down

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Role Variables
 - `datadog_apt_cache_valid_time` - Override the default apt cache expiration time (default 1 hour)
 - `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
+- `use_apt_backup_keyserver` - Set `true` to use the backup keyserver instead of the default one
 
 Agent 5 (older version)
 -----------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ datadog_group: root
 datadog_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_apt_cache_valid_time: 3600
 datadog_apt_key_retries: 5
+use_apt_backup_keyserver: false
+datadog_apt_keyserver: hkp://keyserver.ubuntu.com:80
+datadog_apt_backup_keyserver: hkp://pool.sks-keyservers.net:80
 
 # default yum repo and keys
 datadog_yum_repo: "https://yum.datadoghq.com/stable/6/{{ ansible_userspace_architecture }}/"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -8,7 +8,7 @@
 - name: Install ubuntu apt-key server
   apt_key:
     id: A2923DFF56EDA6E76E55E492D3A80E30382E94DE
-    keyserver: hkp://keyserver.ubuntu.com:80
+    keyserver: "{{ datadog_apt_backup_keyserver if use_apt_backup_keyserver else datadog_apt_keyserver }}"
     state: present
 # keyserver.ubuntu.com is a pool of server, we should retry if one of them is down
   register: result


### PR DESCRIPTION
We should make sure our APT repo's public GPG key is available from another keyserver (pool) than just `keyserver.ubuntu.com` so that, when the latter is down