### PR TITLE
Use new S3 URL format

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ To behavior of the `datadog_windows_download_url` variable has been modified. Wh
 
 `datadog_agent_major_version` | Default Windows msi package URL |
 ------------------------------|------------------------|
-6                             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi |
-7                             | https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi |
+6                             | https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi |
+7                             | https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi |
 
 To override the default behavior, set the `datadog_windows_download_url` variable to something else than an empty string.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,15 +86,15 @@ datadog_windows_download_url: ""
 
 # The default msi package for each major Agent version is specified in the following variables.
 # These variables are for internal use only, do not modify them.
-datadog_windows_agent6_latest_url: "https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-6-latest.amd64.msi"
-datadog_windows_agent7_latest_url: "https://s3.amazonaws.com/ddagent-windows-stable/datadog-agent-7-latest.amd64.msi"
+datadog_windows_agent6_latest_url: "https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-6-latest.amd64.msi"
+datadog_windows_agent7_latest_url: "https://ddagent-windows-stable.s3.amazonaws.com/datadog-agent-7-latest.amd64.msi"
 
 # If datadog_agent_version is set, the role will use the following url prefix instead, and append the version number to it
 # in order to get the full url to the msi package.
-datadog_windows_versioned_url: "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli"
+datadog_windows_versioned_url: "https://ddagent-windows-stable.s3.amazonaws.com/ddagent-cli"
 
 # url of the 6.14 fix script. See http://dtdg.co/win-614-fix for more details.
-datadog_windows_614_fix_script_url: "https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1"
+datadog_windows_614_fix_script_url: "https://ddagent-windows-stable.s3.amazonaws.com/scripts/fix_6_14.ps1"
 
 # Override to change the name of the windows user to create
 datadog_windows_ddagentuser_name: ""


### PR DESCRIPTION
### What does this PR do?

Switch S3 URLs to virtual-hosted style.

### Motivation

Comply with the new standard. Even if old buckets should not be affected, let's be consistent in the path style we use.
