### PR TITLE
Group membership for datadog user

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,7 @@ datadog_checks: {}
 
 # default user/group
 datadog_user: dd-agent
+datadog_user_member_group:
 datadog_group: root
 
 # default apt repo

--- a/tasks/agent6.yml
+++ b/tasks/agent6.yml
@@ -65,3 +65,10 @@
     state: stopped
     enabled: no
   when: not datadog_skip_running_check and not datadog_enabled
+
+- name: Ensure datadog user is part of specified group
+  user:
+    name: '{{ datadog_user }}'
+    shell: /usr/sbin/nologin
+    groups: '{{ datadog_user_member_group }}'
+  when: datadog_user_member_group|default(None) != None


### PR DESCRIPTION
Hello!

By default the Datadog agent is part of root group. For my need, I want to specify a particular group to the Datadog user.

My need is I want to forward my logs to the Datadogs plateforme, for that the Datadog agent need to have the good right on theses files.

Thanks!