### PR TITLE
pkg-debian: fix repo idempotence

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -41,7 +41,7 @@
 
 - name: Ensure Datadog repository is up-to-date
   apt_repository:
-    filename: ansible_datadog_agent
+    filename: "ansible_datadog_{{ item.key }}"
     repo: "{{ item.value }}"
     state: "{% if item.key == datadog_agent_major_version|int and datadog_apt_repo | length == 0 %}present{% else %}absent{% endif %}"
     update_cache: yes
@@ -53,7 +53,7 @@
 
 - name: (Custom) Ensure Datadog repository is up-to-date
   apt_repository:
-    filename: ansible_datadog_agent
+    filename: ansible_datadog_custom
     repo: "{{ datadog_apt_repo }}"
     state: present
     update_cache: yes


### PR DESCRIPTION
While doing development with Molecule on 18.04, I discovered that `pkg-debian.yml` was written in such a way that runs could never be idempotent. This changes the repository file name logic to basically match what is happening in `pkg-redhat.yml` and makes the role (more?) idempotent.