### PR TITLE
Fix Windows handlers definition

### DIFF
--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -1,6 +1,6 @@
 ---
 # This file doesn't actually contain "handlers" in the Ansible sense: when running
-# our role, ansible only loads the contents of handlers/main.yml as handlers.
+# our role, Ansible only loads the contents of handlers/main.yml as handlers.
 # However, this is here because this is a "handler-like" task that is dynamically
 # included by a handler task in handlers/main.yml.
 - name: Restart Windows datadogagent service

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: restart datadog-agent-win
+- name: Restart Windows datadogagent service
   win_service:
     name: datadogagent
     state: restarted

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -1,7 +1,11 @@
 ---
+# This file doesn't actually contain "handlers" in the Ansible sense: when running
+# our role, ansible only loads the contents of handlers/main.yml as handlers.
+# However, this is here because this is a "handler-like" task that is dynamically
+# included by a handler task in handlers/main.yml.
 - name: Restart Windows datadogagent service
   win_service:
     name: datadogagent
     state: restarted
     force_dependent_services: true
-  when: datadog_enabled and not ansible_check_mode
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,7 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
-# We can't add the Windows handler directly here because that makes the role require
+# We can't add the Windows Agent service restart handler directly here because that makes the role require
 # the ansible.windows collection on all platforms. We only want it to be needed on Windows.
 # Therefore, what we do is the following: when needed, our Windows tasks call this handler to require a
 # Windows Agent restart (through notify: restart datadog-agent-win).

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,5 +12,12 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
+# We can't add the Windows handler directly here because that makes the role require
+# the ansible.windows collection on all platforms. We only want it to be needed on Windows.
+# Therefore, what we do is the following: when needed, our Windows tasks call this handler to require a
+# Windows Agent restart.
+# Therefore, if requested by our role, the below task is executed at the end of the playbook run.
+# The include_tasks loads the handlers/main-win.yml file, which contains the real service restart task
+# (which depends on ansible.windows), and runs it, triggering the Windows Agent restart.
 - name: restart datadog-agent-win
   include_tasks: handlers/main-win.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,5 +12,5 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows"
 
-- include_tasks: handlers/main-win.yml
-  when: ansible_facts.os_family == "Windows"
+- name: restart datadog-agent-win
+  include_tasks: handlers/main-win.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -15,8 +15,8 @@
 # We can't add the Windows handler directly here because that makes the role require
 # the ansible.windows collection on all platforms. We only want it to be needed on Windows.
 # Therefore, what we do is the following: when needed, our Windows tasks call this handler to require a
-# Windows Agent restart.
-# Therefore, if requested by our role, the below task is executed at the end of the playbook run.
+# Windows Agent restart (through notify: restart datadog-agent-win).
+# When notified, the below handler is executed at the end of the playbook run.
 # The include_tasks loads the handlers/main-win.yml file, which contains the real service restart task
 # (which depends on ansible.windows), and runs it, triggering the Windows Agent restart.
 - name: restart datadog-agent-win


### PR DESCRIPTION
### What does this PR do?

Dynamically includes the Windows Agent restart handler to make it work as expected.

### Motivation

Second fix for #346. The previous fix (#347) wasn't enough because the `include_tasks: handlers/main-win.yml` task was never run (because it's a handler). This handler needs to be notfied by the role to be executed.

See explanation in comments for details on how this works.

Now the playbook run will show the following when the Windows handler is run:
```
RUNNING HANDLER [ansible-datadog : restart datadog-agent-win] ******************
included: /home/kylian/ansible-datadog/handlers/main-win.yml for win_host

RUNNING HANDLER [ansible-datadog : Restart Windows datadogagent service] *******
changed: [win_host]
```