### PR TITLE
Fix checks delete

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: pip install ansible-lint
-      - run: ansible-lint -v .
+      - run: ansible-lint -x 204 -v . # exclude 204 (line too long)
 
   test_install_downgrade:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
     steps:
       - checkout
       - run: pip install ansible-lint
-      - run: ansible-lint -x 204 -v . # exclude 204 (line too long)
+      - run: ansible-lint -v .
 
   test_install_downgrade:
     parameters:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -39,6 +39,7 @@
 - name: Delete all default checks
   file:
     path: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml.default"
+    state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_default_checks
 

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -42,7 +42,7 @@
     path: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_check
+  when: datadog_disable_default_checks and item not in datadog_tracked_checks
 
 - name: Ensure configuration directories are present for each Datadog check
   file:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -36,6 +36,7 @@
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent
 
 - name: Delete all default checks
   file:
@@ -43,6 +44,7 @@
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent
 
 - name: Ensure configuration directories are present for each Datadog check
   file:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -42,7 +42,7 @@
     path: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks
+  when: datadog_disable_default_checks and item not in datadog_tracked_check
 
 - name: Ensure configuration directories are present for each Datadog check
   file:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -24,7 +24,8 @@
 - name: Register all checks directories present in datadog
   find:
     paths: /etc/datadog-agent/conf.d/
-    pattern: "*.d"
+    patterns:
+    - "*.d"
     file_type: directory
   register: datadog_conf_directories
   when: datadog_disable_untracked_checks or datadog_disable_default_checks

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -22,7 +22,7 @@
   when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
 
 - name: Delete default checks
-  file:
+  win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -20,6 +20,7 @@
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent-win
 
 - name: Delete default checks
   win_file:
@@ -27,6 +28,7 @@
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent-win
 
 - name: Ensure configuration directories are present for each Datadog check
   win_file:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -26,7 +26,7 @@
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks
+  when: datadog_disable_default_checks and item not in datadog_tracked_check
 
 - name: Ensure configuration directories are present for each Datadog check
   win_file:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -26,7 +26,7 @@
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_check
+  when: datadog_disable_default_checks and item not in datadog_tracked_checks
 
 - name: Ensure configuration directories are present for each Datadog check
   win_file:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -17,13 +17,13 @@
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"
     state: absent
-  loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
 
 - name: Delete default checks
   file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
-  loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_default_checks
 
 - name: Ensure configuration directories are present for each Datadog check

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -23,6 +23,7 @@
 - name: Delete default checks
   file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
+    state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
   when: datadog_disable_default_checks
 

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -8,7 +8,8 @@
 - name: Register all checks directories present in datadog
   win_find:
     paths: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d"
-    pattern: "*.d"
+    patterns:
+    - "*.d"
     file_type: directory
   register: datadog_conf_directories
   when: datadog_disable_untracked_checks or datadog_disable_default_checks

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -50,6 +50,7 @@
     state: absent
   loop: "{{ datadog_conf_files.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).yaml$', '\\1') | list }}"
   when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent
 
 - name: Delete default checks
   file:
@@ -58,6 +59,7 @@
   loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list
              | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
   when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  notify: restart datadog-agent
 
 - name: (agent5) Create a configuration file for each Datadog check
   template:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -29,7 +29,8 @@
 - name: Register all checks files present in datadog
   find:
     paths: /etc/dd-agent/conf.d/
-    pattern: "*.yaml"
+    patterns:
+    - "*.yaml"
     file_type: file
   register: datadog_conf_files
   when: datadog_disable_untracked_checks
@@ -37,7 +38,8 @@
 - name: Register all checks files present in datadog
   find:
     paths: /etc/dd-agent/conf.d/
-    pattern: "*.yaml.default"
+    patterns:
+    - "*.yaml.default"
     file_type: file
   register: datadog_conf_files_default
   when: datadog_disable_default_checks

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -55,7 +55,8 @@
   file:
     path: "/etc/dd-agent/conf.d/{{ item }}.yaml.default"
     state: absent
-  loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
+  loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list
+             | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
   when: datadog_disable_default_checks and item not in datadog_tracked_check
 
 - name: (agent5) Create a configuration file for each Datadog check

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -57,7 +57,7 @@
     state: absent
   loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list
              | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_check
+  when: datadog_disable_default_checks and item not in datadog_tracked_checks
 
 - name: (agent5) Create a configuration file for each Datadog check
   template:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -56,7 +56,7 @@
     path: "/etc/dd-agent/conf.d/{{ item }}.yaml.default"
     state: absent
   loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
-  when: datadog_disable_default_checks
+  when: datadog_disable_default_checks and item not in datadog_tracked_check
 
 - name: (agent5) Create a configuration file for each Datadog check
   template:


### PR DESCRIPTION
- Missing `state: absent` in a couple places.
- Ansible on Windows needs `win_basename` and `win_file` instead of `basename` and `file`.
- `pattern` should be `patterns`.
- Made `datadog_disable_default_checks` not delete checks in `datadog_additional_checks`.
- Restart the agent if checks were deleted.
- Make linter happy.