### PR TITLE
Allow pinned version install on multiple platforms at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,29 @@ ansible-galaxy install Datadog.datadog
 | `datadog_additional_groups`                                                                                                                     | Comma separated list of additional groups for the `datadog_user`. Linux only.                                                                                                                                                                            |
 | `datadog_windows_ddagentuser_name`                                                                                                              | Name of windows user to create/use, in the format `<domain>\<user>`.  Windows only.                                                                                                                                                                      |
 | `datadog_windows_ddagentuser_password`                                                                                                          | Password to use to create the user, and/or register the service. Windows only.                                                                                                                                                                           |
+## datadog_agent_version variable
+
+Starting with version 3 of this role, when the `datadog_agent_version` variable is used to pin a specific Agent version, the role will derive per-OS version names to comply with the version naming schemes of the operating systems we support (eg. `1:7.16.0-1` for Debian- and SUSE- based, `7.16.0-1` for Redhat-based and `7.16.0` for Windows).
+
+This makes it possible to target hosts running different operating systems in the same Ansible run.
+
+For instance, you can now provide:
+
+```yaml
+datadog_agent_version: 7.16.0
+```
+
+and the role will install `1:7.16.0-1` on Debian- and SUSE-based systems, `7.16.0-1` on Redhat-based systems, and `7.16.0` on Windows
+(if not provided, the role uses `1` as the epoch, and `1` as the release number).
+
+Alternatively, you can provide:
+
+```yaml
+datadog_agent_version: 1:7.16.0-1
+```
+
+and the role will install `1:7.16.0-1` on Debian- and SUSE-based systems, `7.16.0-1` on Redhat-based systems, and `7.16.0` on Windows.
+
 
 ## Agent 5 (older version)
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 - include_tasks: parse-version.yml
   when: datadog_agent_version | length > 0
+  run_once: true
 
 - include_tasks: pkg-debian.yml
   when: ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include_tasks: parse-version.yml
+  when: datadog_agent_version | length > 0
 
 - include_tasks: pkg-debian.yml
   when: ansible_os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- include_tasks: parse-version.yml
+
 - include_tasks: pkg-debian.yml
   when: ansible_os_family == "Debian"
 

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -30,19 +30,3 @@
     datadog_agent_redhat_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
     datadog_agent_suse_version: "{{ datadog_epoch }}:{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
     datadog_agent_windows_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}"
-
-- name: Print
-  debug:
-    var: datadog_agent_debian_version
-
-- name: Print
-  debug:
-    var: datadog_agent_redhat_version
-
-- name: Print
-  debug:
-    var: datadog_agent_suse_version
-
-- name: Print
-  debug:
-    var: datadog_agent_windows_version

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -1,0 +1,48 @@
+---
+- name: Parse Agent version
+  set_fact:
+    agent_version: "{{ datadog_agent_version | regex_search(regexp, '\\g<epoch>', '\\g<major>', '\\g<minor>', '\\g<bugfix>', '\\g<suffix>', '\\g<release>') }}"
+  vars:
+    regexp: '(?:(?P<epoch>[0-9]+):)?(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<bugfix>[0-9]+)(?P<suffix>[^-\s]+)?(?:-(?P<release>[0-9]+))?'
+
+- name: Set version vars
+  set_fact:
+    datadog_epoch: "{{ agent_version.0 }}"
+    datadog_major: "{{ agent_version.1 }}"
+    datadog_minor: "{{ agent_version.2 }}"
+    datadog_bugfix: "{{ agent_version.3 }}"
+    datadog_suffix: "{{ agent_version.4 }}"
+    datadog_release: "{{ agent_version.5 }}"
+
+- name: Fill empty version epoch with default
+  set_fact:
+    datadog_epoch: "1"
+  when: datadog_epoch | length == 0
+
+- name: Fill empty version release with default
+  set_fact:
+    datadog_release: "1"
+  when: datadog_release | length == 0
+
+- name: Set OS-specific versions
+  set_fact:
+    datadog_agent_debian_version: "{{ datadog_epoch }}:{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
+    datadog_agent_redhat_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
+    datadog_agent_suse_version: "{{ datadog_epoch }}:{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
+    datadog_agent_windows_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}"
+
+- name: Print
+  debug:
+    var: datadog_agent_debian_version
+
+- name: Print
+  debug:
+    var: datadog_agent_redhat_version
+
+- name: Print
+  debug:
+    var: datadog_agent_suse_version
+
+- name: Print
+  debug:
+    var: datadog_agent_windows_version

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -49,12 +49,12 @@
 
 - name: Ensure pinned version of Datadog agent is installed
   apt:
