### PR TITLE
[windows] Fix idempotence when reinstalling same pinned version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,15 +22,15 @@
   include_tasks: pkg-windows.yml
   when: ansible_os_family == "Windows"
 
-- name: Linux Install Tasks (Agent 5)
+- name: Linux Configuration Tasks (Agent 5)
   include_tasks: agent5-linux.yml
   when: datadog_agent_major_version|int == 5 and ansible_os_family != "Windows"
 
-- name: Linux Install Tasks
+- name: Linux Configuration Tasks
   include_tasks: agent-linux.yml
   when: datadog_agent_major_version|int > 5 and ansible_os_family != "Windows"
 
-- name: Agent6 Install Tasks (Windows)
+- name: Windows Configuration Tasks
   include_tasks: agent-win.yml
   when: datadog_agent_major_version|int > 5 and ansible_os_family == "Windows"
 

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -4,48 +4,81 @@
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: datadog_agent_major_version|int == 5
 
+# This is a best-effort solution to avoid redownloading the msi when 
+# It won't work with rc / beta builds, and won't work if the version to install
+# is not pinned (as we don't know what version latest will be before downloading
+# the package).
+- name: Check currently installed Agent version
+  win_shell: |
+    $product_name = "Datadog Agent"
+    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
+    $installs = Get-WmiObject -query $query
+
+    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
+      Write-Host ""
+    } else {
+      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
+      Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
+    }
+  register: version_check
+  changed_when: false # By default win_shell returns changed, but we know this script doesn't change anything.
+
+- name: Initialize skip install flag to false
+  set_fact:
+    datadog_skip_windows_install: "False"
+
+- name: Set skip install flag if version already installed
+  set_fact:
+    datadog_skip_windows_install: "{{ version_check.stdout | trim == datadog_agent_windows_version }}"
+  when: datadog_agent_windows_version is defined
+
 - name: Download windows datadog agent 614 fix script
   win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
     dest: '%TEMP%\fix_6_14.ps1'
+  when: not datadog_skip_windows_install
 
 - name: Run 6.14.0/1 PowerShell fix
   win_shell: |
     Set-ExecutionPolicy Bypass -Scope Process -Force
     &$env:temp\fix_6_14.ps1
+  when: not datadog_skip_windows_install
 
 - include_tasks: win_agent_latest.yml
-  when: datadog_agent_windows_version is not defined
+  when: (not datadog_skip_windows_install) and (datadog_agent_windows_version is not defined)
 
 - include_tasks: win_agent_version.yml
-  when: datadog_agent_windows_version is defined
+  when: (not datadog_skip_windows_install) and (datadog_agent_windows_version is defined)
 
 - name: show URL var
   debug:
     var: dd_download_url
+  when: not datadog_skip_windows_install
 
 - include_tasks: pkg-windows-opts.yml
+  when: not datadog_skip_windows_install
 
 - name: pre-Delete temporary msi
   win_file:
     path: '%TEMP%\ddagent.msi'
     state: absent
+  when: not datadog_skip_windows_install
 
 - name: Download windows datadog agent
   win_get_url:
     url: "{{ dd_download_url }}"
     dest: '%TEMP%\ddagent.msi'
   register: download_msi_result
-
+  when: not datadog_skip_windows_install
 
 - name: Install downloaded agent
   win_package:
     path: "{{ download_msi_result.dest }}"
     arguments: "{{ win_install_args }}"
-  when: not ansible_check_mode
+  when: (not datadog_skip_windows_install) and (not ansible_check_mode)
 
 - name: Delete temporary msi
   win_file:
     path: "{{ download_msi_result.dest }}"
     state: absent
-  when: download_msi_result.status_code == 200
+  when: (not datadog_skip_windows_install) and (download_msi_result.status_code == 200)


### PR DESCRIPTION
### What does this PR do?

Fetches the currently installed Agent version to avoid downloading the msi installer whenever possible.
It won't work with rc and beta builds (`Get-WmiObject` doesn't return these), nor it will work with latest (since we currently have no way of knowing which version "latest" will install), but this should cover most common pinned installs use cases.

### Motivation

Make role more idempotent.
Should partially fix this issue: #265.