### PR TITLE
[debian] Fix error when checking custom repository file

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -50,7 +50,6 @@
   set_fact:
     datadog_remove_custom_repo_file: "False"
 
-
 - name: Check if custom repository file exists
   stat:
     path: /etc/apt/sources.list.d/ansible_datadog_custom.list

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -50,16 +50,23 @@
   set_fact:
     datadog_remove_custom_repo_file: "False"
 
+
 - name: Check if custom repository file exists
   stat:
     path: /etc/apt/sources.list.d/ansible_datadog_custom.list
   register: datadog_custom_repo_file
 
+- name: Fetch custom repository file
+  slurp:
+    src: /etc/apt/sources.list.d/ansible_datadog_custom.list
+  register: datadog_custom_repo_file_contents
+  when: datadog_custom_repo_file.stat.exists
+
 - name: Flag custom repository file for deletion if different from current repository config
   set_fact:
     datadog_remove_custom_repo_file: "{{ datadog_repo_file_contents != datadog_apt_repo }}"
   vars:
-    datadog_repo_file_contents: "{{ lookup('file', '/etc/apt/sources.list.d/ansible_datadog_custom.list') }}"
+    datadog_repo_file_contents: "{{ datadog_custom_repo_file_contents['content'] | b64decode | trim }}"
   when: datadog_custom_repo_file.stat.exists
 
 - name: (Custom) Remove Datadog custom repository file when not set or updated


### PR DESCRIPTION
### What does this PR do?

Uses the [`slurp`](https://docs.ansible.com/ansible/latest/modules/slurp_module.html) module instead of the [`lookup`](https://docs.ansible.com/ansible/latest/plugins/lookup.html) module to fetch the remote custom apt repository file.

### Motivation

Fixes bug found in #262.

The `lookup` module uses the file on the control node instead of the one on the remote node. The `slurp` module allows us to fetch the file on the remote node instead, which is the expected behavior.