### PR TITLE
[WIP] Bump min version due to EOL

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: 'Brian Akins, Dustin Brown & Datadog'
   description: Install Datadog agent and configure checks
   license: Apache2
-  min_ansible_version: 2.4
+  min_ansible_version: 2.5
   platforms:
     - name: Ubuntu
       versions:


### PR DESCRIPTION
Release status indicates that 2.4 is now unsupported / EOL: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#release-status. 

EDIT: need to check the CI and whether we should also update the jobs.