### PR TITLE
Fail with explicit message if OS is not supported by the role

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: Check if OS is supported
+  include_tasks: os-check.yml
+
 - name: Set Facts for Datadog Agent Major Version
   include_tasks: set-parse-version.yml
 

--- a/tasks/os-check.yml
+++ b/tasks/os-check.yml
@@ -1,0 +1,5 @@
+---
+- name: Fail if OS is not supported
+  fail:
+    msg: "The Datadog Ansible role does not support your OS yet. Please email support@datadoghq.com to open a feature request."
+  when: ansible_os_family not in ["RedHat", "Debian", "Suse", "Windows"]


### PR DESCRIPTION
### What does this PR do?

Adds a task at the start of the run checking if the OS is supported by the role.
Adds a message in case it's not supported so that users can contact support to open a feature request.