### PR TITLE
Switch to include_tasks for Windows too

### DIFF
--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -3,10 +3,10 @@
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: datadog_agent5
 
-- include: win_agent_6_latest.yml
+- include_tasks: win_agent_6_latest.yml
   when: not datadog_agent5 and (datadog_agent_version == "")
 
-- include: win_agent_version.yml
+- include_tasks: win_agent_version.yml
   when: not datadog_agent_version == ""
 
 - name: show URL var


### PR DESCRIPTION
As this role supports Ansible version >= 2.4, `include` has been deprecated. Switching to `include_tasks` for Windows too (this was done for Linux in https://github.com/DataDog/ansible-datadog/pull/180).