### PR TITLE
File/directory mode

### DIFF
--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -3,6 +3,9 @@
   file:
     dest: /etc/dd-agent
     state: directory
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_group }}"
+    mode: 0550
 
 - name: (agent5) Create main Datadog agent configuration file
   template:
@@ -10,6 +13,7 @@
     dest: /etc/dd-agent/datadog.conf
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   notify: restart datadog-agent
 
 - name: (agent5) Ensure datadog-agent is running
@@ -32,5 +36,6 @@
     dest: "/etc/dd-agent/conf.d/{{ item }}.yaml"
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -12,7 +12,7 @@
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
     mode: 0550
-    
+
 - name: Create main Datadog agent configuration file
   template:
     src: datadog.yaml.j2

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -9,13 +9,17 @@
   file:
     dest: /etc/datadog-agent
     state: directory
-
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_group }}"
+    mode: 0550
+    
 - name: Create main Datadog agent configuration file
   template:
     src: datadog.yaml.j2
     dest: /etc/datadog-agent/datadog.yaml
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   notify: restart datadog-agent
 
 - name: Ensure configuration directories are present for each Datadog check
@@ -24,6 +28,7 @@
     state: directory
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0550
   with_items: '{{ datadog_checks|list }}'
 
 - name: Create a configuration file for each Datadog check
@@ -32,6 +37,7 @@
     dest: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml"
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 
@@ -48,6 +54,7 @@
     dest: /etc/datadog-agent/trace-agent.conf
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   notify: restart datadog-agent
 
 - name: Create process agent configuration file
@@ -56,6 +63,7 @@
     dest: /etc/datadog-agent/process-agent.conf
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0440
   notify: restart datadog-agent
 
 - name: Ensure datadog-agent is running


### PR DESCRIPTION
Set file 0440 and dir 0550 mode, since it's world readable, user writable, and may contain private data like passwords, api keys, etc. Windows is affected too, we could use win_acl module, but this needs tests.