### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,6 +447,7 @@ system_probe_config:
 ```
 
 Once modification completed, follow the steps below:
+
 1. Start the system-probe: `sudo service datadog-agent-sysprobe start` Note: If the service wrapper is not available on your system, run the following command instead: `sudo initctl start datadog-agent-sysprobe`
 
 2. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent) with `sudo service datadog-agent restart`

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ system_probe_config:
   sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
 ```
 
-Once modification completed, please start system-probe and restart the Datadog Agent follow the steps below:
+Once modification completed, follow the steps below:
 1. Start the system-probe: `sudo service datadog-agent-sysprobe start` Note: If the service wrapper is not available on your system, run the following command instead: sudo initctl start datadog-agent-sysprobe
 
 2. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent) with `sudo service datadog-agent restart`

--- a/README.md
+++ b/README.md
@@ -446,6 +446,15 @@ system_probe_config:
   sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
 ```
 
+Once modification completed, please start system-probe and restart the Datadog Agent follow the steps below:
+1. Start the system-probe: `sudo service datadog-agent-sysprobe start` Note: If the service wrapper is not available on your system, run the following command instead: sudo initctl start datadog-agent-sysprobe
+
+2. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent) with `sudo service datadog-agent restart`
+
+3. Enable the system-probe to start on boot: `sudo service enable datadog-agent-sysprobe`
+
+You may also follow this [documentation](https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=agent#setup) to setup NPM manually.
+
 ### Agent 5
 
 To enable/disable the Process Agent on Agent 5, you need to set on `datadog_config` the `process_agent_enabled` parameter to `true`/`false`.

--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ system_probe_config:
 ```
 
 Once modification completed, follow the steps below:
-1. Start the system-probe: `sudo service datadog-agent-sysprobe start` Note: If the service wrapper is not available on your system, run the following command instead: sudo initctl start datadog-agent-sysprobe
+1. Start the system-probe: `sudo service datadog-agent-sysprobe start` Note: If the service wrapper is not available on your system, run the following command instead: `sudo initctl start datadog-agent-sysprobe`
 
 2. [Restart the Agent](https://docs.datadoghq.com/agent/guide/agent-commands/#restart-the-agent) with `sudo service datadog-agent restart`
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ Once modification completed, follow the steps below:
 
 3. Enable the system-probe to start on boot: `sudo service enable datadog-agent-sysprobe`
 
-You may also follow this [documentation](https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=agent#setup) to setup NPM manually.
+You may also follow the [Datadog Network Performance Monitoring documentation (NPM)](https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=agent#setup) to set it up manually.
 
 ### Agent 5
 


### PR DESCRIPTION
Include steps 6-8 from [Datadog Doc - NPM](https://docs.datadoghq.com/network_performance_monitoring/installation/?tab=agent#setup) on the [GitHub Documentation](https://github.com/DataDog/ansible-datadog/blob/master/README.md#system-probe)?

> 6) Start the system-probe: sudo service datadog-agent-sysprobe start Note: If the service wrapper is not available on your system, run the following command instead: sudo initctl start datadog-agent-sysprobe
> 7) Restart the Agent with sudo service datadog-agent restart
> 8) Enable the system-probe to start on boot: sudo service enable datadog-agent-sysprobe