### PR TITLE
Remove old INI config files from v6/v7 configuration

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -44,22 +44,6 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 
-- name: Create trace agent configuration file
-  template:
-    src: datadog.conf.j2
-    dest: /etc/datadog-agent/trace-agent.conf
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"
-  notify: restart datadog-agent
-
-- name: Create process agent configuration file
-  template:
-    src: datadog.conf.j2
-    dest: /etc/datadog-agent/process-agent.conf
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"
-  notify: restart datadog-agent
-
 - name: Create system-probe configuration file
   template:
     src: system-probe.yaml.j2

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -25,18 +25,6 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
-- name: Create trace agent configuration file
-  win_template:
-    src: datadog.conf.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\trace-agent.conf"
-  notify: restart datadog-agent-win
-
-- name: Create process agent configuration file
-  win_template:
-    src: datadog.conf.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\process-agent.conf"
-  notify: restart datadog-agent-win
-
 - name: Ensure datadog-agent is running
   win_service:
     name: datadogagent


### PR DESCRIPTION
The conifiguration for these is now made in the main configuration file,
so these are no longer used. From the documentation for process-agent:
https://docs.datadoghq.com/infrastructure/process/?tab=linuxwindows
and tracing agent:
https://docs.datadoghq.com/tracing/send_traces/#configure-your-environment

You can see that now both reference the main configuration file.
You can also view the logs of the running agents to see that they're reading
the main agent config.