### PR TITLE
[suse] Import the new GPG key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 3.1.0
+
+- [FEATURE] Trust new RPM key on SUSE. See [#203][]
+
 # 3.0.0 / 2019-05-17
 
 - [FEATURE] On Linux: you can now add the Agent's user to additionnal groups.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ Role Variables
 - `datadog_apt_repo` - Override default Datadog `apt` repository
 - `datadog_apt_cache_valid_time` - Override the default apt cache expiration time (default 1 hour)
 - `datadog_apt_key_url_new` - Override default url to Datadog `apt` key (key ID `382E94DE` ; the deprecated `datadog_apt_key_url` variable refers to an expired key that's been removed from the role)
+- `datadog_yum_repo` - Override default Datadog `yum` repository
+- `datadog_yum_gpgkey` - Override default url to Datadog `yum` key used to verify Agent 5 and Agent 6 (up to 6.13) packages (key ID `4172A230`)
+- `datadog_yum_gpgkey_e09422b3` - Override default url to Datadog `yum` key used to verify Agent 6 (from 6.14 upwards) packages (key ID `E09422B3`)
+- `datadog_yum_gpgkey_e09422b3_sha256sum` - Override default checksum of the `datadog_yum_gpgkey_e09422b3` key
+- `datadog_zypper_repo` - Override default Datadog `zypper` repository
+- `datadog_zypper_gpgkey` - Override default url to Datadog `zypper` key used to verify Agent 5 and Agent 6 (up to 6.13) packages (key ID `4172A230`)
+- `datadog_zypper_gpgkey_sha256sum` - Override default checksum of the `datadog_zypper_gpgkey` key
+- `datadog_zypper_gpgkey_e09422b3` - Override default url to Datadog `zypper` key used to verify Agent 6 (from 6.14 upwards) packages (key ID `E09422B3`)
+- `datadog_zypper_gpgkey_e09422b3_sha256sum` - Override default checksum of the `datadog_zypper_gpgkey_e09422b3` key
 - `datadog_agent_allow_downgrade` - Set to `yes` to allow agent downgrades on apt-based platforms (use with caution, see `defaults/main.yml` for details). **On centos this will only work with ansible 2.4 and up**.
 - `use_apt_backup_keyserver` - Set `true` to use the backup keyserver instead of the default one
 - `datadog_enabled` - Set to `false` to prevent `datadog-agent` service from starting. Defaults to `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,8 @@ datadog_yum_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.publ
 datadog_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ ansible_userspace_architecture }}"
 datadog_zypper_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
 datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db25cba8fee500c80c46"
+datadog_zypper_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_zypper_gpgkey_new_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,14 +25,15 @@ datadog_apt_backup_keyserver: hkp://pool.sks-keyservers.net:80
 # default yum repo and keys
 datadog_yum_repo: "https://yum.datadoghq.com/stable/6/{{ ansible_userspace_architecture }}/"
 datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
-datadog_yum_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_yum_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_yum_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 
 # default zypper repo and keys
 datadog_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ ansible_userspace_architecture }}"
 datadog_zypper_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
 datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db25cba8fee500c80c46"
-datadog_zypper_gpgkey_new: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
-datadog_zypper_gpgkey_new_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
+datadog_zypper_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_zypper_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 
 # Pin agent to a version. Highly recommended.
 datadog_agent_version: ""

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,9 +1,9 @@
 ---
 - name: Download new RPM key
   get_url:
-    url: "{{ datadog_yum_gpgkey_new }}"
+    url: "{{ datadog_yum_gpgkey_e09422b3 }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    checksum: "sha256:694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
+    checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
 
 - name: Import new RPM key
   rpm_key:

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -1,26 +1,51 @@
 ---
 - block:  # Work around due to SNI check for SLES11
-  - name: Stat if RPM key already exist
+  - name: Stat if RPM key already exists
     stat:
       path: /tmp/DATADOG_RPM_KEY.public
     register: ddkey
-  - name: Download new RPM key (SLES11)
+  - name: Download RPM key (SLES11)
     shell: "curl {{ datadog_zypper_gpgkey }} -o /tmp/DATADOG_RPM_KEY.public"
     args:
       warn: no
     when: not ddkey.stat.exists
   when: ansible_distribution_version|int == 11
 
-- name: Download new RPM key
+- name: Download RPM key
   get_url:
     url: "{{ datadog_zypper_gpgkey }}"
     dest: /tmp/DATADOG_RPM_KEY.public
     checksum: "sha256:{{ datadog_zypper_gpgkey_sha256sum }}"
   when: ansible_distribution_version|int >= 12
 
-- name: Import new RPM key
+- name: Import RPM key
   rpm_key:
     key: /tmp/DATADOG_RPM_KEY.public
+    state: present
+  when: not ansible_check_mode
+
+- block:  # Work around due to SNI check for SLES11
+  - name: Stat if new RPM key already exists
+    stat:
+      path: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    register: ddnewkey
+  - name: Download new RPM key (SLES11)
+    shell: "curl {{ datadog_zypper_gpgkey_new }} -o /tmp/DATADOG_RPM_KEY_E09422B3.public"
+    args:
+      warn: no
+    when: not ddnewkey.stat.exists
+  when: ansible_distribution_version|int == 11
+
+- name: Download new RPM key
+  get_url:
+    url: "{{ datadog_zypper_gpgkey_new }}"
+    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    checksum: "sha256:{{ datadog_zypper_gpgkey_new_sha256sum }}"
+  when: ansible_distribution_version|int >= 12
+
+- name: Import new RPM key
+  rpm_key:
+    key: /tmp/DATADOG_RPM_KEY_E09422B3.public
     state: present
   when: not ansible_check_mode
 

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -30,7 +30,7 @@
       path: /tmp/DATADOG_RPM_KEY_E09422B3.public
     register: ddnewkey
   - name: Download new RPM key (SLES11)
-    shell: "curl {{ datadog_zypper_gpgkey_new }} -o /tmp/DATADOG_RPM_KEY_E09422B3.public"
+    shell: "curl {{ datadog_zypper_gpgkey_e09422b3 }} -o /tmp/DATADOG_RPM_KEY_E09422B3.public"
     args:
       warn: no
     when: not ddnewkey.stat.exists
@@ -38,9 +38,9 @@
 
 - name: Download new RPM key
   get_url:
-    url: "{{ datadog_zypper_gpgkey_new }}"
+    url: "{{ datadog_zypper_gpgkey_e09422b3 }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    checksum: "sha256:{{ datadog_zypper_gpgkey_new_sha256sum }}"
+    checksum: "sha256:{{ datadog_zypper_gpgkey_e09422b3_sha256sum }}"
   when: ansible_distribution_version|int >= 12
 
 - name: Import new RPM key


### PR DESCRIPTION
In the near future, we're going to sign our RPM packages with our
newer GPG key. The RHEL task already imports the new key, but not the SUSE
task, so the new key import step has been added to it.