### PR TITLE
Add Windows manual test setup

### DIFF
--- a/manual_tests/inventory_win
+++ b/manual_tests/inventory_win
@@ -1,0 +1,9 @@
+[windows]
+win ansible_host=127.0.0.1
+
+[windows:vars]
+ansible_user=Administrator
+ansible_become=no
+ansible_connection=winrm
+ansible_port=5986
+ansible_winrm_server_cert_validation=ignore

--- a/manual_tests/readme.md
+++ b/manual_tests/readme.md
@@ -1,20 +1,39 @@
-# Test setup
+# Linux test setup with Vagrant
 
 This is an example setup, based on vagrant + virtualbox, that allows to easily run ansible commands to test the module.
 
-# Requirements
+## Requirements
 
 - vagrant > 2.0.0
 - virtualbox > 5.1.28
 
-# Setup
+## Setup
 
-in `$WORK_DIR/ansible-datadog/manual_tests`:
+Run the Vagrantfile defined in `ansible-datadog/manual_tests`:
 
 - provision VM: `vagrant up`
 - connect to the VM to check the configuration: `vagrant ssh`
 - destroy VM when needed: `vagrant destroy -f`
 
-in `$WORK_DIR`:
+- From `ansible-datadog`'s parent directory, run:
 
-- run ansible-playbook: `ansible-playbook ansible-datadog/manual_tests/test_5_full.yml -i ansible-datadog/manual_tests/inventory`
+```shell
+ansible-playbook ansible-datadog/manual_tests/test_5_full.yml -i ansible-datadog/manual_tests/inventory
+```
+
+# Windows test setup from WSL
+
+## Requirements
+
+- Install Ansible and `pywinrm` inside WSL: `sudo python3 -m pip install  ansible pywinrm`
+- From a Powershell terminal (outside WSL), run the following script to setup WinRM so Ansible can connect:
+https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1
+- Make sure the Administrator account is enabled and you know the password (or use a different account in the `inventory_win` file).
+
+## Setup
+
+- From `ansible-datadog`'s parent directory, run (it will ask for the Administrator password each time):
+
+```shell
+ansible-playbook -k ansible-datadog/manual_tests/test_6_full.yml -i ansible-datadog/manual_tests/inventory_win
+```

--- a/manual_tests/readme.md
+++ b/manual_tests/readme.md
@@ -18,8 +18,10 @@ Run the Vagrantfile defined in `ansible-datadog/manual_tests`:
 - From `ansible-datadog`'s parent directory, run:
 
 ```shell
-ansible-playbook ansible-datadog/manual_tests/test_5_full.yml -i ansible-datadog/manual_tests/inventory
+ansible-playbook ansible-datadog/manual_tests/test_6_full.yml -i ansible-datadog/manual_tests/inventory
 ```
+
+Note: Replace `test_6_full.yml` with any of the other yaml files on this directory.
 
 # Windows test setup from WSL
 
@@ -37,3 +39,5 @@ https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/Configu
 ```shell
 ansible-playbook -k ansible-datadog/manual_tests/test_6_full.yml -i ansible-datadog/manual_tests/inventory_win
 ```
+
+Note: Replace `test_6_full.yml` with any of the other yaml files on this directory.


### PR DESCRIPTION
### What?
Adds instruction to test manually on Windows using WSL to `manual_test/readme.md`

### Why?
Since we don't have Windows tests on the CI so we need a way to test manually.