### PR TITLE
Adding 'datadog_integration' to easily control installed integration.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,20 +53,6 @@ jobs:
 
   # Agent 5
 
-  debian_25_5:
-    docker:
-      - image: datadog/docker-library:ansible_debian_2_5
-    environment:
-      - OS_TYPE: "debian"
-    <<: *install_agent_5
-
-  centos_25_5:
-    docker:
-      - image: datadog/docker-library:ansible_centos_2_5
-    environment:
-      - OS_TYPE: "centos"
-    <<: *install_agent_5
-
   debian_26_5:
     docker:
       - image: datadog/docker-library:ansible_debian_2_6
@@ -110,20 +96,6 @@ jobs:
     <<: *install_agent_5
 
   # Agent 6
-
-  debian_25_6:
-    docker:
-      - image: datadog/docker-library:ansible_debian_2_5
-    environment:
-      - OS_TYPE: "debian"
-    <<: *install_agent_6
-
-  centos_25_6:
-    docker:
-      - image: datadog/docker-library:ansible_centos_2_5
-    environment:
-      - OS_TYPE: "centos"
-    <<: *install_agent_6
 
   debian_26_6:
     docker:
@@ -174,9 +146,6 @@ workflows:
       - ansible_lint
 
       # test debian (apt)
-      #   ansible 2.5
-      - debian_25_5
-      - debian_25_6
       #   ansible 2.6
       - debian_26_5
       - debian_26_6
@@ -188,9 +157,6 @@ workflows:
       - debian_28_6
 
       # test centos (rpm)
-      #   ansible 2.5
-      - centos_25_5
-      - centos_25_6
       #   ansible 2.6
       - centos_26_5
       - centos_26_6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ jobs:
     steps:
       - checkout
       - run: pip install ansible-lint
-      - run: ansible-lint -v $(find . -name *yml) -x ANSIBLE0006,ANSIBLE0010,602
+      - run: ansible-lint -v $(find . -name *yml) -x ANSIBLE0006,ANSIBLE0010,602,ANSIBLE0017
 
   # Agent 5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 CHANGELOG
 =========
 
