### PR TITLE
feat(ansible_facts): replace injected facts 'ansible_' with dictionary 'ansible_facts'

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -119,11 +119,11 @@ datadog_agent6_apt_repo: "deb https://apt.datadoghq.com/ stable 6"
 datadog_agent7_apt_repo: "deb https://apt.datadoghq.com/ stable 7"
 
 # The default yum repository for each major Agent version is specified in the following variables.
-datadog_agent5_yum_repo: "https://yum.datadoghq.com/rpm/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
-datadog_agent6_yum_repo: "https://yum.datadoghq.com/stable/6/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
-datadog_agent7_yum_repo: "https://yum.datadoghq.com/stable/7/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent5_yum_repo: "https://yum.datadoghq.com/rpm/{{ ansible_facts.architecture }}"
+datadog_agent6_yum_repo: "https://yum.datadoghq.com/stable/6/{{ ansible_facts.architecture }}"
+datadog_agent7_yum_repo: "https://yum.datadoghq.com/stable/7/{{ ansible_facts.architecture }}"
 
 # The default zypper repository for each major Agent version is specified in the following variables.
-datadog_agent5_zypper_repo: "https://yum.datadoghq.com/suse/rpm/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
-datadog_agent6_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
-datadog_agent7_zypper_repo: "https://yum.datadoghq.com/suse/stable/7/{{ lookup('vars', 'ansible_userspace_architecture', default=ansible_architecture) }}"
+datadog_agent5_zypper_repo: "https://yum.datadoghq.com/suse/rpm/{{ ansible_facts.architecture }}"
+datadog_agent6_zypper_repo: "https://yum.datadoghq.com/suse/stable/6/{{ ansible_facts.architecture }}"
+datadog_agent7_zypper_repo: "https://yum.datadoghq.com/suse/stable/7/{{ ansible_facts.architecture }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -4,11 +4,11 @@
   service:
     name: datadog-agent
     state: restarted
-  when: datadog_enabled and not ansible_check_mode and not ansible_os_family == "Windows"
+  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
 - name: restart datadog-agent-win
   win_service:
     name: datadogagent
     state: restarted
     force_dependent_services: true
-  when: datadog_enabled and not ansible_check_mode and ansible_os_family == "Windows"
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -2,22 +2,22 @@
 - name: set agent binary path (windows)
   set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
-  when: ansible_os_family == "Windows"
+  when: ansible_facts.os_family == "Windows"
 
 - name: set agent binary path (unix)
   set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_linux }}"
-  when: ansible_os_family != "Windows"
+  when: ansible_facts.os_family != "Windows"
 
 - name: set agent user for integration commmand (windows)
   set_fact:
     integration_command_user: "{{ integration_command_user_windows }}"
-  when: ansible_os_family == "Windows"
+  when: ansible_facts.os_family == "Windows"
 
 - name: set agent agent binary path (unix)
   set_fact:
     integration_command_user: "{{ integration_command_user_linux }}"
-  when: ansible_os_family != "Windows"
+  when: ansible_facts.os_family != "Windows"
 
 - name: Validate integrations actions
   fail:
@@ -37,14 +37,14 @@
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove" and ansible_os_family != "Windows"
+  when: item.value.action == "remove" and ansible_facts.os_family != "Windows"
 
 - name: Removing integrations (Windows)
   win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove" and ansible_os_family == "Windows"
+  when: item.value.action == "remove" and ansible_facts.os_family == "Windows"
 
 # Install integrations
 
@@ -55,7 +55,7 @@
   vars:
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_os_family != "Windows"
+  when: item.value.action == "install" and ansible_facts.os_family != "Windows"
 
 - name: Install pinned version of integrations (Windows)
   win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
@@ -64,4 +64,4 @@
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_os_family == "Windows"
+  when: item.value.action == "install" and ansible_facts.os_family == "Windows"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: Gather Ansible Facts
+  setup:
 
 - name: Check if OS is supported
   include_tasks: os-check.yml
@@ -8,31 +10,31 @@
 
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml
-  when: ansible_os_family == "Debian"
+  when: ansible_facts.os_family == "Debian"
 
 - name: RedHat Install Tasks
   include_tasks: pkg-redhat.yml
-  when: ansible_os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat"
 
 - name: Suse Install Tasks
   include_tasks: pkg-suse.yml
-  when: ansible_os_family == "Suse"
+  when: ansible_facts.os_family == "Suse"
 
 - name: Windows Install Tasks
   include_tasks: pkg-windows.yml
-  when: ansible_os_family == "Windows"
+  when: ansible_facts.os_family == "Windows"
 
 - name: Linux Configuration Tasks (Agent 5)
   include_tasks: agent5-linux.yml
-  when: datadog_agent_major_version|int == 5 and ansible_os_family != "Windows"
+  when: datadog_agent_major_version|int == 5 and ansible_facts.os_family != "Windows"
 
 - name: Linux Configuration Tasks
   include_tasks: agent-linux.yml
-  when: datadog_agent_major_version|int > 5 and ansible_os_family != "Windows"
+  when: datadog_agent_major_version|int > 5 and ansible_facts.os_family != "Windows"
 
 - name: Windows Configuration Tasks
   include_tasks: agent-win.yml
-  when: datadog_agent_major_version|int > 5 and ansible_os_family == "Windows"
+  when: datadog_agent_major_version|int > 5 and ansible_facts.os_family == "Windows"
 
 - name: Integrations Tasks
   include_tasks: integration.yml

--- a/tasks/os-check.yml
+++ b/tasks/os-check.yml
@@ -2,4 +2,4 @@
 - name: Fail if OS is not supported
   fail:
     msg: "The Datadog Ansible role does not support your OS yet. Please email support@datadoghq.com to open a feature request."
-  when: ansible_os_family not in ["RedHat", "Debian", "Suse", "Windows"]
+  when: ansible_facts.os_family not in ["RedHat", "Debian", "Suse", "Windows"]


### PR DESCRIPTION
Following [Ansible Documentation on Facts](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variables-discovered-from-systems-facts) this MR replace injected variables prefixed with `ansible_` with dictionary `ansible_facts`

Using facts with prefix was changed in Ansible 2.5, and should be disabled by default in future releases. In cases where users choose to force only `ansible_facts` to be used by setting `inject_facts_as_vars` to _False_, using older naming leads to errors when applying the role.