### PR TITLE
Change RPM key URLs to non-SNI versions

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,14 +74,16 @@ datadog_yum_repo: ""
 
 datadog_yum_repo_gpgcheck: yes
 datadog_yum_gpgcheck: yes
-datadog_yum_gpgkey: "https://keys.datadoghq.com/DATADOG_RPM_KEY.public"
+# NOTE: we don't use URLs starting with https://keys.datadoghq.com/, as Python
+# on older CentOS/RHEL/SUSE doesn't support SNI and get_url would fail on them
+datadog_yum_gpgkey: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY.public"
 # the CURRENT key always contains the key that is used to sign repodata and latest packages
-datadog_yum_gpgkey_current: "https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
+datadog_yum_gpgkey_current: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public"
 # this key expires in 2022
-datadog_yum_gpgkey_e09422b3: "https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_yum_gpgkey_e09422b3: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_E09422B3.public"
 datadog_yum_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 # this key expires in 2024
-datadog_yum_gpgkey_20200908: "http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public"
+datadog_yum_gpgkey_20200908: "http://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
@@ -98,12 +100,12 @@ datadog_zypper_repo: ""
 
 datadog_zypper_repo_gpgcheck: yes
 datadog_zypper_gpgcheck: yes
-datadog_zypper_gpgkey: "https://keys.datadoghq.com/DATADOG_RPM_KEY.public"
+datadog_zypper_gpgkey: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY.public"
 datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db25cba8fee500c80c46"
-datadog_zypper_gpgkey_current: "https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
-datadog_zypper_gpgkey_e09422b3: "https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public"
+datadog_zypper_gpgkey_current: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public"
+datadog_zypper_gpgkey_e09422b3: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_E09422B3.public"
 datadog_zypper_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
-datadog_zypper_gpgkey_20200908: "http://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public"
+datadog_zypper_gpgkey_20200908: "http://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_zypper_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 
 # Avoid checking if the agent is running or not. This can be useful if you're


### PR DESCRIPTION
On older Python versions present in RHEL/CentOS 6 and SUSE 12, using `keys.datadoghq.com` results in following error:

```
Failed to validate the SSL certificate for keys.datadoghq.com:443. Make sure your managed systems have a valid CA certificate installed. If the website serving the url uses SNI you need python >= 2.7.9 on your managed machine
```

This PR changes the URLs to point to `s3.amazonaws.com/public-signing-keys/`, which is the S3 bucket backing `keys.datadoghq.com` and doesn't require the Python interpreter to support SNI.