### PR TITLE
Update linter and fix issues found

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,10 +77,9 @@ commands:
           python: "<<parameters.python>>"
 
 jobs:
-  # TODO: Use 2.10 image, fix file permission errors (E208) that arise.
   ansible_lint:
     docker:
-      - image: datadog/docker-library:ansible_debian_2_7
+      - image: datadog/docker-library:ansible_debian_2_10
     steps:
       - checkout
       - run: pip install ansible-lint

--- a/README.md
+++ b/README.md
@@ -204,12 +204,6 @@ datadog_config_ex:
     custom_sensitive_words: "<FIRST_WORD>,<SECOND_WORD>"
 ```
 
-### Additional tasks
-
-`pre_tasks` and `post_tasks` folders are available to run user defined tasks. `pre_tasks` run before executing any tasks from the Datadog Ansible role, and `post_tasks` run after execution of the role.
-
-Installation tasks on supported platforms register the variable `datadog_agent_install`, which can be used in `post_tasks` to check the installation task's result. `datadog_agent_install.changed` is set to `true` if the installation task did install something, and `false` otherwise (for instance if the requested version was already installed).
-
 ## Versions
 
 By default, the current major version of the Datadog Ansible role installs Agent v7. The variables `datadog_agent_version` and `datadog_agent_major_version` are available to control the Agent version installed.

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,5 +1,7 @@
 ---
 galaxy_info:
+  role_name: datadog
+  namespace: datadog
   author: 'Brian Akins, Dustin Brown & Datadog'
   description: Install Datadog agent and configure checks
   license: Apache2

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -11,6 +11,7 @@
   file:
     dest: /etc/datadog-agent
     state: directory
+    mode: 0755
 
 - name: Create main Datadog agent configuration file
   template:
@@ -52,6 +53,7 @@
     state: directory
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0755
   with_items: '{{ datadog_checks|list }}'
 
 - name: Create a configuration file for each Datadog check
@@ -138,3 +140,4 @@
     dest: /etc/datadog-agent/install_info
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0644

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -1,6 +1,7 @@
 ---
 - name: Create main Datadog agent configuration file
   win_template:
+    #FIXME: should have permissions set to only be readable by ddagentuser
     src: datadog.yaml.j2
     dest: "{{ datadog_windows_config_root }}\\datadog.yaml"
   notify: restart datadog-agent-win
@@ -77,3 +78,4 @@
   template:
     src: install_info.j2
     dest: "{{ datadog_windows_config_root }}\\install_info"
+    mode: 0644

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -3,6 +3,7 @@
   file:
     dest: /etc/dd-agent
     state: directory
+    mode: 0755
 
 - name: (agent5) Create main Datadog agent configuration file
   template:
@@ -10,6 +11,7 @@
     dest: /etc/dd-agent/datadog.conf
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0644
   notify: restart datadog-agent
 
 - name: (agent5) Ensure datadog-agent is running
@@ -67,12 +69,6 @@
     dest: "/etc/dd-agent/conf.d/{{ item }}.yaml"
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+    mode: 0644
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
-
-- name: Create installation information file
-  template:
-    src: install_info.j2
-    dest: /etc/dd-agent/install_info
-    owner: "{{ datadog_user }}"
-    group: "{{ datadog_group }}"

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -11,7 +11,7 @@
     dest: /etc/dd-agent/datadog.conf
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
-    mode: 0644
+    mode: 0644 #FIXME: should have permissions set to only be readable by owner
   notify: restart datadog-agent
 
 - name: (agent5) Ensure datadog-agent is running
@@ -69,6 +69,6 @@
     dest: "/etc/dd-agent/conf.d/{{ item }}.yaml"
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
-    mode: 0644
+    mode: 0644 #FIXME: should have permissions set to only be readable by owner
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,11 +39,3 @@
 - name: Integrations Tasks
   include_tasks: integration.yml
   when: datadog_integration is defined
-
-- name: Post Tasks
-  include_tasks: post_tasks/*.yml
-  when: post_tasks is defined
-
-- name: Pre Tasks
-  include_tasks: pre_tasks/*.yml
-  when: pre_tasks is defined

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -109,6 +109,7 @@
     dest: /etc/zypp/repos.d/datadog.repo
     owner: "root"
     group: "root"
+    mode: 0644
   register: datadog_zypper_repo
 
 # refresh zypper repos only if the template changed


### PR DESCRIPTION
Bumps the linter docker image and fixes the following warnings:
- File permissions not being explicit.
- `role_name` and `namespace` missing from metadata.
- Wildcards used in pre/post tasks are not expanded (confirmed manually in 2.6 and 2.10)-> I removed the tasks since they never worked so nobody must be using them.