### PR TITLE
Make security-agent also affected by datadog_enabled

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -105,7 +105,7 @@
     state: stopped
     enabled: no
   when: not datadog_skip_running_check and not datadog_enabled
-  ignore_errors: yes
+  ignore_errors: yes # Since older versions of the Agent don't include the security agent
 
 - name: Create installation information file
   template:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -99,6 +99,14 @@
     - datadog-agent-process
     - datadog-agent-trace
 
+- name: Ensure datadog-agent-security is not running
+  service:
+    name: datadog-agent-security
+    state: stopped
+    enabled: no
+  when: not datadog_skip_running_check and not datadog_enabled
+  ignore_errors: yes
+
 - name: Create installation information file
   template:
     src: install_info.j2


### PR DESCRIPTION
Otherwise, it will start by default and cause `datadog-agent` to start with it.

Fixes #317