### PR TITLE
Ensure that system-probe is stopped if it is disabled or not installed

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -89,6 +89,13 @@
     enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and datadog_sysprobe_enabled
 
+- name: Ensure datadog-agent-sysprobe is stopped if disabled or not installed
+  service:
+    name: datadog-agent-sysprobe
+    state: stopped
+    enabled: no
+  when: not datadog_skip_running_check and (not datadog_enabled or not datadog_sysprobe_enabled)
+
 - name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
   service:
     name: "{{ item }}"


### PR DESCRIPTION
If the system probe is not installed or is explicitly disabled, we should ensure that the service is stopped. 

This covers the use case where the probe had been previously enabled and then disabled.