### PR TITLE
Document datadog_enabled role variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Role Variables
 - `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
 - `use_apt_backup_keyserver` - Set `true` to use the backup keyserver instead of the default one
+- `datadog_enabled` - Set to `false` to prevent `datadog-agent` service from starting. Defaults to `true`
 
 Agent 5 (older version)
 -----------------------


### PR DESCRIPTION
Hi there! It seems that there exists a `datadog_enabled` variable that can be set to `false` to disable the `datadog-agent` from starting.

However, that role variable was not documented, so I wasn't sure whether it's OK to use it. Our use case is that we'd want development boxes to not start the agent, but still run all the other datadog installation steps to get the development boxes as close to the production systems as possible.

It seems like there are other issues / pull requests also referring to this role variable based on a quick search:

- https://github.com/DataDog/ansible-datadog/pull/153
- https://github.com/DataDog/ansible-datadog/issues/161

Cheers! Let me know if there's any questions :relaxed: