### PR TITLE
Remove `indentfirst` in system-probe.yaml.j2

### DIFF
--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -2,25 +2,14 @@
 
 {% if system_probe_config is defined and system_probe_config | default({}, true) | length > 0 -%}
 system_probe_config:
-{# The "first" option is only supported by jinja 2.10+
-  which is not present on older systems (CentOS 7, Debian 8, etc.)
-  Using the equivalent option "indentfirst" no longer works in jinja 3.
- #}
-{% filter indent(width=2, first=True) %}
+{% filter indent(width=2, True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}
 
 {% if network_config is defined and network_config | default({}, true) | length > 0 -%}
 network_config:
-{# The "first" option is only supported by jinja 2.10+
-  which is not present on older systems (CentOS 7, Debian 8, etc.)
-  Using the equivalent option "indentfirst" is supported for
-  all jinja 2 versions up to v2.10.
-  TODO: when future versions of Jinja are released, check that
-  indentfirst is still supported.
- #}
-{% filter indent(width=2, indentfirst=True) %}
+{% filter indent(width=2, True) %}
 {{ network_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -2,14 +2,22 @@
 
 {% if system_probe_config is defined and system_probe_config | default({}, true) | length > 0 -%}
 system_probe_config:
-{% filter indent(width=2, True) %}
+{# The "first" option in indent() is only supported by jinja 2.10+
+  while the old equivalent option "indentfirst" is removed in jinja 3.
+  Using non-keyword argument in indent() to be backward compatible.
+#}
+{% filter indent(2, True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}
 
 {% if network_config is defined and network_config | default({}, true) | length > 0 -%}
 network_config:
-{% filter indent(width=2, True) %}
+{# The "first" option in indent() is only supported by jinja 2.10+
+  while the old equivalent option "indentfirst" is removed in jinja 3.
+  Using non-keyword argument in indent() to be backward compatible.
+#}
+{% filter indent(2, True) %}
 {{ network_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -4,12 +4,9 @@
 system_probe_config:
 {# The "first" option is only supported by jinja 2.10+
   which is not present on older systems (CentOS 7, Debian 8, etc.)
-  Using the equivalent option "indentfirst" will work with
-  all currently existing jinja 2 versions (as of this comment, up to 2.10).
-  TODO: when future versions of Jinja are released, check that
-  indentfirst is still supported.
+  Using the equivalent option "indentfirst" no longer works in jinja 3.
  #}
-{% filter indent(width=2, indentfirst=True) %}
+{% filter indent(width=2, first=True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}


### PR DESCRIPTION
### What does this PR do?

Removes specification of the obsolete indent filter argument `identfirst`.
Fixes #360 

### Motivation

The indentfirst option [no longer supported](https://github.com/pallets/jinja/pull/1136/commits/b0015c72d5acbf93b9d99a1ce6167889338db85b#diff-d3eeabaeac0164a4aa81d32a82599f1a5c90aca43eb52117d387ae393e9431f7) in jinja 3