### PR TITLE
[debian] Fix role idempotence

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -23,11 +23,6 @@
     state: present
   when: datadog_apt_key_url_new is defined
 
-- name: Remove previous datadog apt list file
-  file:
-    path: /etc/apt/sources.list.d/ansible_datadog_agent.list
-    state: absent
-
 - name: Ensure Datadog non-https repositories are deprecated
   apt_repository:
     repo: "{{ item }}"
@@ -50,6 +45,28 @@
     5: '{{ datadog_agent5_apt_repo }}'
     6: '{{ datadog_agent6_apt_repo }}'
     7: '{{ datadog_agent7_apt_repo }}'
+
+- name: Initialize custom repo file deletion flag to False
+  set_fact:
+    datadog_remove_custom_repo_file: "False"
+
+- name: Check if custom repository file exists
+  stat:
+    path: /etc/apt/sources.list.d/ansible_datadog_custom.list
+  register: datadog_custom_repo_file
+
+- name: Flag custom repository file for deletion if different from current repository config
+  set_fact:
+    datadog_remove_custom_repo_file: "{{ datadog_repo_file_contents != datadog_apt_repo }}"
+  vars:
+    datadog_repo_file_contents: "{{ lookup('file', '/etc/apt/sources.list.d/ansible_datadog_custom.list') }}"
+  when: datadog_custom_repo_file.stat.exists
+
+- name: (Custom) Remove Datadog custom repository file when not set or updated
+  file:
+    path: /etc/apt/sources.list.d/ansible_datadog_custom.list
+    state: absent
+  when: (datadog_apt_repo | length == 0) or datadog_remove_custom_repo_file and (not ansible_check_mode)
 
 - name: (Custom) Ensure Datadog repository is up-to-date
   apt_repository:

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -41,7 +41,7 @@
 
 - name: Ensure Datadog repository is up-to-date
   apt_repository:
-    filename: ansible_datadog_agent
+    filename: "ansible_datadog_{{ item.key }}"
     repo: "{{ item.value }}"
     state: "{% if item.key == datadog_agent_major_version|int and datadog_apt_repo | length == 0 %}present{% else %}absent{% endif %}"
     update_cache: yes
@@ -53,7 +53,7 @@
 
 - name: (Custom) Ensure Datadog repository is up-to-date
   apt_repository:
-    filename: ansible_datadog_agent
+    filename: ansible_datadog_custom
     repo: "{{ datadog_apt_repo }}"
     state: present
     update_cache: yes


### PR DESCRIPTION
### What does this PR do?

After the big 4.0 refactor, the debian part of the role was not idempotent anymore (on every run, two tasks would be marked as "changed", even when no changes were made to the config).
This PR fixes that by adding some logic around the custom repository to keep the current behavior while making the role idempotent.

### Motivation

Make role idempotent again on Debian.

### Additional Notes

Improves upon #250, with help from @jharley.