### PR TITLE
[readme] Fix tags config format

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,8 +205,8 @@ Sending data to Datadog US (default) and configuring a few checks.
     datadog_agent_version: "1:6.13.0-1" # for apt-based platforms, use a `6.13.0-1` format on yum-based platforms and `6.13.0` for Windows
     datadog_config:
       tags:
-        - env: dev
-        - datacenter: local
+        - "env:dev"
+        - "datacenter:local"
       log_level: INFO
       apm_config:
         enabled: true
@@ -238,12 +238,12 @@ Sending data to Datadog US (default) and configuring a few checks.
         instances:
           - nginx_status_url: http://example.com/nginx_status/
             tags:
-              - source: nginx
-              - instance: foo
+              - "source:nginx"
+              - "instance:foo"
           - nginx_status_url: http://example2.com:1234/nginx_status/
             tags:
-              - source: nginx
-              - instance:bar
+              - "source:nginx"
+              - "instance:bar"
 
         #Log collection is available on agent 6
         logs:


### PR DESCRIPTION
In agent config and integration configs, `tags` are expected to be lists of strings, not lists of hashes/maps.

Fix the README accordingly.

Fixes https://github.com/DataDog/ansible-datadog/issues/216.

Thanks to @rosario-raulin, @robstar and @blackstar257 for reporting this!