### PR TITLE
System-probe indent filter fix

### DIFF
--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -2,7 +2,14 @@
 
 {% if system_probe_config is defined and system_probe_config|length > 0 -%}
 system_probe_config:
-{% filter indent(width=2, first=True) %}
+{# The "first" option is only supported by jinja 2.10+
+  which is not present on older systems (CentOS 7, Debian 8, etc.)
+  Using the equivalent option "indentfirst" will work with
+  all currently existing jinja 2 versions (as of this comment, up to 2.10).
+  The only downside is that this will print a deprecation warning if used
+  with jinja 2.10+.
+ #}
+{% filter indent(width=2, indentfirst=True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -6,8 +6,8 @@ system_probe_config:
   which is not present on older systems (CentOS 7, Debian 8, etc.)
   Using the equivalent option "indentfirst" will work with
   all currently existing jinja 2 versions (as of this comment, up to 2.10).
-  The only downside is that this will print a deprecation warning if used
-  with jinja 2.10+.
+  TODO: when future versions of Jinja are released, check that
+  indentfirst is still supported.
  #}
 {% filter indent(width=2, indentfirst=True) %}
 {{ system_probe_config | to_nice_yaml }}


### PR DESCRIPTION
### What does this PR do?

Replaces the `first` argument of the `indent` filter with the older `indentfirst`.
Fixes #229.

### Motivation

The `first` option is only supported by jinja 2.10+ which is not present on older systems (CentOS 7, Debian 8, etc.).
Using the equivalent option `indentfirst` (see [here](https://github.com/pallets/jinja/blob/4fe03dafcdf251739e1fa27843d7167a7b2f2031/jinja2/filters.py#L611-L630)) will work with all currently existing jinja 2 versions (as of this comment, up to 2.10).