### PR TITLE
Blacklist version 6.14.0 and 6.14.1 version on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 CHANGELOG
 =========
 
+# 3.2.1 /
+
+* [FEATURE] Blacklist installation of 6.14.0 and 6.14.1 on Windows.
+* [FEATURE] Run fix + sanity check script before agent install/upgrade on Windows.
+* [FEATURE] Adding support for Datadog system-probe.
+
 # 3.2.0 / 2019-10-02
 
 * [DEPRECATION] Drop support for EOL version of Ansible (2.5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 CHANGELOG
 =========
 
-# 3.2.1 /
+# 3.3.0 /
 
 * [FEATURE] Blacklist installation of 6.14.0 and 6.14.1 on Windows.
 * [FEATURE] Run fix + sanity check script before agent install/upgrade on Windows.

--- a/README.md
+++ b/README.md
@@ -368,16 +368,16 @@ On Debian Stretch, the `apt_key` module that the role uses requires an additiona
 
 ### Datadog Agent 6.14 for Windows
 
-Due to a critical bug in agent versions `6.14.0` and `6.14.1` for Windows, these versions have
-been blacklisted (stating with the version `3.2.1` of this role).
+Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, these versions have
+been blacklisted (starting with the version `3.3.0` of this role).
 
-**PLEASE NOTE:** ansible will fail on windows if `datadog_agent_version` is set
-to `6.14.0` or `6.14.1`, please use 6.14.2 instead. If the agent version is not
+**PLEASE NOTE:** ansible will fail on Windows if `datadog_agent_version` is set
+to `6.14.0` or `6.14.1`. Please use `6.14.2` instead. If the Agent version is not
 pinned, `6.14.2` will be installed by default.
 
 If you are updating from **6.14.0 or 6.14.1 on Windows**, we **strongly** recommend following these steps:
 
-1. Upgrade `Datadog.datadog` ansible role to the latest version (`>=3.2.1`)
+1. Upgrade the present `Datadog.datadog` ansible role to the latest version (`>=3.3.0`)
 2. Set the `datadog_agent_version` to `6.14.2`
 
 To learn more about this bug, please read [here](http://dtdg.co/win-614-fix).

--- a/README.md
+++ b/README.md
@@ -348,6 +348,8 @@ datadog_config_ex:
 
 ## Known Issues and Workarounds
 
+### dirmngr
+
 On Debian Stretch, the `apt_key` module that the role uses requires an additional system dependency to work correctly. Unfortunately that dependency (`dirmngr`) is not provided by the module. To work around this, you can add the following configuration to the playbooks that make use of the present role:
 
 ```yml
@@ -363,6 +365,22 @@ On Debian Stretch, the `apt_key` module that the role uses requires an additiona
   roles:
     - { role: Datadog.datadog, become: yes, datadog_api_key: "mykey" }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
 ```
+
+### Datadog Agent 6.14 for Windows
+
+Due to a critical bug in agent versions `6.14.0` and `6.14.1` for Windows, these versions have
+been blacklisted (stating with the version `3.2.1` of this role).
+
+**PLEASE NOTE:** ansible will fail on windows if `datadog_agent_version` is set
+to `6.14.0` or `6.14.1`, please use 6.14.2 instead. If the agent version is not
+pinned, `6.14.2` will be installed by default.
+
+If you are updating from **6.14.0 or 6.14.1 on Windows**, we **strongly** recommend following these steps:
+
+1. Upgrade `Datadog.datadog` ansible role to the latest version (`>=3.2.1`)
+2. Set the `datadog_agent_version` to `6.14.2`
+
+To learn more about this bug, please read [here](http://dtdg.co/win-614-fix).
 
 ## License
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,8 +57,11 @@ datadog_skip_running_check: false
 datadog_agent_allow_downgrade: no
 
 # default datadog windows download url
-datadog_windows_download_url: "https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi"
+# we're pinning 6.14.2 instead of latest for now. See http://dtdg.co/win-614-fix for more details.
+#datadog_windows_download_url: "https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi"
+datadog_windows_download_url: "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-6.14.2.msi"
 datadog_windows_versioned_url: "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli"
+datadog_windows_614_fix_script_url: "https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1"
 
 # Override to change the name of the windows user to create
 datadog_windows_ddagentuser_name: ""

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -4,6 +4,16 @@
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: datadog_agent5
 
+- name: Download windows datadog agent 614 fix script
+  win_get_url:
+    url: "{{ datadog_windows_614_fix_script_url }}"
+    dest: '%TEMP%\fix_6_14.ps1'
+
+- name: Run 6.14.0/1 PowerShell fix
+  win_shell: |
+    Set-ExecutionPolicy Bypass -Scope Process -Force
+    &$env:temp\fix_6_14.ps1
+
 - include_tasks: win_agent_6_latest.yml
   when: not datadog_agent5 and (datadog_agent_version | length == 0)
 

--- a/tasks/win_agent_version.yml
+++ b/tasks/win_agent_version.yml
@@ -1,4 +1,10 @@
 ---
+
+- name: Check agent pinned version on Windows
+  fail:
+    msg: "The Agent versions you pinned (6.14.0 or 6.14.1) have been blacklisted, please use 6.14.2 instead. See http://dtdg.co/win-614-fix."
+  when: datadog_agent_version == "6.14.0" or datadog_agent_version == "6.14.1"
+
 - name: set agent download filename to a specific version
   set_fact:
     dd_download_url: "{{ datadog_windows_versioned_url }}-{{ datadog_agent_version }}.msi"


### PR DESCRIPTION
The Agent versions you pinned (6.14.0 or 6.14.1) have been blacklisted
on Windows. See http://dtdg.co/win-614-fix.  Ansible now refuse to
install those version, default to 6.14.2 on Windows and will run the fix
PowerShell script in case 6.14.0/1 was installed.