### PR TITLE
Fix ansible-lint CI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - run: pip install ansible-lint
-      - run: ansible-lint -v $(find . -name *yml) -x ANSIBLE0006,ANSIBLE0010,602,ANSIBLE0017
+      - run: ansible-lint -v $(find . -name '*yml') -x ANSIBLE0006,ANSIBLE0010,602,ANSIBLE0017
 
   # Agent 5
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - run: pip install ansible-lint
-      - run: ansible-lint -v $(find . -name '*yml') -x ANSIBLE0006,ANSIBLE0010,602,ANSIBLE0017
+      - run: ansible-lint -v $(find . -name '*yml')
 
   # Agent 5
 

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -53,7 +53,7 @@
   become: yes
   become_user: "{{ integration_command_user }}"
   vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %}"
+    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family != "Windows"
 
@@ -61,7 +61,7 @@
   win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: yes
   vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party == true %}--third-party{% endif %}"
+    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
   when: item.value.action == "install" and ansible_os_family == "Windows"


### PR DESCRIPTION
### What does this PR do?

Fixes the ansible-lint CI job, which wasn't linting anything: the `*yml` expression was expended by the shell and not by `find`, resulting in files in subfolders not being linted.
Removes the ansible-lint exceptions, as we're complying with them.
Fixes lint error in `tasks/integration.yml`.

### Motivation

Keep the role properly linted.