### PR TITLE
Do not name the RPM repo file differently depending on the Agent version

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -67,7 +67,7 @@
   yum_repository:
     name: "ansible_datadog_{{ item }}.repo"
     state: absent
-  with_items: [ 5, 6, 7 ]
+  with_items: [ 5, 6, 7, "custom" ]
 
 - include_tasks: pkg-redhat/install-pinned.yml
   when: datadog_agent_redhat_version is defined

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -23,31 +23,51 @@
     state: present
   when: not ansible_check_mode
 
-- name: Install Datadog yum repo
+- name: Install Datadog Agent 5 yum repo
   yum_repository:
-    name: "ansible_datadog_{{ item.key }}"
+    name: datadog
     description: Datadog, Inc.
-    baseurl: "{{ item.value }}"
+    baseurl: "{{ datadog_agent5_yum_repo }}"
     enabled: yes
     gpgcheck: yes
-    gpgkey: "{% if datadog_agent_major_version|int == 7 %}{{ datadog_yum_gpgkey_20200908 }}{% else %}{{ datadog_yum_gpgkey }}{% endif %}"
-    state: "{% if item.key == datadog_agent_major_version|int and datadog_yum_repo | length == 0 %}present{% else %}absent{% endif %}"
-  when: (not ansible_check_mode)
-  with_dict:
-    5: '{{ datadog_agent5_yum_repo }}'
-    6: '{{ datadog_agent6_yum_repo }}'
-    7: '{{ datadog_agent7_yum_repo }}'
+    gpgkey: "{{ datadog_yum_gpgkey }}"
+  when: (datadog_agent_major_version|int == 5) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
-- name: (Custom) Install Datadog yum repo
+- name: Install Datadog Agent 6 yum repo
   yum_repository:
-    name: ansible_datadog_custom
+    name: datadog
+    description: Datadog, Inc.
+    baseurl: "{{ datadog_agent6_yum_repo }}"
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: "{{ datadog_yum_gpgkey }}"
+  when: (datadog_agent_major_version|int == 6) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
+
+- name: Install Datadog Agent 7 yum repo
+  yum_repository:
+    name: datadog
+    description: Datadog, Inc.
+    baseurl: "{{ datadog_agent7_yum_repo }}"
+    enabled: yes
+    gpgcheck: yes
+    gpgkey: "{{ datadog_yum_gpgkey_20200908 }}"
+  when: (datadog_agent_major_version|int == 7) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
+
+- name: Install Datadog Custom yum repo
+  yum_repository:
+    name: datadog
     description: Datadog, Inc.
     baseurl: "{{ datadog_yum_repo }}"
     enabled: yes
     gpgcheck: yes
     gpgkey: "{{ datadog_yum_gpgkey }}"
-    state: present
   when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
+
+- name: Remove old yum repo files
+  yum_repository:
+    name: "ansible_datadog_{{ item }}.repo"
+    state: absent
+  with_items: [ 5, 6, 7 ]
 
 - include_tasks: pkg-redhat/install-pinned.yml
   when: datadog_agent_redhat_version is defined

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -76,7 +76,7 @@
 
 - name: Remove old yum repo files
   yum_repository:
-    name: "ansible_datadog_{{ item }}.repo"
+    name: "ansible_datadog_{{ item }}"
     state: absent
   with_items: [ 5, 6, 7, "custom" ]
 

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -31,6 +31,7 @@
     enabled: yes
     gpgcheck: yes
     gpgkey: "{{ datadog_yum_gpgkey }}"
+  register: repofile5
   when: (datadog_agent_major_version|int == 5) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
 - name: Install Datadog Agent 6 yum repo
@@ -41,6 +42,7 @@
     enabled: yes
     gpgcheck: yes
     gpgkey: "{{ datadog_yum_gpgkey }}"
+  register: repofile6
   when: (datadog_agent_major_version|int == 6) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
 - name: Install Datadog Agent 7 yum repo
@@ -51,6 +53,7 @@
     enabled: yes
     gpgcheck: yes
     gpgkey: "{{ datadog_yum_gpgkey_20200908 }}"
+  register: repofile7
   when: (datadog_agent_major_version|int == 7) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
 - name: Install Datadog Custom yum repo
@@ -61,7 +64,15 @@
     enabled: yes
     gpgcheck: yes
     gpgkey: "{{ datadog_yum_gpgkey }}"
+  register: repofilecustom
   when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
+
+- name: Clean repo metadata if repo changed # noqa 503
+  command: yum clean metadata --disablerepo="*" --enablerepo=datadog
+  ignore_errors: yes # Cleaning the metadata is only needed when downgrading a major version of the Agent, don't fail because of this
+  args:
+    warn: no
+  when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
 - name: Remove old yum repo files
   yum_repository:


### PR DESCRIPTION
## What does this PR do?

Use `datadog.repo` as the name, to be consistent with other install methods.

## Motivation

We might want the repo file to be installed with the package manager in the future, and we don't want to end up with two of them. I'm still not sure how managing this file with Ansible will interact with the package manager trying to install a newer version of the file (eg: because we added a new GPG key). In case the package manager replaces the file (which I think is not the default behavior, but can be configured that way), Ansible will change it back anyway in the next run 🤷 In any case, that's a problem we will have to solve for all config management tools, so I think this change is still making things better by making all install methods consistent.