### PR TITLE
Add a note about the dependency on ansible.windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The Ansible Datadog role installs and configures the Datadog Agent and integrati
 
 - Requires Ansible v2.6+.
 - Supports most Debian and RHEL-based Linux distributions, and Windows.
-- When using Ansible 2.10+, requires the `ansible.windows` collection to be installed (even on Linux):
+- When using Ansible 2.10+ on Windows, requires the `ansible.windows` collection to be installed:
 
-  ```sh
+  ```shell
   ansible-galaxy collection install ansible.windows
   ```
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ The Ansible Datadog role installs and configures the Datadog Agent and integrati
 
 - Requires Ansible v2.6+.
 - Supports most Debian and RHEL-based Linux distributions, and Windows.
-- When using Ansible 2.10+, requires the `ansible.windows` collection to be installed (even on Linux): `ansible-galaxy collection install ansible.windows`
+- When using Ansible 2.10+, requires the `ansible.windows` collection to be installed (even on Linux):
+
+  ```sh
+  ansible-galaxy collection install ansible.windows
+  ```
 
 ### Installation
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The Ansible Datadog role installs and configures the Datadog Agent and integrati
 
 - Requires Ansible v2.6+.
 - Supports most Debian and RHEL-based Linux distributions, and Windows.
+- When using Ansible 2.10+, requires the `ansible.windows` collection to be installed (even on Linux): `ansible-galaxy collection install ansible.windows`
 
 ### Installation
 

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -1,0 +1,8 @@
+---
+
+- name: restart datadog-agent-win
+  win_service:
+    name: datadogagent
+    state: restarted
+    force_dependent_services: true
+  when: datadog_enabled and not ansible_check_mode

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,9 +6,5 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
-- name: restart datadog-agent-win
-  win_service:
-    name: datadogagent
-    state: restarted
-    force_dependent_services: true
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+- include_tasks: handlers/main-win.yaml
+  when: ansible_facts.os_family == "Windows"

--- a/tasks/facts-ansible10.yml
+++ b/tasks/facts-ansible10.yml
@@ -1,0 +1,3 @@
+---
+- name: Gather Ansible Facts
+  ansible.builtin.setup:

--- a/tasks/facts-ansible10.yml
+++ b/tasks/facts-ansible10.yml
@@ -1,3 +1,3 @@
 ---
 - name: Gather Ansible Facts
-  ansible.builtin.setup:
+  ansible.builtin.setup: # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.

--- a/tasks/facts-ansible9.yml
+++ b/tasks/facts-ansible9.yml
@@ -1,0 +1,3 @@
+---
+- name: Gather Ansible Facts
+  setup:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Gather Ansible Facts
-  setup:
+  ansible.builtin.setup:
 
 - name: Check if OS is supported
   include_tasks: os-check.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,11 @@
 ---
-- name: Gather Ansible Facts
-  ansible.builtin.setup:
+- name: Include Gather Ansible Facts task on Ansible >= 2.10
+  include_tasks: facts-ansible10.yml
+  when: ansible_version.major >= 2 and ansible_version.minor >= 10
+
+- name: Include Gather Ansible Facts task on Ansible < 2.10
+  include_tasks: facts-ansible9.yml
+  when: ansible_version.major == 2 and ansible_version.minor < 10
 
 - name: Check if OS is supported
   include_tasks: os-check.yml


### PR DESCRIPTION
- Add a note about the dependency on `ansible.windows` since Ansible 2.10. This is because some tasks have been moved from base Ansible into separate collections [1], like `win_service` which is now in `ansible.windows` [2]. Fixes: #289
- Split Windows handler into its own file, so we don't include anything from `ansible.windows` on non-Windows (so we don't have to add the `ansible.windows` dependency on Linux as well).
- Split "Gather Ansible Facts" task in two files for different Ansible versions, prefixed or unprefixed (for some reason in 2.10 it tried to run Powershell on Linux without this when using the task unprefixed as it was before).

Unfortunately there isn't a way the dependency `ansible.windows` is installed automatically when installing our role [3]. In the future, we might be able to provide our own collection that could have an automatic dependency on `ansible.windows`.

[1] https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_2.10.html
[2] https://galaxy.ansible.com/ansible/windows
[3] https://github.com/ansible/ansible/issues/73347#issuecomment-772062084

