### PR TITLE
add datadog_additional_groups and datadog_use_local_repo switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Role Variables
 - `datadog_apt_cache_valid_time` - Override the default apt cache expiration time (default 1 hour)
 - `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
+- `datadog_additional_groups` - List of additional groups for `datadog_user`.
+- `datadog_use_local_repo` - Set to `true` only in case you have local repo with datadog sources. When set to true, repo is not handled at all - this assumes you have your e.g. satellite server already configured and containing the datadog rpm. This switch applies to yum repo management only.
 
 Agent 5 (older version)
 -----------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,15 @@ datadog_checks: {}
 datadog_user: dd-agent
 datadog_group: root
 
+# list of additional groups for datadog_user
+datadog_additional_groups: {}
+
+# use 'datadog_use_local_repo: true' only in case you have local repo with datadog sources
+# when set to true, repo is not handled at all - this assumes you have your e.g. satellite 
+# server already configured and containing the datadog rpm
+# FIXME this switch is currently used just for yum repo handling but can be extended to others
+datadog_use_local_repo: false
+
 # default apt repo
 datadog_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_apt_cache_valid_time: 3600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,3 +13,9 @@
 
 - include: agent6.yml
   when: not datadog_agent5
+
+- name: add "{{ datadog_user }}" user to additional groups
+  user: name="{{ datadog_user }}" groups="{{ item }}" append=yes
+  with_items: "{{ datadog_additional_groups }}"
+  when: datadog_additional_groups is defined and datadog_additional_groups != ''
+  notify: restart datadog-agent

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,35 +1,37 @@
 ---
-- name: Download new RPM key
-  get_url:
-    url: "{{ datadog_yum_gpgkey_new }}"
-    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
+- block:
+  - name: Download new RPM key
+    get_url:
+      url: "{{ datadog_yum_gpgkey_new }}"
+      dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+      sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
 
-- name: Import new RPM key
-  rpm_key:
-    key: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    state: present
-  when: not ansible_check_mode
+  - name: Import new RPM key
+    rpm_key:
+      key: /tmp/DATADOG_RPM_KEY_E09422B3.public
+      state: present
+    when: not ansible_check_mode
 
-- name: Install DataDog yum repo
-  yum_repository:
-    name: datadog
-    description: Datadog, Inc.
-    baseurl: "{{ datadog_yum_repo }}"
-    enabled: yes
-    gpgcheck: yes
-    gpgkey: "{{ datadog_yum_gpgkey }}"
-    state: "{% if datadog_agent5 %}absent{% else %}present{% endif %}"
+  - name: Install DataDog yum repo
+    yum_repository:
+      name: datadog
+      description: Datadog, Inc.
+      baseurl: "{{ datadog_yum_repo }}"
+      enabled: yes
+      gpgcheck: yes
+      gpgkey: "{{ datadog_yum_gpgkey }}"
+      state: "{% if datadog_agent5 %}absent{% else %}present{% endif %}"
 
-- name: (agent5) Install DataDog yum repo
-  yum_repository:
-    name: datadog_5
-    description: Datadog, Inc.
-    baseurl: "{{ datadog_agent5_yum_repo }}"
-    enabled: yes
-    gpgcheck: yes
-    gpgkey: "{{ datadog_yum_gpgkey }}"
-    state: "{% if datadog_agent5 %}present{% else %}absent{% endif %}"
+  - name: (agent5) Install DataDog yum repo
+    yum_repository:
+      name: datadog_5
+      description: Datadog, Inc.
+      baseurl: "{{ datadog_agent5_yum_repo }}"
+      enabled: yes
+      gpgcheck: yes
+      gpgkey: "{{ datadog_yum_gpgkey }}"
+      state: "{% if datadog_agent5 %}present{% else %}absent{% endif %}"
+  when: datadog_use_local_repo | default(false) | bool == false
 
 - name: Install pinned datadog-agent package
   yum:


### PR DESCRIPTION
This is to make DD deploy more flexible - two changes [switches] are proposed:

1] `datadog_use_local_repo` - Set to `true` only in case you have local repo with datadog sources. When set to true, repo is not handled at all - this assumes you have your e.g. satellite server already configured and containing the datadog rpm. This switch applies to yum repo management only.

2] `datadog_additional_groups` - List of additional groups for `datadog_user`.

comment: this may seem to interfere with these two [and I like them!] ..
- https://github.com/DataDog/ansible-datadog/pull/165
- https://github.com/DataDog/ansible-datadog/pull/166

.. but my proposal brings extra option to add DD user to other groups which may not be detected or which are simply out of scope of the auto-detection. E.g. you may need cassandra group to read debug logs etc.. In a way this could be also used to [test-only / edge cases / not recommended] add DD user to root group.

There's also another interfering pull request https://github.com/DataDog/ansible-datadog/pull/160 - but that one allows only one group, while my proposal has a list.


thanks a lot for coop / update and have a nice day all!
Ondrej