### PR TITLE
[handlers] Fix typo when importing main-win.yml

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,5 +12,5 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
-- include_tasks: handlers/main-win.yaml
+- include_tasks: handlers/main-win.yml
   when: ansible_facts.os_family == "Windows"


### PR DESCRIPTION
### What does this PR do?

Fixes a typo when including the [`main-win.yml`](https://github.com/DataDog/ansible-datadog/blob/master/handlers/main-win.yml) file.

### Motivation

This is causing errors when the role tries to notify a restart on Windows.
Should fix #346.