### PR TITLE
Add support for creating system-probe configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vagrant
 *.retry
+.venv
 
 # pre and post tasks folders (user defined)
 pre_tasks/

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ Sending data to Datadog US (default) and configuring a few checks.
   roles:
     - { role: Datadog.datadog, become: yes }
   vars:
+    system_probe_config:
+      enabled: true
     datadog_api_key: "123456"
     datadog_agent_version: "1:6.8.0-1" # for apt-based platforms, use a `6.8.0-1` format on yum-based platforms
     datadog_config:
@@ -317,6 +319,10 @@ or "disabled" (to disable the Process Agent entirely)
 - `scrub_args` - enables the scrubbing of sensitive arguments from a process command line. Default value is true
 - `custom_sensitive_words` - expands the default list of sensitive words used by the cmdline scrubber
 
+#### System Probe
+
+The network performance monitoring system probe is configured under the `system_probe_config` variable.  Any variables nested underneath will be written to the `system-probe.yaml`
+
 #### Example of configuration
 ```yml
 datadog_config:
@@ -324,6 +330,9 @@ datadog_config:
     enabled: "true" # has to be set as a string
     scrub_args: true
     custom_sensitive_words: ['consul_token','dd_api_key']
+system_probe_config:
+  enabled: true
+  sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
 ```
 
 ### Agent 5

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supports most Debian and RHEL-based Linux distributions, and Windows.
   * [APM](#apm)
   * [Process Agent](#process-agent)
       - [Variables](#variables)
+      - [System Probe](#system-probe)
       - [Example of configuration](#example-of-configuration)
     + [Agent 5](#agent-5)
       - [Example of configuration](#example-of-configuration-1)
@@ -217,8 +218,6 @@ Sending data to Datadog US (default) and configuring a few checks.
   roles:
     - { role: Datadog.datadog, become: yes }
   vars:
-    system_probe_config:
-      enabled: true
     datadog_api_key: "123456"
     datadog_agent_version: "1:6.8.0-1" # for apt-based platforms, use a `6.8.0-1` format on yum-based platforms
     datadog_config:
@@ -277,6 +276,8 @@ Sending data to Datadog US (default) and configuring a few checks.
         version: 1.11.0
       datadog-postgres:
         action: remove
+    system_probe_config:
+      enabled: true
 ```
 
 Example for sending data to EU site:
@@ -321,7 +322,9 @@ or "disabled" (to disable the Process Agent entirely)
 
 #### System Probe
 
-The network performance monitoring system probe is configured under the `system_probe_config` variable.  Any variables nested underneath will be written to the `system-probe.yaml`
+The [network performance monitoring](https://docs.datadoghq.com/network_performance_monitoring/) system probe is configured under the `system_probe_config` variable.  Any variables nested underneath will be written to the `system-probe.yaml`.
+
+Currently, the system probe only works on Linux with the Agent 6 version and beyond.
 
 #### Example of configuration
 ```yml

--- a/README.md
+++ b/README.md
@@ -307,15 +307,13 @@ The following variables are available for the Process Agent:
 * `scrub_args`: Enables the scrubbing of sensitive arguments from a process command line. Default value is `true`.
 * `custom_sensitive_words`: Expands the default list of sensitive words used by the cmdline scrubber.
 
-### Example of configuration
-
-#### System Probe
+### System Probe
 
 The [network performance monitoring](https://docs.datadoghq.com/network_performance_monitoring/) system probe is configured under the `system_probe_config` variable.  Any variables nested underneath will be written to the `system-probe.yaml`.
 
 Currently, the system probe only works on Linux with the Agent 6 version and beyond.
 
-#### Example of configuration
+### Example of configuration
 ```yml
 datadog_config:
   process_config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,7 @@
 ---
+system_probe_config:
+  enabled: false
+
 datadog_enabled: yes
 
 # default datadog.conf options

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -1,4 +1,7 @@
 ---
+- name: populate service facts
+  service_facts:
+
 - name: add "{{ datadog_user }}" user to additional groups
   user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
   with_items: "{{ datadog_additional_groups }}"
@@ -73,14 +76,19 @@
     enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
-- name: Ensure datadog-agent-sysprobe is running if enabled
+- name: set system probe enabled
+  set_fact:
+    datadog_sysprobe_enabled: true
+  when: system_probe_config is defined and system_probe_config["enabled"] and ansible_facts.services['datadog-agent-sysprobe'] is defined
+
+- name: Ensure datadog-agent-sysprobe is running if enabled and installed
   service:
     name: datadog-agent-sysprobe
     state: started
     enabled: yes
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and system_probe_config is defined and system_probe_config["enabled"]
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and datadog_sysprobe_enabled
 
-- name: Ensure datadog-agent, datadog-agent-process, datadog-agent-trace and datadog-agent-sysprobe are not running
+- name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
   service:
     name: "{{ item }}"
     state: stopped
@@ -90,4 +98,3 @@
     - datadog-agent
     - datadog-agent-process
     - datadog-agent-trace
-    - datadog-agent-sysprobe

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -10,6 +10,13 @@
     dest: /etc/datadog-agent
     state: directory
 
+- name: Create system-probe configuration file
+  template:
+    src: system-probe.yaml.j2
+    dest: /etc/datadog-agent/system-probe.yaml
+    owner: "root"
+    group: "root"
+
 - name: Create main Datadog agent configuration file
   template:
     src: datadog.yaml.j2

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -10,13 +10,6 @@
     dest: /etc/datadog-agent
     state: directory
 
-- name: Create system-probe configuration file
-  template:
-    src: system-probe.yaml.j2
-    dest: /etc/datadog-agent/system-probe.yaml
-    owner: "root"
-    group: "root"
-
 - name: Create main Datadog agent configuration file
   template:
     src: datadog.yaml.j2
@@ -65,6 +58,14 @@
     group: "{{ datadog_group }}"
   notify: restart datadog-agent
 
+- name: Create system-probe configuration file
+  template:
+    src: system-probe.yaml.j2
+    dest: /etc/datadog-agent/system-probe.yaml
+    mode: 0644
+    owner: "root"
+    group: "root"
+
 - name: Ensure datadog-agent is running
   service:
     name: datadog-agent
@@ -72,7 +73,14 @@
     enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
-- name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
+- name: Ensure datadog-agent-sysprobe is running if enabled
+  service:
+    name: datadog-agent-sysprobe
+    state: started
+    enabled: yes
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and system_probe_config is defined and system_probe_config["enabled"]
+
+- name: Ensure datadog-agent, datadog-agent-process, datadog-agent-trace and datadog-agent-sysprobe are not running
   service:
     name: "{{ item }}"
     state: stopped
@@ -82,3 +90,4 @@
     - datadog-agent
     - datadog-agent-process
     - datadog-agent-trace
+    - datadog-agent-sysprobe

--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -65,9 +65,9 @@
   template:
     src: system-probe.yaml.j2
     dest: /etc/datadog-agent/system-probe.yaml
-    mode: 0644
+    mode: 0640
     owner: "root"
-    group: "root"
+    group: "{{ datadog_group }}"
 
 - name: Ensure datadog-agent is running
   service:

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -1,0 +1,8 @@
+# Managed by Ansible
+
+{% if system_probe_config is defined and system_probe_config|length > 0 -%}
+system_probe_config:
+{% filter indent(width=2, first=True) %}
+{{ system_probe_config | to_nice_yaml }}
+{% endfilter %}
+{% endif %}

--- a/tests/test_6_full.yml
+++ b/tests/test_6_full.yml
@@ -4,6 +4,14 @@
   vars:
     datadog_api_key: "123456"
     datadog_agent_allow_downgrade: true
+    system_probe_config:
+      enabled: true
+      source_excludes:
+        "*":
+          - 8301
+      dest_excludes:
+        "*":
+          - 8301
     datadog_config:
       tags: "mytag0, mytag1"
       log_level: INFO


### PR DESCRIPTION
This PR adds support for writing the `system-probe.yaml` configuration file to the ansible playbook.

If the system probe is enabled, the corresponding service will be started.

@DataDog/burrito 
@hush-hush 