### PR TITLE
Skip install on Linux systems when pinned version is already installed

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,21 +13,24 @@
 - name: Resolve datadog_tracked_checks later to defend against variable presidence issues arising from dynamically included null datadog_checks 
   include_tasks: sanitize-checks.yml
 
+# Also sets datadog_skip_install
 - name: Set Facts for Datadog Agent Major Version
   include_tasks: set-parse-version.yml
 
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml
-  when: ansible_facts.os_family == "Debian"
+  when: ansible_facts.os_family == "Debian" and not datadog_skip_install
 
 - name: RedHat Install Tasks
   include_tasks: pkg-redhat.yml
-  when: ansible_facts.os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat" and not datadog_skip_install
 
 - name: Suse Install Tasks
   include_tasks: pkg-suse.yml
-  when: ansible_facts.os_family == "Suse"
+  when: ansible_facts.os_family == "Suse" and not datadog_skip_install
 
+# Note we don't check datadog_skip_install variable value for windows here,
+# because some tasks in pkg-windows.yml are carried out regardless of its value.
 - name: Windows Install Tasks
   include_tasks: pkg-windows.yml
   when: ansible_facts.os_family == "Windows"

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -36,8 +36,61 @@
     datadog_agent_major_version: "{{ datadog_major }}"
 
 - name: Set OS-specific versions
+  # NOTE: if changing these, make sure the format correspond with values in datadog_version_finding_cmds below
   set_fact:
     datadog_agent_debian_version: "{{ datadog_epoch }}:{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
     datadog_agent_redhat_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
     datadog_agent_suse_version: "{{ datadog_epoch }}:{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}-{{ datadog_release }}"
     datadog_agent_windows_version: "{{ datadog_major }}.{{ datadog_minor }}.{{ datadog_bugfix }}{{ datadog_suffix }}"
+
+- name: Construct commands to find Agent version
+  set_fact:
+    datadog_version_finding_cmds:
+      Debian: "dpkg -s {{ datadog_agent_flavor }} | grep '^Version:' | awk '{print $2}'"
+      RedHat: "rpm -q --qf '%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
+      Suse: "rpm -q --qf '%{EPOCH}:%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
+
+- name: Create OS-specific version dict
+  set_fact:
+    datadog_agent_os2version:
+      Debian: "{{ datadog_agent_debian_version }}"
+      RedHat: "{{ datadog_agent_redhat_version }}"
+      Suse: "{{ datadog_agent_suse_version }}"
+      Windows: "{{ datadog_agent_windows_version }}"
+
+- name: Get Linux Agent version
+  shell: "{{ datadog_version_finding_cmds[ansible_facts.os_family] }}"  # noqa 305 - Ansible lint things we could use command, but we need shell because some of the cmds have pipes
+  register: datadog_version_check_linux
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  when: ansible_facts.system == "Linux"
+
+# NOTE: This won't work with rc / beta builds.
+- name: Get Windows Agent version
+  win_shell: |
+    $product_name = "Datadog Agent"
+    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$pr    oduct_name%'"
+    $installs = Get-WmiObject -query $query
+
+    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
+      Write-Host ""
+    } else {
+      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
+      Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
+    }
+  register: datadog_version_check_win
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  when: ansible_facts.os_family == "Windows"
+
+- name: Set skip install flag if version already installed (Linux)
+  set_fact:
+    datadog_skip_install: "{{ datadog_version_check_linux.stdout | trim == datadog_agent_os2version[ansible_facts.os_family] }}"
+  when: ansible_facts.system == "Linux"
+
+- name: Set skip install flag if version already installed (Windows)
+  set_fact:
+    datadog_skip_install: "{{ datadog_version_check_win.stdout | trim == datadog_agent_os2version[ansible_facts.os_family] }}"
+  when: ansible_facts.system == "Windows"

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -59,7 +59,7 @@
       Windows: "{{ datadog_agent_windows_version }}"
 
 - name: Get Linux Agent version
-  shell: "{{ datadog_version_finding_cmds[ansible_facts.os_family] }}"  # noqa 305 - Ansible lint things we could use command, but we need shell because some of the cmds have pipes
+  shell: "{{ datadog_version_finding_cmds[ansible_facts.os_family] }}"  # noqa 305 - Ansible lint thinks we could use command, but we need shell because some of the cmds have pipes
   register: datadog_version_check_linux
   changed_when: false
   failed_when: false

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -70,7 +70,7 @@
 - name: Get Windows Agent version
   win_shell: |
     $product_name = "Datadog Agent"
