### PR TITLE
Fixes windows service names to the correct names

### DIFF
--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -39,8 +39,8 @@
   when: not datadog_skip_running_check and not datadog_enabled
   with_list:
     - datadogagent
-    - datadog-agent-process
-    - datadog-agent-trace
+    - datadog-process-agent
+    - datadog-trace-agent
 
 - name: Create installation information file
   template:


### PR DESCRIPTION
The task to verify that the Windows datadog-agent is running is not using the Windows names of the services, which are apparently different than the Linux names.