### PR TITLE
Ansible lint for the agent version

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -30,6 +30,6 @@ galaxy_info:
         - 2012
         - 2012R2
         - 2016
-  categories:
+  galaxy_tags:
     - monitoring
 dependencies: []

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -2,7 +2,7 @@
 - name: add "{{ datadog_user }}" user to additional groups
   user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
   with_items: "{{ datadog_additional_groups }}"
-  when: datadog_additional_groups is defined and datadog_additional_groups != ''
+  when: datadog_additional_groups is defined and (datadog_additional_groups | length != 0)
   notify: restart datadog-agent
 
 - name: Create Datadog agent config directory

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -54,7 +54,7 @@
     force: "{{ datadog_agent_allow_downgrade }}"
     update_cache: yes
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  when: (datadog_agent_version != "") and (not ansible_check_mode)
+  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
 
 - name: Ensure Datadog agent is installed
   apt:
@@ -62,4 +62,4 @@
     state: latest
     update_cache: yes
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  when: (datadog_agent_version == "") and (not ansible_check_mode)
+  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -59,7 +59,7 @@
 - name: Ensure Datadog agent is installed
   apt:
     name: datadog-agent
-    state: latest
+    state: latest  # noqa 403
     update_cache: yes
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
   when: (datadog_agent_version | length == 0) and (not ansible_check_mode)

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -36,7 +36,7 @@
     name: "datadog-agent-{{ datadog_agent_version }}"
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
-  when: (datadog_agent_version != "") and (not ansible_check_mode)
+  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
   notify: restart datadog-agent
 
 - name: Install latest datadog-agent package

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -44,4 +44,4 @@
     name: datadog-agent
     update_cache: yes
     state: latest  # noqa 403
-  when: datadog_agent_version == "" and (not ansible_check_mode)
+  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -43,5 +43,5 @@
   yum:
     name: datadog-agent
     update_cache: yes
-    state: latest
+    state: latest  # noqa 403
   when: datadog_agent_version == "" and (not ansible_check_mode)

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -34,7 +34,7 @@
   register: datadog_zypper_repo
 
 # refresh zypper repos only if the template changed
-- name: refresh Datadog zypper_repos
+- name: refresh Datadog zypper_repos  # noqa 503
   command: zypper refresh datadog
   when: datadog_zypper_repo.changed and not ansible_check_mode
   args:
@@ -51,6 +51,6 @@
 - name: Install latest datadog-agent package
   zypper:
     name: datadog-agent
-    state: latest
+    state: latest  # noqa 403
   when: (datadog_agent_version | length == 0) and (not ansible_check_mode)
   notify: restart datadog-agent

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -45,12 +45,12 @@
     name: "datadog-agent={{ datadog_agent_version }}"
     state: present
     oldpackage: "{{ datadog_agent_allow_downgrade }}"
-  when: (datadog_agent_version != "") and (not ansible_check_mode)
+  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
   notify: restart datadog-agent
 
 - name: Install latest datadog-agent package
   zypper:
     name: datadog-agent
     state: latest
-  when: datadog_agent_version == "" and (not ansible_check_mode)
+  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)
   notify: restart datadog-agent

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -1,13 +1,14 @@
 ---
-- fail:
+- name: Fail if Agent 5
+  fail:
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: datadog_agent5
 
 - include_tasks: win_agent_6_latest.yml
-  when: not datadog_agent5 and (datadog_agent_version == "")
+  when: not datadog_agent5 and (datadog_agent_version | length == 0)
 
 - include_tasks: win_agent_version.yml
-  when: not datadog_agent_version == ""
+  when: not datadog_agent_version | length == 0
 
 - name: show URL var
   debug:


### PR DESCRIPTION
Picks up the work started in https://github.com/DataDog/ansible-datadog/pull/188/ but for ansible-lint issues only (which recommends to avoid comparing to empty string).