### PR TITLE
Implement usage of multiple GPG keys in repofiles, use keys.datadoghq.com

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ datadog_yum_repo: ""
 
 datadog_yum_gpgcheck: yes
 datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
-# the CURRENT key always points to the key that is used to sign repodata and latest pakcages
+# the CURRENT key always points to the key that is used to sign repodata and latest packages
 datadog_yum_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 # this key expires in 2022
 datadog_yum_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ datadog_yum_repo: ""
 
 datadog_yum_gpgcheck: yes
 datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
-# the CURRENT key always points to the key that is used to sign repodata and latest packages
+# the CURRENT key always contains the key that is used to sign repodata and latest packages
 datadog_yum_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 # this key expires in 2022
 datadog_yum_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,6 +74,8 @@ datadog_yum_repo: ""
 
 datadog_yum_gpgcheck: yes
 datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+# the CURRENT key always points to the key that is used to sign repodata and latest pakcages
+datadog_yum_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 # this key expires in 2022
 datadog_yum_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 datadog_yum_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
@@ -96,6 +98,7 @@ datadog_zypper_repo: ""
 datadog_zypper_gpgcheck: yes
 datadog_zypper_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
 datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db25cba8fee500c80c46"
+datadog_zypper_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 datadog_zypper_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 datadog_zypper_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 datadog_zypper_gpgkey_20200908: "http://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,14 +73,14 @@ datadog_apt_backup_keyserver: hkp://pool.sks-keyservers.net:80
 datadog_yum_repo: ""
 
 datadog_yum_gpgcheck: yes
-datadog_yum_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_yum_gpgkey: "https://keys.datadoghq.com/DATADOG_RPM_KEY.public"
 # the CURRENT key always contains the key that is used to sign repodata and latest packages
-datadog_yum_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
+datadog_yum_gpgkey_current: "https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
 # this key expires in 2022
-datadog_yum_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_yum_gpgkey_e09422b3: "https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 datadog_yum_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 # this key expires in 2024
-datadog_yum_gpgkey_20200908: "http://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public"
+datadog_yum_gpgkey_20200908: "http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
@@ -96,12 +96,12 @@ datadog_ignore_old_centos_python3_error: false
 datadog_zypper_repo: ""
 
 datadog_zypper_gpgcheck: yes
-datadog_zypper_gpgkey: "https://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_zypper_gpgkey: "https://keys.datadoghq.com/DATADOG_RPM_KEY.public"
 datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db25cba8fee500c80c46"
-datadog_zypper_gpgkey_current: "https://yum.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
-datadog_zypper_gpgkey_e09422b3: "https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_zypper_gpgkey_current: "https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
+datadog_zypper_gpgkey_e09422b3: "https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
 datadog_zypper_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
-datadog_zypper_gpgkey_20200908: "http://yum.datadoghq.com/DATADOG_RPM_KEY_20200908.public"
+datadog_zypper_gpgkey_20200908: "http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_zypper_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 
 # Avoid checking if the agent is running or not. This can be useful if you're

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -11,6 +11,7 @@
   get_url:
     url: "{{ datadog_yum_gpgkey_current }}"
     dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    force: yes
 
 - name: Import current RPM key
   rpm_key:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -7,6 +7,17 @@
         and (ansible_facts.distribution_major_version | int <= 7)
         and (ansible_facts.python.version.major | int >= 3)
 
+- name: Download current RPM key
+  get_url:
+    url: "{{ datadog_yum_gpgkey_current }}"
+    dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+
+- name: Import current RPM key
+  rpm_key:
+    key: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    state: present
+  when: not ansible_check_mode
+
 - name: Download new RPM key (Expires in 2022)
   get_url:
     url: "{{ datadog_yum_gpgkey_e09422b3 }}"
@@ -38,7 +49,12 @@
     baseurl: "{{ datadog_agent5_yum_repo }}"
     enabled: yes
     gpgcheck: "{{ datadog_yum_gpgcheck }}"
-    gpgkey: "{{ datadog_yum_gpgkey }}"
+    gpgkey: [
+      "{{ datadog_yum_gpgkey_current }}",
+      "{{ datadog_yum_gpgkey_20200908 }}",
+      "{{ datadog_yum_gpgkey_e09422b3 }}",
+      "{{ datadog_yum_gpgkey }}",
+    ]
   register: repofile5
   when: (datadog_agent_major_version|int == 5) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