+# 3.2.0 /
+
+* [DEPRECATION] Drop support for EOL version of Ansible (2.5)
+
 # 3.1.0 / 2019-08-30
 
 - [FEATURE] Trust new RPM key on SUSE. See [#203][].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ CHANGELOG
 # 3.2.0 /
 
 * [DEPRECATION] Drop support for EOL version of Ansible (2.5)
+- [FEATURE] Add the `datadog_integration resource` to easily control installed integrations.
 
 # 3.1.0 / 2019-08-30
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,25 @@ this role version 6 of the agent is installed by default (instead of version
 
 Supports most Debian and RHEL-based Linux distributions, and Windows.
 
+- [Ansible Datadog Role](#ansible-datadog-role)
+  * [Installation](#installation)
+  * [Role Variables](#role-variables)
+  * [Agent 5 (older version)](#agent-5--older-version-)
+  * [Dependencies](#dependencies)
+  * [Configuring a check](#configuring-a-check)
+  * [Upgrading an integration](#upgrading-an-integration)
+  * [Example Playbooks](#example-playbooks)
+  * [APM](#apm)
+  * [Process Agent](#process-agent)
+      - [Variables](#variables)
+      - [Example of configuration](#example-of-configuration)
+    + [Agent 5](#agent-5)
+      - [Example of configuration](#example-of-configuration-1)
+  * [Additional tasks](#additional-tasks)
+  * [Known Issues and Workarounds](#known-issues-and-workarounds)
+  * [License](#license)
+  * [Author Information](#author-information)
+
 Installation
 ------------
 
@@ -147,6 +166,48 @@ This example will configure the PostgeSQL check through **autodiscovery**:
 ```
 
 
+Upgrading an integration
+------------------------
+
+**Available for Agent v6.8+**
+
+The `datadog_integration` resource will help you to install specific versions
+of Datadog integrations. Keep in mind the Agent comes with all the
+integrations already installed. So this command is here to allow you to upgrade
+a specific integration without upgrading the whole Agent. For more usage
+information consult the [Agent
+docs](https://docs.datadoghq.com/agent/guide/integration-management/).
+
+Available actions:
+- `install`: install a specific version of the integration.
+- `remove`: removes an integration.
+
+Syntax:
+```yml
+  datadog_integration:
+    <name of the integration>:
+      action: <'install' or 'remove'>
+      version: <the version to install>
+```
+
+### Example
+
+This example installs version `1.11.0` of the ElasticSearch integration and
+removes the `postgres` integration.
+
+
+```yml
+ datadog_integration:
+   datadog-elastic:
+     action: install
+     version: 1.11.0
+   datadog-postgres:
+     action: remove
+```
+
+In order to get the available versions of the integrations, please refer to
+their `CHANGELOG.md` file in the [integrations-core repository](https://github.com/DataDog/integrations-core).
+
 Example Playbooks
 -----------------
 
@@ -157,7 +218,7 @@ Sending data to Datadog US (default) and configuring a few checks.
     - { role: Datadog.datadog, become: yes }
   vars:
     datadog_api_key: "123456"
-    datadog_agent_version: "1:6.0.0-1" # for apt-based platforms, use a `6.0.0-1` format on yum-based platforms
+    datadog_agent_version: "1:6.8.0-1" # for apt-based platforms, use a `6.8.0-1` format on yum-based platforms
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO
@@ -207,6 +268,13 @@ Sending data to Datadog US (default) and configuring a few checks.
             service: nginx
             source: nginx
             sourcecategory: http_web_access
+    # datadog_integration is available on agent 6.8+
+    datadog_integration:
+      datadog-elastic:
+        action: install
+        version: 1.11.0
+      datadog-postgres:
+        action: remove
 ```
 
 Example for sending data to EU site:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,12 @@ datadog_checks: {}
 datadog_user: dd-agent
 datadog_group: root
 
+# agent integration variables
+integration_command_user_linux: "dd-agent"
+integration_command_user_windows: "administrator"
+datadog_agent_binary_path_linux: /opt/datadog-agent/bin/agent/agent
+datadog_agent_binary_path_windows: "C:\\Program Files\\Datadog\\Datadog Agent\\bin\\agent.exe"
+
 # list of additional groups for datadog_user
 datadog_additional_groups: {}
 
@@ -56,7 +62,7 @@ datadog_windows_ddagentuser_name: ""
 # Override to change the password of the created windows user.
 datadog_windows_ddagentuser_password: ""
 
-# do not modify.  Default empty value for constructing the list of optional 
+# do not modify.  Default empty value for constructing the list of optional
 # arguments to supply to the windows installer.
 win_install_args: " "
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: 'Brian Akins, Dustin Brown & Datadog'
   description: Install Datadog agent and configure checks
   license: Apache2
-  min_ansible_version: 2.5
+  min_ansible_version: 2.6
   platforms:
     - name: Ubuntu
       versions:

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -1,0 +1,66 @@
+---
+- name: set agent binary path (windows)
+  set_fact:
+    datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
+  when: ansible_os_family == "Windows"
+
+- name: set agent binary path (unix)
+  set_fact:
+    datadog_agent_binary_path: "{{ datadog_agent_binary_path_linux }}"
+  when: ansible_os_family != "Windows"
+
+- name: set agent user for integration commmand (windows)
+  set_fact:
+    integration_command_user: "{{ integration_command_user_windows }}"
+  when: ansible_os_family == "Windows"
+
+- name: set agent agent binary path (unix)
+  set_fact:
+    integration_command_user: "{{ integration_command_user_linux }}"
+  when: ansible_os_family != "Windows"
+
+- name: Validate integrations actions
+  fail:
+    msg: "Unkown action '{{ item.value.action }}' for integration command ({{ item.key }}). Valid actions are 'install' and 'remove'"
+  when: item.value.action != "install" and item.value.action != "remove"
+  loop: "{{ datadog_integration|dict2items }}"
+
+# Remove Integrations
+
+- name: Removing integrations (Unix)
+  command:
+    argv:
+      - "{{ datadog_agent_binary_path }}"
+      - integration
+      - remove
+      - "{{ item.key }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "remove" and ansible_os_family != "Windows"
+
+- name: Removing integrations (Windows)
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "remove" and ansible_os_family == "Windows"
+
+# Install integrations
+
+- name: Install pinned version of integrations (Unix)
+  command:
+    argv:
+      - "{{ datadog_agent_binary_path }}"
+      - integration
+      - install
+      - "{{ item.key }}=={{ item.value.version }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "install" and ansible_os_family != "Windows"
+
+- name: Install pinned version of integrations (Windows)
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ item.key }}=={{ item.value.version }}"
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "install" and ansible_os_family == "Windows"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -20,6 +20,9 @@
 - include_tasks: agent6-win.yml
   when: not datadog_agent5 and ansible_os_family == "Windows"
 
+- include_tasks: integration.yml
+  when: datadog_integration is defined
+
 - include_tasks: post_tasks/*.yml
   when: post_tasks is defined
 


### PR DESCRIPTION
Allows user to pin integration version using the `integration` command (see more [here](https://docs.datadoghq.com/agent/guide/integration-management/)).