### PR TITLE
Remove entries which cause ansible to fail.

### DIFF
--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -30,14 +30,12 @@
     name: datadogagent
     state: started
     start_mode: auto
-    enabled: yes
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent is not running
   win_service:
     name: "{{ item }}"
     state: stopped
-    enabled: no
   when: not datadog_skip_running_check and not datadog_enabled
   with_list:
     - datadogagent


### PR DESCRIPTION
It seems in ansible 2.10 they're more aggressive about disallowing
unexpected keywords

Fixes windows ansible role as of Ansible 2.10 beta1