### PR TITLE
Adds dd-user to optional groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Role Variables
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
 - `use_apt_backup_keyserver` - Set `true` to use the backup keyserver instead of the default one
 - `datadog_enabled` - Set to `false` to prevent `datadog-agent` service from starting. Defaults to `true`
+- `datadog_additional_groups` - Comma separated list of additional groups for the `datadog_user`.
 
 Agent 5 (older version)
 -----------------------

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Role Variables
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
 - `use_apt_backup_keyserver` - Set `true` to use the backup keyserver instead of the default one
 - `datadog_enabled` - Set to `false` to prevent `datadog-agent` service from starting. Defaults to `true`
-- `datadog_additional_groups` - Comma separated list of additional groups for the `datadog_user`.
+- `datadog_additional_groups` - Comma separated list of additional groups for the `datadog_user`. Linux only.
 
 Agent 5 (older version)
 -----------------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,9 @@ datadog_checks: {}
 datadog_user: dd-agent
 datadog_group: root
 
+# list of additional groups for datadog_user
+datadog_additional_groups: {}
+
 # default apt repo
 datadog_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_apt_cache_valid_time: 3600

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -1,4 +1,10 @@
 ---
+- name: add "{{ datadog_user }}" user to additional groups
+  user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
+  with_items: "{{ datadog_additional_groups }}"
+  when: datadog_additional_groups is defined and datadog_additional_groups != ''
+  notify: restart datadog-agent
+
 - name: Create Datadog agent config directory
   file:
     dest: /etc/datadog-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,9 +19,3 @@
 
 - include_tasks: agent6-win.yml
   when: not datadog_agent5 and ansible_os_family == "Windows"
-
-- name: add "{{ datadog_user }}" user to additional groups - Linux
-  user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
-  with_items: "{{ datadog_additional_groups }}"
-  when: datadog_additional_groups is defined and datadog_additional_groups != '' and ansible_os_family != "Windows"
-  notify: restart datadog-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,3 +19,9 @@
 
 - include_tasks: agent6-win.yml
   when: not datadog_agent5 and ansible_os_family == "Windows"
+
+- name: add "{{ datadog_user }}" user to additional groups - Linux
+  user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
+  with_items: "{{ datadog_additional_groups }}"
+  when: datadog_additional_groups is defined and datadog_additional_groups != '' and ansible_os_family != "Windows"
+  notify: restart datadog-agent


### PR DESCRIPTION
Tested on Ubuntu and CentOS.

This picks up the work done in https://github.com/DataDog/ansible-datadog/pull/167 to add the `dd-user` to other groups (to be specified by the user). Linux only.