### PR TITLE
[CentOS] Use dnf instead of yum with Python 3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ workflows:
               os: ["centos8"]
               python: ["python3"]
 
-      # Newer suse images only have Pythpn 3 installed
+      # Newer suse images only have Python 3 installed
       - test_install:
           matrix:
             parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,18 @@ commands:
     parameters:
       version:
         type: string
+      python:
+        type: string
     steps:
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml" --check
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/downgrade_to_5.yaml" --check
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>' --check
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/downgrade_to_5.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>' --check
 
   install_agent_5:
+    parameters:
+      python:
+        type: string
     steps:
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_5.yaml"
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_5.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>'
       - run: dd-agent info || true
       - run: ps aux | grep -v grep | grep datadog-agent
 
@@ -20,13 +25,18 @@ commands:
     parameters:
       version:
         type: string
+      python:
+        type: string
     steps:
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml"
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>'
       - run: datadog-agent version
 
   downgrade_agent_5_23_0:
+    parameters:
+      python:
+        type: string
     steps:
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/downgrade_to_5.yaml"
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/downgrade_to_5.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>'
       - run: dd-agent info || true
       - run: ps aux | grep -v grep | grep datadog-agent
 
@@ -34,28 +44,37 @@ commands:
     parameters:
       version:
         type: string
+      python:
+        type: string
     steps:
       - checkout
       - dry_run:
           version: "<<parameters.version>>"
-      - install_agent_5
+          python: "<<parameters.python>>"
+      - install_agent_5:
+          python: "<<parameters.python>>"
       - when:
           condition:
             not:
               equal: [<<parameters.version>>, "5"]
           steps:
             - install_agent:
-                version: <<parameters.version>>
-      - downgrade_agent_5_23_0
+                version: "<<parameters.version>>"
+                python: "<<parameters.python>>"
+      - downgrade_agent_5_23_0:
+          python: "<<parameters.python>>"
 
   test_agent_install:
     parameters:
       version:
         type: string
+      python:
+        type: string
     steps:
       - checkout
       - install_agent:
-          version: <<parameters.version>>
+          version: "<<parameters.version>>"
+          python: "<<parameters.python>>"
 
 jobs:
   # TODO: Use 2.10 image, fix file permission errors (E208) that arise.
@@ -75,12 +94,15 @@ jobs:
         type: string
       os:
         type: string
+      python:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
       - test_agent_install_downgrade:
           version: "<<parameters.agent_version>>"
+          python: "<<parameters.python>>"
 
   test_install:
     parameters:
@@ -90,12 +112,15 @@ jobs:
         type: string
       os:
         type: string
+      python:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
       - test_agent_install:
           version: "<<parameters.agent_version>>"
+          python: "<<parameters.python>>"
 
 workflows:
   version: 2
@@ -105,13 +130,45 @@ workflows:
       - test_install_downgrade:
           matrix:
             parameters:
+              ansible_version: ["2_6", "2_7", "2_8"]
+              agent_version: ["5", "6", "7"]
+              os: ["debian"]
+              python: ["python2", "python3"]
+
+      # Newer debian images only have Pythpn 3 installed
+      - test_install_downgrade:
+          matrix:
+            parameters:
+              ansible_version: ["2_9", "2_10"]
+              agent_version: ["5", "6", "7"]
+              os: ["debian"]
+              python: ["python3"]
+      
+      # centos = CentOS 7. CentOS <= 7 + Python3 is not supported,
+      # as the yum module is Python2-only.
+      - test_install_downgrade: 
+          matrix:
+            parameters:
               ansible_version: ["2_6", "2_7", "2_8", "2_9", "2_10"]
               agent_version: ["5", "6", "7"]
-              os: ["debian", "centos"]
+              os: ["centos"]
+              python: ["python2"]
 
+      # We want to check that the dnf path works with CentOS 8
+      # Newer CentOS images only have Pythpn 3 installed
+      - test_install:
+          matrix:
+            parameters:
+              ansible_version: ["2_8", "2_9", "2_10"]
+              agent_version: ["6", "7"]
+              os: ["centos8"]
+              python: ["python3"]
+
+      # Newer suse images only have Pythpn 3 installed
       - test_install:
           matrix:
             parameters:
               ansible_version: ["2_8", "2_9", "2_10"]
               agent_version: ["6", "7"]
               os: ["suse"]
+              python: ["python3"]

