### PR TITLE
Ensure gnupg is installed on Debian/Ubuntu

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -6,6 +6,13 @@
     state: present
   when: not ansible_check_mode
 
+- name: Install gnupg
+  apt:
+    update_cache: yes
+    name: gnupg
+    state: present
+  when: not ansible_check_mode
+
 - name: "Check if {{ datadog_apt_usr_share_keyring }} exists with correct mode"
   stat:
     path: "{{ datadog_apt_usr_share_keyring }}"


### PR DESCRIPTION
As we're using `gpg` in some of the commands below, we have to ensure it's installed. Since Debian 9, it seems that `apt` no longer depends on `gnupg`, but only on `gpgv`, and `gpg` isn't necessarily installed by default.