### PR TITLE
Multi-line set_fact jinja2 template cannot assign boolean values.

### DIFF
--- a/tasks/agent6-linux.yml
+++ b/tasks/agent6-linux.yml
@@ -78,10 +78,9 @@
 
 - name: set system probe enabled
   set_fact:
-    datadog_sysprobe_enabled: >
-            "{{ system_probe_config is defined
-                and system_probe_config['enabled']
-                and ansible_facts.services['datadog-agent-sysprobe'] is defined }}"
+    datadog_sysprobe_enabled: "{{ system_probe_config is defined
+      and system_probe_config['enabled']
+      and ansible_facts.services['datadog-agent-sysprobe'] is defined }}"
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
   service:


### PR DESCRIPTION
Probably because of a bug in ansible the multi-line yaml used for
jinja2 template in one set_fact task assign a string to a variable
that needs to be used as a boolean in the next task.

Before the change:
```
task path: /Users/user/development/datadog/roles/datadog/tasks/agent6-linux.yml:79
ok: [vm01] => {
    "ansible_facts": {
        "datadog_sysprobe_enabled": "False\n"
    },
    "changed": false
}

[...]

task path: /Users/user/development/datadog/roles/datadog/tasks/agent6-linux.yml:86
fatal: [vm01]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "daemon_reexec": false,
            "daemon_reload": false,
            "enabled": true,
            "force": null,
            "masked": null,
            "name": "datadog-agent-sysprobe",
            "no_block": false,
            "scope": null,
            "state": "started",
            "user": null
        }
    },
    "msg": "Could not find the requested service datadog-agent-sysprobe: host"
}
```

After the change:
```
task path: /Users/user/development/datadog/roles/datadog/tasks/agent6-linux.yml:79
ok: [vm01] => {
    "ansible_facts": {
        "datadog_sysprobe_enabled": false
    },
    "changed": false
}

[...]

task path: /Users/user/development/datadog/roles/datadog/tasks/agent6-linux.yml:86
skipping: [vm01] => {
    "changed": false,
    "skip_reason": "Conditional result was False"
}
```

REASON:
Just removing the multi-line fixes the issue:

```
datadog_sysprobe_enabled: >
     "{{ true and false}}"
```

=> "False"

```
datadog_sysprobe_enabled: "{{ true and false}}"
```

=> false


For reference:
```
$ ansible --version
ansible 2.8.1
...
  ansible python module location = /usr/local/lib/python2.7/site-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 2.7.17 (default, Oct 24 2019, 12:57:47) [GCC 4.2.1 Compatible Apple LLVM 11.0.0 (clang-1100.0.33.8)]
```

Fixes #217