-    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$pr    oduct_name%'"
+    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
     $installs = Get-WmiObject -query $query
 
     if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
@@ -93,4 +93,4 @@
 - name: Set skip install flag if version already installed (Windows)
   set_fact:
     datadog_skip_install: "{{ datadog_version_check_win.stdout | trim == datadog_agent_os2version[ansible_facts.os_family] }}"
-  when: ansible_facts.system == "Windows"
+  when: ansible_facts.os_family == "Windows"

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -4,57 +4,28 @@
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: datadog_agent_major_version|int == 5
 
-# This is a best-effort solution to avoid redownloading the msi when
-# It won't work with rc / beta builds, and won't work if the version to install
-# is not pinned (as we don't know what version latest will be before downloading
-# the package).
-- name: Check currently installed Agent version
-  win_shell: |
-    $product_name = "Datadog Agent"
-    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
-    $installs = Get-WmiObject -query $query
-
-    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
-      Write-Host ""
-    } else {
-      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
-      Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
-    }
-  register: version_check
-  check_mode: no
-  changed_when: false # By default win_shell returns changed, but we know this script doesn't change anything.
-
-- name: Initialize skip install flag to false
-  set_fact:
-    datadog_skip_windows_install: "False"
-
-- name: Set skip install flag if version already installed
-  set_fact:
-    datadog_skip_windows_install: "{{ version_check.stdout | trim == datadog_agent_windows_version }}"
-  when: datadog_agent_windows_version is defined
-
 - name: Download windows datadog agent 614 fix script
   win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
     dest: '%TEMP%\fix_6_14.ps1'
-  when: not datadog_skip_windows_install
+  when: not datadog_skip_install
 
 - name: Run 6.14.0/1 PowerShell fix
   win_shell: |
     Set-ExecutionPolicy Bypass -Scope Process -Force
     &$env:temp\fix_6_14.ps1
-  when: not datadog_skip_windows_install
+  when: not datadog_skip_install
 
 - include_tasks: win_agent_latest.yml
-  when: (not datadog_skip_windows_install) and (datadog_agent_windows_version is not defined)
+  when: (not datadog_skip_install) and (datadog_agent_windows_version is not defined)
 
 - include_tasks: win_agent_version.yml
-  when: (not datadog_skip_windows_install) and (datadog_agent_windows_version is defined)
+  when: (not datadog_skip_install) and (datadog_agent_windows_version is defined)
 
 - name: show URL var
   debug:
     var: dd_download_url
-  when: not datadog_skip_windows_install
+  when: not datadog_skip_install
 
 ## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
 - name: Set windows NPM installed
@@ -66,14 +37,14 @@
   win_file:
     path: '%TEMP%\ddagent.msi'
     state: absent
-  when: not datadog_skip_windows_install
+  when: not datadog_skip_install
 
 - name: Download windows datadog agent
   win_get_url:
     url: "{{ dd_download_url }}"
     dest: '%TEMP%\ddagent.msi'
   register: download_msi_result
-  when: (not datadog_skip_windows_install) and (not ansible_check_mode)
+  when: (not datadog_skip_install) and (not ansible_check_mode)
 
 - name: Create Binary directory root (if not default)
   win_file:
@@ -101,10 +72,10 @@
     path: "{{ download_msi_result.dest }}"
     arguments: "{{ win_install_args }}"
   register: datadog_agent_install
-  when: (not datadog_skip_windows_install) and (not ansible_check_mode)
+  when: (not datadog_skip_install) and (not ansible_check_mode)
 
 - name: Delete temporary msi
   win_file:
     path: "{{ download_msi_result.dest }}"
     state: absent
-  when: (not datadog_skip_windows_install) and (not ansible_check_mode) and (download_msi_result.status_code == 200)
+  when: (not datadog_skip_install) and (not ansible_check_mode) and (download_msi_result.status_code == 200)

--- a/tasks/set-parse-version.yml
+++ b/tasks/set-parse-version.yml
@@ -3,6 +3,10 @@
   set_fact:
     datadog_agent_major_version: "{{ datadog_agent_major_version | default('', true) | string }}"
 
+- name: Initialize skip install flag to false
+  set_fact:
+    datadog_skip_install: "false"
+
 - include_tasks: parse-version.yml
   when: datadog_agent_version | default('', true) | length > 0
 


### PR DESCRIPTION
When users are using pinned version of the agent and that version is already installed, we want to skip the whole repository setup + package installation to speed up the role runs significantly. This was already implemented for Windows, so I just made it more general to cover all supported systems.