### PR TITLE
Remove max_traces_per_second suggestion of 10.

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,7 +342,6 @@ The following example sends data to Datadog US (default), enables logs, and conf
       log_level: INFO
       apm_config:
         enabled: true
-        max_traces_per_second: 10
       logs_enabled: true  # available with Agent v6 and v7
     datadog_checks:
       process:


### PR DESCRIPTION
With the rollout of Tracing without Limits in the latest Datadog Agents (back in October 2020), setting `max_traces_per_second:10` is not suggested.

To make sure all your traces are ingested as expected, follow https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/#ingestion-controls . The other sections of the doc explains how to set up [custom retention filters to retain spans](https://docs.datadoghq.com/tracing/trace_retention_and_ingestion/#retention-filters).

Let me know if anything is missing from this PR! 