### PR TITLE
[system-probe] Fix datadog_sysprobe_enabled fact definition

### DIFF
--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -78,8 +78,10 @@
 
 - name: set system probe enabled
   set_fact:
-    datadog_sysprobe_enabled: true
-  when: system_probe_config is defined and system_probe_config["enabled"] and ansible_facts.services['datadog-agent-sysprobe'] is defined
+    datadog_sysprobe_enabled: >
+            "{{ system_probe_config is defined
+                and system_probe_config['enabled']
+                and ansible_facts.services['datadog-agent-sysprobe'] is defined }}"
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
   service:


### PR DESCRIPTION
Fixes an issue where the `datadog_sysprobe_enabled` fact was only defined if it was true.

This PR ensures that the fact is always defined, whether it is true or false 

Fixes

https://github.com/DataDog/ansible-datadog/issues/212
https://github.com/DataDog/ansible-datadog/issues/214