### PR TITLE
Fix error when facts value don't exist

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,11 +119,11 @@ datadog_agent6_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_agent7_apt_repo: "deb https://apt.datadoghq.com/ stable 7"
 
 # The default yum repository for each major Agent version is specified in the following variables.
-datadog_agent5_yum_repo: "https://yum.datadoghq.com/rpm/{{ ansible_userspace_architecture }}"
-datadog_agent6_yum_repo: "https://yum.datadoghq.com/stable/6/{{ ansible_userspace_architecture }}"
-datadog_agent7_yum_repo: "https://yum.datadoghq.com/stable/7/{{ ansible_userspace_architecture }}"
+datadog_agent5_yum_repo: "https://yum.datadoghq.com/rpm/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent6_yum_repo: "https://yum.datadoghq.com/stable/6/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent7_yum_repo: "https://yum.datadoghq.com/stable/7/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
 
 # The default zypper repository for each major Agent version is specified in the following variables.
-datadog_agent5_zypper_repo: "https://yum.datadoghq.com/suse/rpm/{{ ansible_userspace_architecture }}"
-datadog_agent6_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ ansible_userspace_architecture }}"
-datadog_agent7_zypper_repo: "https://yum.datadoghq.com/suse/stable/7/{{ ansible_userspace_architecture }}"
+datadog_agent5_zypper_repo: "https://yum.datadoghq.com/suse/rpm/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent6_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent7_zypper_repo: "https://yum.datadoghq.com/suse/stable/7/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"


### PR DESCRIPTION
#### What does this PR do?
Fix https://github.com/DataDog/ansible-datadog/issues/282
Resolves installation errors that occur in the Redhat OS family of the arm architecture.

#### Additional information

`ansible_userspace_architecture` is undefined in arm because it is a variable that is only set on Intel family CPUs.
https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/system/platform.py#L61-L72

I used `vars` and changed it to use `ansible_architecture` if `ansible_userspace_architecture ` is undefined.
https://docs.ansible.com/ansible/latest/plugins/lookup/vars.html

#### Describe your test plan

Install this version of the role using

```
ansible-galaxy install git+https://github.com/kanga333/ansible-datadog.git,fix-redhat-arm
```

Running on an arm architecture machine, such as an AWS m6g instance.

I have run the test plan and have confirmed that it ran successfully.