### PR TITLE
Align windows agent to linux so that service is disabled on when datadog_enabled false

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,9 +26,6 @@ datadog_additional_checks: []
 # set this to `true` to delete default checks
 datadog_disable_default_checks: false
 
-# default tracked checks
-datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks }}"
-
 # default user/group
 datadog_user: dd-agent
 datadog_group: dd-agent

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ datadog_additional_checks: []
 datadog_disable_default_checks: false
 
 # default tracked checks
-datadog_tracked_checks: "{{ datadog_checks | default({}) | list + datadog_additional_checks }}"
+datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks }}"
 
 # default user/group
 datadog_user: dd-agent

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,7 @@ datadog_additional_checks: []
 datadog_disable_default_checks: false
 
 # default tracked checks
-datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks }}"
+datadog_tracked_checks: "{{ datadog_checks | default({}) | list + datadog_additional_checks }}"
 
 # default user/group
 datadog_user: dd-agent

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -61,11 +61,12 @@
   win_service:
     name: "{{ item }}"
     state: stopped
+    start_mode: disabled
   when: not datadog_skip_running_check and not datadog_enabled
   with_list:
-    - datadogagent
-    - datadog-process-agent
     - datadog-trace-agent
+    - datadog-process-agent
+    - datadogagent    
 
 - name: Create installation information file
   template:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -52,7 +52,7 @@
 
 - name: Ensure datadog-trace-agent and datadog-process-agent are not disabled
   win_service:
-    name: "{{item}}"    
+    name: "{{ item }}"
     start_mode: manual
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
   with_list:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -58,7 +58,7 @@
   with_list:
     - datadog-trace-agent
     - datadog-process-agent
-    
+
 - name: Ensure datadog-agent is running
   win_service:
     name: datadogagent
@@ -66,7 +66,7 @@
     start_mode: auto
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
-- name: Ensure datadog-agent is not running
+- name: Ensure datadog-agent is disabled
   win_service:
     name: "{{ item }}"
     state: stopped

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -14,6 +14,10 @@
   register: datadog_conf_directories
   when: datadog_disable_untracked_checks or datadog_disable_default_checks
 
+- name: "[Debug] Print contents of datadog_tracked_checks"
+  debug:
+    msg: "Value of datadog_tracked_checks: {{ datadog_tracked_checks }}.   Is datadog_tracked_checks_null? {{ datadog_tracked_checks is none }}"
+
 - name: Delete checks not present in datadog_tracked_checks
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -58,6 +58,7 @@
   with_list:
     - datadog-trace-agent
     - datadog-process-agent
+
 - name: Create system-probe configuration file
   win_template:
     src: system-probe.yaml.j2

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -14,10 +14,6 @@
   register: datadog_conf_directories
   when: datadog_disable_untracked_checks or datadog_disable_default_checks
 
-- name: "[Debug] Print contents of datadog_tracked_checks"
-  debug:
-    msg: "Value of datadog_tracked_checks: {{ datadog_tracked_checks }}.   Is datadog_tracked_checks_null? {{ datadog_tracked_checks is none }}"
-
 - name: Delete checks not present in datadog_tracked_checks
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -50,6 +50,15 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
+- name: Ensure datadog-trace-agent and datadog-process-agent are not disabled
+  win_service:
+    name: "{{item}}"    
+    start_mode: manual
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  with_list:
+    - datadog-trace-agent
+    - datadog-process-agent
+    
 - name: Ensure datadog-agent is running
   win_service:
     name: datadogagent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,7 @@
 - name: Check if OS is supported
   include_tasks: os-check.yml
 
-- name: resolve datadog_tracked_checks later to defend against variable presidence issues arising from null datadog_checks
+- name: Resolve datadog_tracked_checks later to defend against variable presidence issues arising from dynamically included null datadog_checks 
   include_tasks: sanitize-checks.yml
 
 - name: Set Facts for Datadog Agent Major Version

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,9 @@
 - name: Check if OS is supported
   include_tasks: os-check.yml
 
+- name: resolve datadog_tracked_checks later to defend against variable presidence issues arising from null datadog_checks
+  include_tasks: sanitize-checks.yml
+
 - name: Set Facts for Datadog Agent Major Version
   include_tasks: set-parse-version.yml
 

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -1,0 +1,4 @@
+- name: Defend against defined but null datadog_checks variable
+  set_fact:
+    datadog_tracked_checks: "{{ datadog_checks | default({}) | list + datadog_additional_checks }}"
+  when: datadog_checks is none

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -1,4 +1,9 @@
 - name: Defend against defined but null datadog_checks variable
   set_fact:
-    datadog_tracked_checks: "{{ datadog_checks | default({}) | list + datadog_additional_checks }}"
+      datadog_checks: "{{datadog_checks | default({})}}"
   when: datadog_checks is none
+
+- name: Resolve datadog_tracked_checks
+  set_fact:
+    datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks }}"
+  

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -4,5 +4,5 @@
 
 - name: Resolve datadog_tracked_checks
   set_fact:
-    datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks }}"
+    datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks | default([], true) }}"
   

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -1,7 +1,6 @@
 - name: Defend against defined but null datadog_checks variable
   set_fact:
-      datadog_checks: "{{datadog_checks | default({})}}"
-  when: datadog_checks is none
+      datadog_checks: "{{ datadog_checks | default({}, true) }}"
 
 - name: Resolve datadog_tracked_checks
   set_fact:


### PR DESCRIPTION
This includes several proposed modifications:

- Reorder the services in the stop_services task so that when they are shut down, they don't have dependency issues due to shutdown order of operations
- Disable services rather than stopping them when datadog_enabled is false
- Ensure services are not set to disabled when datadog_enabled is true
- Resolve/compute datadog_tracked_checks within the task sequence as set_fact rather than only with the default vars so that its variable precedence is higher than include_vars.  Also address null/none dictionary during this step.   Propose calling it sanitize-checks.