### PR TITLE
Add default values when variables are defined but nil

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -4,7 +4,7 @@
 
 - name: add "{{ datadog_user }}" user to additional groups
   user: name="{{ datadog_user }}" groups="{{ datadog_additional_groups }}" append=yes
-  when: datadog_additional_groups is defined and (datadog_additional_groups | length != 0)
+  when: datadog_additional_groups | default([], true) | length > 0
   notify: restart datadog-agent
 
 - name: Create Datadog agent config directory

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,15 +24,15 @@
 
 - name: Linux Configuration Tasks (Agent 5)
   include_tasks: agent5-linux.yml
-  when: datadog_agent_major_version|int == 5 and ansible_os_family != "Windows"
+  when: datadog_agent_major_version | int == 5 and ansible_os_family != "Windows"
 
 - name: Linux Configuration Tasks
   include_tasks: agent-linux.yml
-  when: datadog_agent_major_version|int > 5 and ansible_os_family != "Windows"
+  when: datadog_agent_major_version | int > 5 and ansible_os_family != "Windows"
 
 - name: Windows Configuration Tasks
   include_tasks: agent-win.yml
-  when: datadog_agent_major_version|int > 5 and ansible_os_family == "Windows"
+  when: datadog_agent_major_version | int > 5 and ansible_os_family == "Windows"
 
 - name: Integrations Tasks
   include_tasks: integration.yml

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -1,7 +1,7 @@
 - name: Set DD Username Arg
   set_fact:
     win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
-  when: datadog_windows_ddagentuser_name | | default('', true) | length > 0
+  when: datadog_windows_ddagentuser_name | default('', true) | length > 0
 
 - name: Set DD Password Arg
   set_fact:

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -1,12 +1,12 @@
 - name: Set DD Username Arg
   set_fact:
     win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
-  when: datadog_windows_ddagentuser_name | length > 0
+  when: datadog_windows_ddagentuser_name | | default('', true) | length > 0
 
 - name: Set DD Password Arg
   set_fact:
     win_install_args: "{{ win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
-  when: datadog_windows_ddagentuser_password | length > 0
+  when: datadog_windows_ddagentuser_password | default('', true) | length > 0
 
 - name: Set Test
   set_fact:

--- a/tasks/set-parse-version.yml
+++ b/tasks/set-parse-version.yml
@@ -1,10 +1,10 @@
 ---
 - name: Convert datadog_agent_major_version to string
   set_fact:
-    datadog_agent_major_version: "{{ datadog_agent_major_version | string }}"
+    datadog_agent_major_version: "{{ datadog_agent_major_version | default('', true) | string }}"
 
 - include_tasks: parse-version.yml
-  when: datadog_agent_version | length > 0
+  when: datadog_agent_version | default('', true) | length > 0
 
 - name: Set Agent default major version
   set_fact:

--- a/tasks/win_agent_latest.yml
+++ b/tasks/win_agent_latest.yml
@@ -3,10 +3,10 @@
 - name: (Custom) Set agent download filename to latest
   set_fact:
     dd_download_url: "{{ datadog_windows_download_url }}"
-  when: datadog_windows_download_url | length > 0
+  when: datadog_windows_download_url | default('', true) | length > 0
 
 - name: Set agent download filename to latest
   set_fact:
     dd_download_url: "{% if datadog_agent_major_version|int == 7 %}{{ datadog_windows_agent7_latest_url }}
       {% else %}{{ datadog_windows_agent6_latest_url }}{% endif %}"
-  when: datadog_windows_download_url | length == 0
+  when: datadog_windows_download_url | default('', true) | length == 0

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -14,6 +14,6 @@ dd_url: {{ datadog_url }}
 api_key: {{ datadog_api_key | default('youshouldsetthis') }}
 {% endif %}
 
-{% if datadog_config is defined and datadog_config|length > 0 -%}
+{% if datadog_config | default({}, true) | length > 0 -%}
 {{ datadog_config | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
### What does this PR do?

Adds guards when trying to read variable lengths, to avoid reading the length of `null`, which results in a crash. 

### Motivation

It is possible to get into situations where a variable is set, but has a `null` value (eg. by adding `key: ` in the yaml vars). If we check the length of such a variable (which should thus be a list, string or dictionary), we should first default to a reasonable value if a null value is given.

`default` needs to be used with `boolean=True` to also match falsey values (such as `null`), otherwise it only matches undefined variables.