### PR TITLE
Remove agent v5 INI config templates from v6 tasks

### DIFF
--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -42,22 +42,6 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 
-- name: Create trace agent configuration file
-  template:
-    src: datadog.conf.j2
-    dest: /etc/datadog-agent/trace-agent.conf
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"
-  notify: restart datadog-agent
-
-- name: Create process agent configuration file
-  template:
-    src: datadog.conf.j2
-    dest: /etc/datadog-agent/process-agent.conf
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"
-  notify: restart datadog-agent
-
 - name: Ensure datadog-agent is running
   service:
     name: datadog-agent

--- a/tasks/agent6-win.yml
+++ b/tasks/agent6-win.yml
@@ -25,18 +25,6 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
-- name: Create trace agent configuration file
-  win_template:
-    src: datadog.conf.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\trace-agent.conf"
-  notify: restart datadog-agent-win
-
-- name: Create process agent configuration file
-  win_template:
-    src: datadog.conf.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\process-agent.conf"
-  notify: restart datadog-agent-win
-
 - name: Ensure datadog-agent is running
   win_service:
     name: datadogagent


### PR DESCRIPTION
The v6 agent doesn't need these v5 config files.  Further, the new
datadog_config variable is YAML, and the datadog.conf.j2 template
renders the YAML content incorrectly (as Python datatypes), producing
confusing and invalid ansible updates to these unused files.

Fixes #206 