### PR TITLE
[windows] Add support for installing to different binary directory

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -103,6 +103,15 @@ datadog_windows_ddagentuser_name: ""
 # Override to change the password of the created windows user.
 datadog_windows_ddagentuser_password: ""
 
+# Override to change the binary installation directory (instead of default c:\program files\datadog\datadog agent)
+datadog_windows_program_files_dir: ""
+
+# Override to change the root of the configuration directory
+datadog_windows_config_files_dir: ""
+
+# Default configuration root.  Do not modify
+datadog_windows_config_root: "{{ ansible_facts.env['ProgramData'] }}\\Datadog"
+
 # do not modify.  Default empty value for constructing the list of optional
 # arguments to supply to the windows installer.
 win_install_args: " "

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -2,25 +2,25 @@
 - name: Create main Datadog agent configuration file
   win_template:
     src: datadog.yaml.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\datadog.yaml"
+    dest: "{{ datadog_windows_config_root }}\\datadog.yaml"
   notify: restart datadog-agent-win
 
 - name: Ensure configuration directories are present for each Datadog check
   win_file:
-    path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d"
+    path: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.d"
     state: directory
   with_items: '{{ datadog_checks|list }}'
 
 - name: Create a configuration file for each Datadog check
   win_template:
     src: checks.yaml.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"
+    dest: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
 - name: Remove old configuration file for each Datadog check
   win_file:
-    path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.yaml"
+    path: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.yaml"
     state: absent
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
@@ -47,4 +47,4 @@
 - name: Create installation information file
   template:
     src: install_info.j2
-    dest: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\install_info"
+    dest: "{{ datadog_windows_config_root }}\\install_info"

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -11,7 +11,7 @@
 # check the registry. On upgrade, the location of the config file root will 
 # be set here.  
 - name: Check existing config file Directory
-  ansible.windows.win_reg_stat:
+  win_reg_stat:
     path: HKLM:\SOFTWARE\Datadog\Datadog Agent
     name: ConfigRoot
   register: config_root_from_registry
@@ -20,7 +20,7 @@
 # be set here.  
 
 - name: Check existing installPath Directory
-  ansible.windows.win_reg_stat:
+  win_reg_stat:
     path: HKLM:\SOFTWARE\Datadog\Datadog Agent
     name: InstallPath
   register: install_path_from_registry

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -8,6 +8,21 @@
     win_install_args: "{{ win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
   when: datadog_windows_ddagentuser_password | length > 0
 
+- name: Set Program Files Target Directory
+  set_fact:
+    win_install_args: "{{ win_install_args }} PROJECTLOCATION=\"{{ datadog_windows_program_files_dir }}\" "
+  when: datadog_windows_program_files_dir | length > 0
+
+- name: Set Config Files Target Directory
+  set_fact:
+    win_install_args: "{{ win_install_args }} APPLICATIONDATADIRECTORY=\"{{ datadog_windows_config_files_dir }}\" "
+  when: datadog_windows_config_files_dir | length > 0
+
+- name: Set config root for config Files
+  set_fact:
+    datadog_windows_config_root: "{{ datadog_windows_config_files_dir }}"
+  when: datadog_windows_config_files_dir | length > 0
+
 - name: Set Test
   set_fact:
     win_install_args: "{{ win_install_args }}"

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -8,6 +8,58 @@
     win_install_args: "{{ win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
   when: datadog_windows_ddagentuser_password | length > 0
 
