### PR TITLE
Creates install info file

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,6 @@
 ---
+role_version: 4.2.2
+
 system_probe_config:
   enabled: false
 

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -96,3 +96,10 @@
     - datadog-agent
     - datadog-agent-process
     - datadog-agent-trace
+
+- name: Create installation information file
+  template:
+    src: install_info.j2
+    dest: /etc/datadog-agent/install_info
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_group }}"

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -43,3 +43,8 @@
     - datadogagent
     - datadog-agent-process
     - datadog-agent-trace
+
+- name: Create installation information file
+  template:
+    src: install_info.j2
+    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\install_info"

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -34,3 +34,10 @@
     group: "{{ datadog_group }}"
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
+
+- name: Create installation information file
+  template:
+    src: install_info.j2
+    dest: /etc/dd-agent/install_info
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_group }}"

--- a/templates/install_info.j2
+++ b/templates/install_info.j2
@@ -1,0 +1,5 @@
+---
+install_method:
+  tool: ansible
+  tool_version: ansible-{{ ansible_version.full }}
+  installer_version: ansible_role-{{ role_version  }}

--- a/templates/install_info.j2
+++ b/templates/install_info.j2
@@ -2,4 +2,4 @@
 install_method:
   tool: ansible
   tool_version: ansible-{{ ansible_version.full }}
-  installer_version: ansible_role-{{ role_version  }}
+  installer_version: datadog_role-{{ role_version  }}


### PR DESCRIPTION
### What does this PR do?

Creates `install_info` file with information about the install method used (overwrites any other existing file).

### Additional information

Role versioning is managed by the tags on this repository. Ansible [does not](https://groups.google.com/d/msg/ansible-project/1FLJC2lkP2A/kGquI1n0CgAJ) provide a straightforward way of accessing that information (I requested the feature on ansible/ansible#69600).

This PR hardcodes the role version on to a variable (`role_version`) which would need to be updated on each new release. I think this is the most desirable option but two alternatives I considered are described below.

#### Alternative 1

We could run `ansible-galaxy info [role name] --offline`, and parse the resulting output, which looks like (abbreviated):

```
Role: datadog.datadog
        description:
        dependencies: []
        galaxy_info:
                [...]
        install_date: Fri May 22 10:55:03 2020
        installed_version: x.x.x
        path: ('/root/.ansible/roles', '/usr/share/ansible/roles', '/etc/ansible/roles')
```
this is not valid YAML; we could `grep` it but I don't think it is a good idea (the format might change).

#### Alternative 2

The version is stored in a hidden YAML file (see [here](https://github.com/ansible/ansible/blob/bc41dd45141f627b31fbb04443fbaa1ea0c7d1d4/lib/ansible/galaxy/role.py#L149-L154)) so we could retrieve and parse it. It is an internal Ansible file which I don't think we should rely on it.

### Describe your test plan

Install this version of the role using

```bash
ansible-galaxy install git+https://github.com/DataDog/ansible-datadog.git,mx-psi/ansible-install-info
```

Run it using the repo's instructions and check that:

1. the installation succeeded and
2. the file was created with the correct information.