### PR TITLE
Change configuration perms on Linux

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -16,6 +16,7 @@
   template:
     src: datadog.yaml.j2
     dest: /etc/datadog-agent/datadog.yaml
+    mode: 0640
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
   notify: restart datadog-agent
@@ -32,6 +33,7 @@
   template:
     src: checks.yaml.j2
     dest: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml"
+    mode: 0640
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
   with_items: "{{ datadog_checks|list }}"


### PR DESCRIPTION
Prevent main & check configuration files to be read by everybody.
The reason is they can contains some secrets, we unfortunately switch to the fork because of that…

Before this modification we had something like that:
```
$ ls -lah /etc/datadog-agent/conf.d/mysql.d/conf.yaml
-rw-r--r-- 1 dd-agent dd-agent 657 Nov 30 15:15 /etc/datadog-agent/conf.d/mysql.d/conf.yaml
$ ls -lah /etc/datadog-agent/datadog.yaml
-rw-r--r-- 1 dd-agent dd-agent 215 Nov 30 15:09 /etc/datadog-agent/datadog.yaml
```

After it become:
```
$ ls -lah /etc/datadog-agent/datadog.yaml
-rw-r----- 1 dd-agent dd-agent 215 Dec  1 12:26 /etc/datadog-agent/datadog.yaml
$ ls -lah /etc/datadog-agent/conf.d/mysql.d/conf.yaml
-rw-r----- 1 dd-agent dd-agent 657 Dec  1 12:26 /etc/datadog-agent/conf.d/mysql.d/conf.yaml
```

Fix #312