-    name: "datadog-agent={{ datadog_agent_version }}"
+    name: "datadog-agent={{ datadog_agent_debian_version }}"
     state: present
     force: "{{ datadog_agent_allow_downgrade }}"
     update_cache: yes
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
+  when: (datadog_agent_debian_version is defined) and (not ansible_check_mode)
 
 - name: Ensure Datadog agent is installed
   apt:
@@ -62,4 +62,4 @@
     state: latest  # noqa 403
     update_cache: yes
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)
+  when: (datadog_agent_debian_version is not defined) and (not ansible_check_mode)

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -33,10 +33,10 @@
 
 - name: Install pinned datadog-agent package
   yum:
-    name: "datadog-agent-{{ datadog_agent_version }}"
+    name: "datadog-agent-{{ datadog_agent_redhat_version }}"
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
-  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
+  when: (datadog_agent_redhat_version is defined) and (not ansible_check_mode)
   notify: restart datadog-agent
 
 - name: Install latest datadog-agent package
@@ -44,4 +44,4 @@
     name: datadog-agent
     update_cache: yes
     state: latest  # noqa 403
-  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)
+  when: (datadog_agent_redhat_version is not defined) and (not ansible_check_mode)

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -67,15 +67,15 @@
 
 - name: Install pinned datadog-agent package
   zypper:
-    name: "datadog-agent={{ datadog_agent_version }}"
+    name: "datadog-agent={{ datadog_agent_suse_version }}"
     state: present
     oldpackage: "{{ datadog_agent_allow_downgrade }}"
-  when: (datadog_agent_version | length != 0) and (not ansible_check_mode)
+  when: (datadog_agent_suse_version is defined) and (not ansible_check_mode)
   notify: restart datadog-agent
 
 - name: Install latest datadog-agent package
   zypper:
     name: datadog-agent
     state: latest  # noqa 403
-  when: (datadog_agent_version | length == 0) and (not ansible_check_mode)
+  when: (datadog_agent_suse_version is not defined) and (not ansible_check_mode)
   notify: restart datadog-agent

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -15,10 +15,10 @@
     &$env:temp\fix_6_14.ps1
 
 - include_tasks: win_agent_6_latest.yml
-  when: not datadog_agent5 and (datadog_agent_version | length == 0)
+  when: datadog_agent_windows_version is not defined
 
 - include_tasks: win_agent_version.yml
-  when: not datadog_agent_version | length == 0
+  when: datadog_agent_windows_version is defined
 
 - name: show URL var
   debug:

--- a/tasks/win_agent_version.yml
+++ b/tasks/win_agent_version.yml
@@ -7,4 +7,4 @@
 
 - name: set agent download filename to a specific version
   set_fact:
-    dd_download_url: "{{ datadog_windows_versioned_url }}-{{ datadog_agent_version }}.msi"
+    dd_download_url: "{{ datadog_windows_versioned_url }}-{{ datadog_agent_windows_version }}.msi"


### PR DESCRIPTION
### What does this PR do?

Changes the behavior of the role if `datadog_agent_version` is specified: in that case, the Agent version is parsed into `<epoch>:<major>.<minor>.<bugfix><suffix>-<release>` (`epoch`, `suffix` and `release` are optional), and default values are applied to `epoch` (`1`) and `release` (`1`).

Then, per-OS version names are derived:
Debian and SUSE: `<epoch>:<major>.<minor>.<bugfix><suffix>-<release>`
Redhat: `<major>.<minor>.<bugfix><suffix>-<release>`
Windows: `<major>.<minor>.<bugfix><suffix>`
which are then used for the install.

### Motivation

Being able to install a pinned version on different OSes at the same time, which was not possible before.