@@ -49,7 +65,12 @@
     baseurl: "{{ datadog_agent6_yum_repo }}"
     enabled: yes
     gpgcheck: "{{ datadog_yum_gpgcheck }}"
-    gpgkey: "{{ datadog_yum_gpgkey }}"
+    gpgkey: [
+      "{{ datadog_yum_gpgkey_current }}",
+      "{{ datadog_yum_gpgkey_20200908 }}",
+      "{{ datadog_yum_gpgkey_e09422b3 }}",
+      "{{ datadog_yum_gpgkey }}",
+    ]
   register: repofile6
   when: (datadog_agent_major_version|int == 6) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
@@ -60,7 +81,11 @@
     baseurl: "{{ datadog_agent7_yum_repo }}"
     enabled: yes
     gpgcheck: "{{ datadog_yum_gpgcheck }}"
-    gpgkey: "{{ datadog_yum_gpgkey_20200908 }}"
+    gpgkey: [
+      "{{ datadog_yum_gpgkey_current }}",
+      "{{ datadog_yum_gpgkey_20200908 }}",
+      "{{ datadog_yum_gpgkey_e09422b3 }}",
+    ]
   register: repofile7
   when: (datadog_agent_major_version|int == 7) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
@@ -71,7 +96,12 @@
     baseurl: "{{ datadog_yum_repo }}"
     enabled: yes
     gpgcheck: "{{ datadog_yum_gpgcheck }}"
-    gpgkey: "{{ datadog_yum_gpgkey }}"
+    gpgkey: [
+      "{{ datadog_yum_gpgkey_current }}",
+      "{{ datadog_yum_gpgkey_20200908 }}",
+      "{{ datadog_yum_gpgkey_e09422b3 }}",
+      "{{ datadog_yum_gpgkey }}",
+    ]
   register: repofilecustom
   when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
 

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -1,4 +1,28 @@
 ---
+- block:  # Work around due to SNI check for SLES11
+  - name: Stat if current RPM key already exists
+    stat:
+      path: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    register: ddkeycurrent
+  - name: Download current RPM key (SLES11)
+    get_url:
+      url: "{{ datadog_zypper_gpgkey_current }}"
+      dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    when: not ddkeycurrent.stat.exists
+  when: ansible_distribution_version|int == 11
+
+- name: Download current RPM key
+  get_url:
+    url: "{{ datadog_zypper_gpgkey_current }}"
+    dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+  when: ansible_distribution_version|int >= 12
+
+- name: Import current RPM key
+  rpm_key:
+    key: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    state: present
+  when: not ansible_check_mode
+
 # Do not import old key if installing Agent 7, as all Agent 7 packages are signed with the new key
 - block:  # Work around due to SNI check for SLES11
   - name: Stat if RPM key already exists

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -8,6 +8,7 @@
     get_url:
       url: "{{ datadog_zypper_gpgkey_current }}"
       dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+      force: yes
     when: not ddkeycurrent.stat.exists
   when: ansible_distribution_version|int == 11
 
@@ -15,6 +16,7 @@
   get_url:
     url: "{{ datadog_zypper_gpgkey_current }}"
     dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    force: yes
   when: ansible_distribution_version|int >= 12
 
 - name: Import current RPM key

--- a/templates/zypper.repo.j2
+++ b/templates/zypper.repo.j2
@@ -17,3 +17,11 @@ baseurl={{ baseurl }}
 type=rpm-md
 gpgcheck={{ datadog_zypper_gpgcheck|int }}
 repo_gpgcheck=0
+{# zypper in SUSE < 15 will not parse (SUSE 11) or respect (SUSE 12 - 14) mutliple entries in gpgkey #}
+{% if ansible_distribution_version|int < 15 %}
+gpgkey={{ datadog_zypper_gpgkey_current }}
+{% else %}
+gpgkey={{ datadog_zypper_gpgkey_current }}
+       {{ datadog_zypper_gpgkey_20200908 }}
+       {{ datadog_zypper_gpgkey_e09422b3 }}
+{% endif %}


### PR DESCRIPTION
This PR adds multiple entries to the repofiles' `gpgkey` entry in order for both yum/dnf/zypper and rpm to have access to all necessary keys. The special `DATADOG_RPM_KEY_CURRENT.public` entry will always contain the key that is used to sign current metadata as well as newly released packages.