+# check the registry. On upgrade, the location of the config file root will 
+# be set here.  
+- name: Check existing config file Directory
+  ansible.windows.win_reg_stat:
+    path: HKLM:\SOFTWARE\Datadog\Datadog Agent
+    name: ConfigRoot
+  register: config_root_from_registry
+
+# check the registry. On upgrade, the location of the installation root directory will
+# be set here.  
+
+- name: Check existing installPath Directory
+  ansible.windows.win_reg_stat:
+    path: HKLM:\SOFTWARE\Datadog\Datadog Agent
+    name: InstallPath
+  register: install_path_from_registry
+
+## validate the config path.  Only necessary if it's set in the registry alread (i.e. upgrade)
+## Will fail the install if the caller has set the config root to a non-standard root, and that
+## root is different than what's already present.
+- name: Validate config path
+  fail:
+    msg: "Incompatible configuration option {{ config_root_from_registry.value }} != {{ datadog_windows_config_files_dir }}"
+  when: ( (config_root_from_registry.exists) and
+          (datadog_windows_config_files_dir | length > 0 ) and
+          (config_root_from_registry.value | regex_replace('\\\\$','') | lower != datadog_windows_config_files_dir | lower ) )
+
+- name: Validated config path
+  debug:
+    msg: "Allowing configuration option {{ config_root_from_registry.value }} == {{ datadog_windows_config_files_dir }}"
+  when: ( (config_root_from_registry.exists) and
+          (datadog_windows_config_files_dir | length > 0 ) and
+          (config_root_from_registry.value | regex_replace('\\\\$','') | lower == datadog_windows_config_files_dir | lower ) )
+
+## validate the binary install path.  Only necessary if it's set in the registry alread (i.e. upgrade)
+## Will fail the install if the caller has set the binary install path to a non-standard root, and that
+## root is different than what's already present.
+- name: Validate install path
+  fail:
+    msg: "Incompatible configuration option {{ install_path_from_registry.value }} != {{ datadog_windows_program_files_dir }}"
+  when: ( (install_path_from_registry.exists) and
+          (datadog_windows_program_files_dir | length > 0 ) and
+          (install_path_from_registry.value | regex_replace('\\\\$','') | lower != datadog_windows_program_files_dir | lower ) )
+
+- name: Validated install path
+  debug:
+    msg: "Allowing configuration option {{ install_path_from_registry.value }} == {{ datadog_windows_program_files_dir }}"
+  when: ( (install_path_from_registry.exists) and
+          (datadog_windows_program_files_dir | length > 0 ) and
+          (install_path_from_registry.value | regex_replace('\\\\$','') | lower == datadog_windows_program_files_dir | lower ) )
+
+
 - name: Set Program Files Target Directory
   set_fact:
     win_install_args: "{{ win_install_args }} PROJECTLOCATION=\"{{ datadog_windows_program_files_dir }}\" "
@@ -18,10 +70,18 @@
     win_install_args: "{{ win_install_args }} APPLICATIONDATADIRECTORY=\"{{ datadog_windows_config_files_dir }}\" "
   when: datadog_windows_config_files_dir | length > 0
 
+# if the current installation was set to a non-standard config root, and that config root is not
+# presented here, then update accordingly, so that any config file modifications will be made
+# in the right place
 - name: Set config root for config Files
   set_fact:
     datadog_windows_config_root: "{{ datadog_windows_config_files_dir }}"
-  when: datadog_windows_config_files_dir | length > 0
+  when: ((datadog_windows_config_files_dir | length > 0) and (not config_root_from_registry.exists))
+
+- name: Set config root for config files from current location
+  set_fact:
+    datadog_windows_config_root: "{{ config_root_from_registry.value | regex_replace('\\\\$','') }}"
+  when: config_root_from_registry.exists
 
 - name: Set Test
   set_fact:

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -71,6 +71,23 @@
   register: download_msi_result
   when: not datadog_skip_windows_install
 
+- name: Create Binary directory root (if not default)
+  win_file:
+    path: "{{ datadog_windows_program_files_dir }}"
+    state: directory
+  when: datadog_windows_program_files_dir | length > 0
+
+- name: Set default permissions on binary directory root (if not default)
+  win_acl:
+    path: "{{ datadog_windows_program_files_dir }}"
+    inherit: ContainerInherit,ObjectInherit
+    user: "BUILTIN\\USERS"
+    rights: ReadAndExecute
+    type: allow
+    state: present
+    propagation: None
+  when: datadog_windows_program_files_dir | length > 0
+
 - name: Install downloaded agent
   win_package:
     path: "{{ download_msi_result.dest }}"

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -56,7 +56,6 @@
   when: not datadog_skip_windows_install
 
 - include_tasks: pkg-windows-opts.yml
-  when: not datadog_skip_windows_install
 
 - name: pre-Delete temporary msi
   win_file:


### PR DESCRIPTION
add support for installing to different config directory

Currently, the MSI installer allows installing to a different binary directory (using `PROJECTLOCATION`) and a different config file root (using `APPLICATIONDATADIRECTORY`) with install command line options.

While those options could be passed to the installer, the portion of the role which sets the agent config did not take that into account, and therefore couldn't modify the config.

With this PR, add two new variable options for specifying the binary directory and config directory.
The role will take care of setting up the install time options _and_ set the directories such that the configuration is properly applied.

PR has additional verification

- On upgrade, ansible role will fail if the user-supplied configuration directory or user-supplied binary directory are different than the original installation directory.

- on upgrade, if there is no user-supplied configuration directory or user-supplied binary directory, the role will query the registry to find the correct configuration; otherwise, on upgrade, any configuration changes written by ansible would not be written to the same directory.