### PR TITLE
Changes get_url.sha256sum to get_url.checksum

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -3,7 +3,7 @@
   get_url:
     url: "{{ datadog_yum_gpgkey_new }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    sha256sum: 694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085
+    checksum: "sha256:694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 
 - name: Import new RPM key
   rpm_key:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -39,9 +39,9 @@
   when: (datadog_agent_version != "") and (not ansible_check_mode)
   notify: restart datadog-agent
 
-# Using `yum` directly to work around an Ansible bug:
-# https://github.com/ansible/ansible/issues/20608
 - name: Install latest datadog-agent package
-  command: yum install -y datadog-agent
+  yum:
+    name: datadog-agent
+    state: present
   when: datadog_agent_version == ""
   notify: restart datadog-agent


### PR DESCRIPTION
The get_url.sha256sum has been deprecated in favor of the get_url.checksum parameter. Corresponding Ansible documentation: https://docs.ansible.com/ansible/2.7/modules/get_url_module.html