### PR TITLE
Compatibility for containerized agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,6 +32,19 @@ datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""
 
+# Restart the agent as a specific user to avoid containerization issues.
+datadog_agent_environment:
+  - user: dd-agent
+    stat: True
+  - user: root
+    stat: False
+
+# Default list of Datadog agent services.
+datadog_agent_services:
+  - datadog-agent
+  - datadog-agent-process
+  - datadog-agent-trace
+
 # Avoid checking if the agent is running or not. This can be useful if you're
 # using sysvinit and providing your own init script.
 datadog_skip_running_check: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,6 +4,7 @@
   service:
     name: datadog-agent
     state: restarted
+  become_user: dd-agent
   when: datadog_enabled and not ansible_check_mode and not ansible_os_family == "Windows"
 
 - name: restart datadog-agent-win

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,8 +4,9 @@
   service:
     name: datadog-agent
     state: restarted
-  become_user: dd-agent
-  when: datadog_enabled and not ansible_check_mode and not ansible_os_family == "Windows"
+  become_user: "{{ item.user }}"
+  when: datadog_enabled and not ansible_check_mode and not ansible_os_family == "Windows" and dockerenv.stat.exists == item.stat
+  with_items: "{{ datadog_agent_environment }}"
 
 - name: restart datadog-agent-win
   win_service:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -12,21 +12,28 @@
     group: "{{ datadog_group }}"
   notify: restart datadog-agent
 
+- name: (agent5) Check if Datadog agent is in a containerized environment
+  stat: 
+    path: /.dockerenv
+  register: dockerenv
+
 - name: (agent5) Ensure datadog-agent is running
   service:
     name: datadog-agent
     state: started
     enabled: yes
-  become_user: dd-agent
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  become_user: "{{ item.user }}"
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and dockerenv.stat.exists == item.stat
+  with_items: "{{ datadog_agent_environment }}"
 
 - name: (agent5) Ensure datadog-agent is not running
   service:
     name: datadog-agent
     state: stopped
     enabled: no
-  become_user: dd-agent
-  when: not datadog_skip_running_check and not datadog_enabled
+  become_user: "{{ item.user }}"
+  when: not datadog_skip_running_check and not datadog_enabled and dockerenv.stat.exists == item.stat
+  with_items: "{{ datadog_agent_environment }}"
 
 - name: (agent5) Create a configuration file for each Datadog check
   template:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -17,6 +17,7 @@
     name: datadog-agent
     state: started
     enabled: yes
+  become_user: dd-agent
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: (agent5) Ensure datadog-agent is not running
@@ -24,6 +25,7 @@
     name: datadog-agent
     state: stopped
     enabled: no
+  become_user: dd-agent
   when: not datadog_skip_running_check and not datadog_enabled
 
 - name: (agent5) Create a configuration file for each Datadog check

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -57,6 +57,7 @@
     name: datadog-agent
     state: started
     enabled: yes
+  become_user: dd-agent
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
@@ -64,6 +65,7 @@
     name: "{{ item }}"
     state: stopped
     enabled: no
+  become_user: dd-agent
   when: not datadog_skip_running_check and not datadog_enabled
   with_list:
     - datadog-agent

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -52,22 +52,25 @@
     group: "{{ datadog_group }}"
   notify: restart datadog-agent
 
+- name: Check if Datadog agent is in a containerized environment
+  stat: 
+    path: /.dockerenv
+  register: dockerenv
+
 - name: Ensure datadog-agent is running
   service:
     name: datadog-agent
     state: started
     enabled: yes
-  become_user: dd-agent
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  become_user: "{{ item.user }}"
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and dockerenv.stat.exists == item.stat
+  with_items: "{{ datadog_agent_environment }}"
 
 - name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
   service:
-    name: "{{ item }}"
+    name: "{{ datadog_agent_services }}"
     state: stopped
     enabled: no
-  become_user: dd-agent
-  when: not datadog_skip_running_check and not datadog_enabled
-  with_list:
-    - datadog-agent
-    - datadog-agent-process
-    - datadog-agent-trace
+  become_user: "{{ item.user }}"
+  when: not datadog_skip_running_check and not datadog_enabled and dockerenv.stat.exists == item.stat
+  with_items: "{{ datadog_agent_environment }}"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -5,6 +5,12 @@
     state: present
   when: not ansible_check_mode
 
+- name: Install setfacl support
+  apt:
+    name: acl
+    state: present
+  when: not ansible_check_mode
+
 - name: Install ubuntu apt-key server
   apt_key:
     id: A2923DFF56EDA6E76E55E492D3A80E30382E94DE

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -11,6 +11,12 @@
     state: present
   when: not ansible_check_mode
 
+- name: Install setfacl support
+  yum:
+    name: acl
+    state: present
+  when: not ansible_check_mode
+
 - name: Install DataDog yum repo
   yum_repository:
     name: datadog

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -24,6 +24,12 @@
     state: present
   when: not ansible_check_mode
 
+- name: Install setfacl support
+  zypper:
+    name: acl
+    state: present
+  when: not ansible_check_mode
+
 # ansible don't allow repo_gpgcheck to be set, we have to create the repo file manually
 - name: Install DataDog zypper repo
   template:


### PR DESCRIPTION
This PR fixes an issue with datadog-agent.service using a containerized agent. By default Ansible will handle the service as root. In a containerized environment datadog.service needs to be manipulated as dd-agent, else it will result in a failed state and leave a zombie process.