### PR TITLE
Add skip check on sysprobe set_fact tasks

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -79,12 +79,14 @@
 - name: set system probe installed
   set_fact:
     datadog_sysprobe_installed: "{{ ansible_facts.services['datadog-agent-sysprobe'] is defined or ansible_facts.services['datadog-agent-sysprobe.service'] is defined }}"
+  when: not datadog_skip_running_check
 
 - name: set system probe enabled
   set_fact:
     datadog_sysprobe_enabled: "{{ system_probe_config is defined
       and system_probe_config['enabled']
       and datadog_sysprobe_installed }}"
+  when: not datadog_skip_running_check
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
   service:


### PR DESCRIPTION
### What does this PR do?

Adds `when: not datadog_skip_running_check` to the system-probe `set_fact` tasks.

### Motivation

The `datadog_sysprobe_installed` and `datadog_sysprobe_enabled` facts are only used on tasks with the `when: not datadog_skip_running_check` condition.
Fixes the CI (as it needs to skip the running check).