### PR TITLE
Add support for 3rd party integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,16 @@ Available actions:
       version: <VERSION_TO_INSTALL>
 ```
 
+To install third party integrations, set `third_party` to true:
+
+```yml
+  datadog_integration:
+    <INTEGRATION_NAME>:
+      action: <ACTION>
+      version: <VERSION_TO_INSTALL>
+      third_party: true
+```
+
 ##### Example
 
 This example installs version `1.11.0` of the ElasticSearch integration and removes the `postgres` integration.

--- a/manual_tests/inventory
+++ b/manual_tests/inventory
@@ -1,2 +1,2 @@
 [test_host]
-127.0.0.1 ansible_ssh_host=localhost ansible_ssh_user=vagrant ansible_ssh_port=2200 ansible_ssh_private_key_file=./ansible-datadog/tests/.vagrant/machines/default/virtualbox/private_key
+127.0.0.1 ansible_ssh_host=localhost ansible_ssh_user=vagrant ansible_ssh_port=2222 ansible_ssh_private_key_file=./ansible-datadog/manual_tests/.vagrant/machines/default/virtualbox/private_key

--- a/manual_tests/test_7_full.yml
+++ b/manual_tests/test_7_full.yml
@@ -25,6 +25,11 @@
         env: dev
       trace.concentrator:
         extra_aggregators: version
+    datadog_integration:
+      datadog-aqua:
+        action: 'install'
+        version: '1.0.0'
+        third_party: true
     datadog_checks:
       process:
         init_config:

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -49,14 +49,14 @@
 # Install integrations
 
 - name: Install pinned version of integrations (Unix)
-  command: "{{ datadog_agent_binary_path }} integration install {% if 'third_party' in item.value and item.value.third_party %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
+  command: "{{ datadog_agent_binary_path }} integration install {% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family != "Windows"
 
 - name: Install pinned version of integrations (Windows)
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {% if 'third_party' in item.value and item.value.third_party %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -49,15 +49,19 @@
 # Install integrations
 
 - name: Install pinned version of integrations (Unix)
-  command: "{{ datadog_agent_binary_path }} integration install {% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
+  command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
+  vars:
+    third_party: "{% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family != "Windows"
 
 - name: Install pinned version of integrations (Windows)
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: yes
+  vars:
+    third_party: "{% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %}"
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family == "Windows"

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -49,19 +49,14 @@
 # Install integrations
 
 - name: Install pinned version of integrations (Unix)
-  command:
-    argv:
-      - "{{ datadog_agent_binary_path }}"
-      - integration
-      - install
-      - "{{ item.key }}=={{ item.value.version }}"
+  command: "{{ datadog_agent_binary_path }} integration install {% if 'third_party' in item.value and item.value.third_party %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family != "Windows"
 
 - name: Install pinned version of integrations (Windows)
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ item.key }}=={{ item.value.version }}"
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {% if 'third_party' in item.value and item.value.third_party %}--third-party{% endif %} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"


### PR DESCRIPTION
Adds support to install 3rd party integrations using the `datadog-agent integration` command.

I also tested that regular (1st party) integrations can still be installed by adding the following to a manual test:
```
    datadog_integration:
      datadog-snmp:
        action: 'install'
        version: '3.7.1'
```

Unfortunately I can't commit the above, since the version used might become superseded by the one shipped in the Agent, making the install fail. That shouldn't be the case for the 3rd party integration, because we won't bundle them, so I left the test there.