### PR TITLE
Switch from include to include_tasks to speed up the role

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: 'Brian Akins, Dustin Brown & Datadog'
   description: Install Datadog agent and configure checks
   license: Apache2
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,22 +1,21 @@
 ---
-- include: pkg-debian.yml
+- include_tasks: pkg-debian.yml
   when: ansible_os_family == "Debian"
 
-- include: pkg-redhat.yml
+- include_tasks: pkg-redhat.yml
   when: ansible_os_family == "RedHat"
 
-- include: pkg-suse.yml
+- include_tasks: pkg-suse.yml
   when: ansible_os_family == "Suse"
 
-- include: pkg-windows.yml
+- include_tasks: pkg-windows.yml
   when: ansible_os_family == "Windows"
 
-- include: agent5-linux.yml
+- include_tasks: agent5-linux.yml
   when: datadog_agent5 and ansible_os_family != "Windows"
 
-- include: agent6-linux.yml
+- include_tasks: agent6-linux.yml
   when: not datadog_agent5 and ansible_os_family != "Windows"
 
-- include: agent6-win.yml
+- include_tasks: agent6-win.yml
   when: not datadog_agent5 and ansible_os_family == "Windows"
-


### PR DESCRIPTION
This patch switches from Ansible's `include` to `include_tasks`. With `include`, the file is always included and the `when:` conditional is evaluated on each task. With `include_tasks`, the conditional is evaluated once.

In my tests with 36 hosts, this cuts the time spent in the Datadog role in half!