### PR TITLE
Update 'http' URLs to 'https' wherever possible.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 The code is licensed under the Apache License 2.0 (see LICENSE for details).
 
-[![Ansible Galaxy](http://img.shields.io/badge/galaxy-Datadog.datadog-660198.svg)](https://galaxy.ansible.com/Datadog/datadog/)
+[![Ansible Galaxy](https://img.shields.io/badge/galaxy-Datadog.datadog-660198.svg)](https://galaxy.ansible.com/Datadog/datadog/)
 [![Build Status](https://travis-ci.org/DataDog/ansible-datadog.svg?branch=master)](https://travis-ci.org/DataDog/ansible-datadog)
 
 First of all, thanks for contributing!
@@ -110,6 +110,6 @@ Datadog <info@datadoghq.com> --Forked from dustinjamesbrown@gmail.com
 
 [kitchen]: https://kitchen.ci
 [kitchen_yml]: https://github.com/DataDog/ansible-datadog/blob/master/kitchen.yml
-[slack]: http://datadoghq.slack.com
+[slack]: https://datadoghq.slack.com
 [tests]: https://github.com/DataDog/ansible-datadog/blob/master/manual_tests/readme.md
 [vagrant]: https://www.vagrantup.com

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -79,7 +79,7 @@ datadog_yum_gpgkey_current: "https://s3.amazonaws.com/public-signing-keys/DATADO
 datadog_yum_gpgkey_e09422b3: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_E09422B3.public"
 datadog_yum_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
 # this key expires in 2024
-datadog_yum_gpgkey_20200908: "http://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
+datadog_yum_gpgkey_20200908: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
@@ -101,7 +101,7 @@ datadog_zypper_gpgkey_sha256sum: "00d6505c33fd95b56e54e7d91ad9bfb22d2af17e5480db
 datadog_zypper_gpgkey_current: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_CURRENT.public"
 datadog_zypper_gpgkey_e09422b3: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_E09422B3.public"
 datadog_zypper_gpgkey_e09422b3_sha256sum: "694a2ffecff85326cc08e5f1a619937999a5913171e42f166e13ec802c812085"
-datadog_zypper_gpgkey_20200908: "http://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
+datadog_zypper_gpgkey_20200908: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public"
 datadog_zypper_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 
 # Avoid checking if the agent is running or not. This can be useful if you're
@@ -128,7 +128,7 @@ datadog_windows_agent7_latest_url: "https://s3.amazonaws.com/ddagent-windows-sta
 # in order to get the full url to the msi package.
 datadog_windows_versioned_url: "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli"
 
-# url of the 6.14 fix script. See http://dtdg.co/win-614-fix for more details.
+# url of the 6.14 fix script. See https://dtdg.co/win-614-fix for more details.
 datadog_windows_614_fix_script_url: "https://s3.amazonaws.com/ddagent-windows-stable/scripts/fix_6_14.ps1"
 
 # Override to change the name of the windows user to create

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -56,6 +56,9 @@
     state: "absent"
     update_cache: yes
   with_items:
+    - "deb http://apt.datadoghq.com/ stable main"
+    - "deb http://apt.datadoghq.com/ stable 6"
+    - "deb http://apt.datadoghq.com/ stable 7"
     - "deb https://apt.datadoghq.com/ stable main"
     - "deb https://apt.datadoghq.com/ stable 6"
     - "deb https://apt.datadoghq.com/ stable 7"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -56,9 +56,6 @@
     state: "absent"
     update_cache: yes
   with_items:
-    - "deb http://apt.datadoghq.com/ stable main"
-    - "deb http://apt.datadoghq.com/ stable 6"
-    - "deb http://apt.datadoghq.com/ stable 7"
     - "deb https://apt.datadoghq.com/ stable main"
     - "deb https://apt.datadoghq.com/ stable 6"
     - "deb https://apt.datadoghq.com/ stable 7"

--- a/tasks/win_agent_version.yml
+++ b/tasks/win_agent_version.yml
@@ -2,7 +2,7 @@
 
 - name: Check agent pinned version on Windows
   fail:
-    msg: "The Agent versions you pinned (6.14.0 or 6.14.1) have been blacklisted, please use 6.14.2 instead. See http://dtdg.co/win-614-fix."
+    msg: "The Agent versions you pinned (6.14.0 or 6.14.1) have been blacklisted, please use 6.14.2 instead. See https://dtdg.co/win-614-fix."
   when: datadog_agent_version == "6.14.0" or datadog_agent_version == "6.14.1"
 
 - name: set agent download filename to a specific version


### PR DESCRIPTION
Resolves issue where RPM key cannot be retrieved in secure environments.

https://github.com/DataDog/ansible-datadog/issues/368