### PR TITLE
Run apt-update before installing apt-transport-https

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,6 +1,7 @@
 ---
 - name: Install apt-transport-https
   apt:
+    update_cache: yes
     name: apt-transport-https
     state: present
   when: not ansible_check_mode


### PR DESCRIPTION
Since the local repo metadata cache might not be there, or be outdated.

update_cache docs: https://docs.ansible.com/ansible/latest/modules/apt_module.html#parameter-update_cache

This fixes the CI tests that were broken.