--- a/README.md
+++ b/README.md
@@ -497,6 +497,14 @@ On Debian Stretch, the `apt_key` module used by the role requires an additional 
     datadog_api_key: "<YOUR_DD_API_KEY>"
 ```
 
+### CentOS 6/7 with Python 3 interpreter
+
+The `yum` Python module, which is used in this role to install the Agent on CentOS-based hosts, is only available on Python 2. When a Python 3 interpreter is detected on a target host, the `dnf` package manager and the `dnf` Python module are used instead.
+
+However, `dnf` and the `dnf` Python module are not installed by default on CentOS-based hosts before CentOS 8. In this case, it is not possible to install the Agent when a Python 3 interpreter is used. This role will fail early when this situation is detected to indicate that a Python 2 interpreter is needed when installing the Agent on CentOS / RHEL < 8.
+
+To bypass this early failure detection (for instance, if `dnf` and the `python3-dnf` package are available on your host), set the `datadog_ignore_old_centos_python3_error` variable to `true`.
+
 ### Windows
 
 Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, installation of these versions is now blocked (starting with version `3.3.0` of this role).

--- a/ci_test/downgrade_to_5.yaml
+++ b/ci_test/downgrade_to_5.yaml
@@ -22,4 +22,4 @@
         init_config:
         instances:
           - name: agent
-            search_string: ['agent' ]
+            search_string: ['agent']

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,13 @@ datadog_yum_gpgkey_20200908: "http://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
+# By default, we fail early & print a helpful message if a Python 3 interpreter is used on CentOS < 8, as
+# the 'yum' module is only available on Python 2, and the 'python3-dnf' package is not available before
+# CentOS 8.
+# If set to true, this option removes this check and allows the install to proceed. Useful in specific setups
+# where an old CentOS host using a Python 3 interpreter does have 'dnf' (eg. through backports).
+datadog_ignore_old_centos_python3_error: false
+
 # By default, the role uses the official zypper Datadog repository for the chosen major version
 # Use the datadog_zypper_repo variable to override the repository used.
 datadog_zypper_repo: ""

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -3,7 +3,7 @@
   fail:
     msg: "The installation of the Agent on CentOS / RHEL versions < 8 requires the 'yum' module, which is not compatible with Python 3.
           To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8."
-  when: (ansible_facts.distribution_major_version | int <= 7) and (ansible_facts.python.version.major | int >= 3)
+  when: (not datadog_ignore_old_centos_python3_error) and (ansible_facts.distribution_major_version | int <= 7) and (ansible_facts.python.version.major | int >= 3)
 
 - name: Download new RPM key (Expires in 2022)
   get_url:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,4 +1,10 @@
 ---
+- name: Fail early if Python 3 is used on CentOS / RHEL < 8
+  fail:
+    msg: "The installation of the Agent on CentOS / RHEL versions < 8 requires the 'yum' module, which is not compatible with Python 3.
+          To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8."
+  when: (ansible_facts.distribution_major_version | int <= 7) and (ansible_facts.python.version.major | int >= 3)
+
 - name: Download new RPM key (Expires in 2022)
   get_url:
     url: "{{ datadog_yum_gpgkey_e09422b3 }}"

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -3,7 +3,9 @@
   fail:
     msg: "The installation of the Agent on CentOS / RHEL versions < 8 requires the 'yum' module, which is not compatible with Python 3.
           To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8."
-  when: (not datadog_ignore_old_centos_python3_error) and (ansible_facts.distribution_major_version | int <= 7) and (ansible_facts.python.version.major | int >= 3)
+  when: (not datadog_ignore_old_centos_python3_error)
+        and (ansible_facts.distribution_major_version | int <= 7)
+        and (ansible_facts.python.version.major | int >= 3)
 
 - name: Download new RPM key (Expires in 2022)
   get_url:

--- a/tasks/pkg-redhat/install-latest.yml
+++ b/tasks/pkg-redhat/install-latest.yml
@@ -1,9 +1,19 @@
 ---
-- name: Install latest datadog-agent package
+- name: Install latest datadog-agent package (dnf)
+  dnf:
+    name: "{{ datadog_agent_flavor }}"
+    update_cache: yes
+    state: latest  # noqa 403
+  register: datadog_agent_install
+  when: not ansible_check_mode and ansible_facts.python.version.major | int >= 3
+  notify: restart datadog-agent
+
+- name: Install latest datadog-agent package (yum)
   yum:
     name: "{{ datadog_agent_flavor }}"
     update_cache: yes
     state: latest  # noqa 403
   register: datadog_agent_install
-  when: not ansible_check_mode
+  when: not ansible_check_mode and ansible_facts.python.version.major | int < 3
   notify: restart datadog-agent
+

--- a/tasks/pkg-redhat/install-latest.yml
+++ b/tasks/pkg-redhat/install-latest.yml
@@ -16,4 +16,3 @@
   register: datadog_agent_install
   when: not ansible_check_mode and ansible_facts.python.version.major | int < 3
   notify: restart datadog-agent
-

--- a/tasks/pkg-redhat/install-pinned.yml
+++ b/tasks/pkg-redhat/install-pinned.yml
@@ -1,9 +1,20 @@
 ---
-- name: Install pinned datadog-agent package
-  yum:
+- name: Install pinned datadog-agent package (dnf)
+  dnf:
     name: "{{ datadog_agent_flavor }}-{{ datadog_agent_redhat_version }}"
+    update_cache: yes
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
   register: datadog_agent_install
-  when: not ansible_check_mode
+  when: not ansible_check_mode and ansible_facts.python.version.major | int >= 3
+  notify: restart datadog-agent
+
+- name: Install pinned datadog-agent package (yum)
+  yum:
+    name: "{{ datadog_agent_flavor }}-{{ datadog_agent_redhat_version }}"
+    update_cache: yes
+    state: present
+    allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
+  register: datadog_agent_install
+  when: not ansible_check_mode and ansible_facts.python.version.major | int < 3
   notify: restart datadog-agent


### PR DESCRIPTION
### What does this PR do?

Use the `dnf` task instead of `yum` when we detect that a Python 3 interpreter is used on a target host.
Add CentOS 8 tests to the CI.
Add Python 2 / Python 3 tests to the CI.

### Motivation

The `yum` Python module is not compatible with Python 3.
Should fix #298.

### Additional Notes

CentOS / RHEL < 8 + Python 3 interpreter is an invalid setup (you can't use the `dnf` module either because the `python3-dnf` package doesn't exist on these versions of CentOS), so we fail early in that case, with a helpful error message.