### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The version `4` of this role installs the Datadog Agent version 7 by default.
 
 Supports most Debian and RHEL-based Linux distributions, and Windows.
 
+Requires Ansible version `2.6` or higher.
+
 - [Installation](#installation)
 - [Role Variables](#role-variables)
 - [Role upgrade from v3 to v4](#role-upgrade-from-v3-to-v4)
@@ -167,9 +169,9 @@ To define 2 instances for the `process` check use the configuration below:
         init_config:
         instances:
           - name: ssh
-            search_string: ['ssh', 'sshd' ]
+            search_string: ['ssh', 'sshd']
           - name: syslog
-            search_string: ['rsyslog' ]
+            search_string: ['rsyslog']
             cpu_check_interval: 0.2
             exact_match: true
             ignore_denied_access: true
@@ -177,7 +179,7 @@ To define 2 instances for the `process` check use the configuration below:
 
 This creates the corresponding configuration files:
 
-* For Agent v6: `/etc/datadog-agent/conf.d/process.d/conf.yaml`
+* For Agent v6 & v7: `/etc/datadog-agent/conf.d/process.d/conf.yaml`
 * For Agent v5: `/etc/dd-agent/conf.d/process.yaml`
 
 ### Custom Check
@@ -194,7 +196,7 @@ To configure a custom check use the configuration below:
 
 This creates the corresponding configuration files:
 
-* For Agent v6: `/etc/datadog-agent/conf.d/my_custom_check.d/conf.yaml`
+* For Agent v6 & v7: `/etc/datadog-agent/conf.d/my_custom_check.d/conf.yaml`
 * For Agent v5: `/etc/dd-agent/conf.d/my_custom_check.yaml`
 
 ### Autodiscovery Check
@@ -402,7 +404,7 @@ Alternatively, if your playbook **only runs on Windows hosts**, you can do the f
 
 ## APM
 
-To enable APM with Agent v6 use the following configuration:
+To enable APM with Agent v6 and v7 use the following configuration:
 
 ```yaml
 datadog_config:
@@ -488,13 +490,13 @@ On Debian Stretch, the `apt_key` module that the role uses requires an additiona
 - hosts: all
   pre_tasks:
     - name: Debian Stretch requires dirmngr package to be installed in order to use apt_key
-      become: yes  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
+      become: yes
       apt:
         name: dirmngr
         state: present
 
   roles:
-    - { role: datadog.datadog, become: yes, datadog_api_key: "mykey" }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
+    - { role: datadog.datadog, become: yes, datadog_api_key: "mykey" }
 ```
 
 ### Datadog Agent 6.14 for Windows


### PR DESCRIPTION
### What does this PR do?

Adds minimum Ansible version required at the top of the README.
Removes Ansible < 1.9 instructions, as we don't support these Ansible versions in the current version of the role.
Adds missing "& v7" in some instructions.

### Motivation

Keep README up-to-date & make it clear which are the supported versions.