### PR TITLE
Add network_config defaults

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,17 @@
 ---
 role_version: 4.7.0
 
+# default system-probe.yaml options
 system_probe_config:
   enabled: false
 
+network_config:
+  enabled: false
+
+# define if the datadog-agent services should be enabled
 datadog_enabled: yes
 
-# default datadog.conf options
+# default datadog.conf / datadog.yaml options
 datadog_config: {}
 
 # default checks enabled

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -58,7 +58,7 @@
 ## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
 - name: Set windows NPM installed
   set_fact:
-    datadog_sysprobe_enabled: "{{ network_config['enabled'] }}"
+    datadog_sysprobe_enabled: "{{ network_config is defined and network_config['enabled'] }}"
 
 - include_tasks: pkg-windows-opts.yml
 


### PR DESCRIPTION
### What does this PR do?

Set default value for `network_config['enabled']`. Otherwise the role fails when this is not explicitly defined.