### PR TITLE
Install datadog-signing-keys package on Debian/Ubuntu

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -117,3 +117,11 @@
 
 - include_tasks: pkg-debian/install-latest.yml
   when: datadog_agent_debian_version is not defined
+
+- name: Install latest datadog-signing-keys package
+  apt:
+    name: datadog-signing-keys
+    state: latest  # noqa 403
+    # we don't use update_cache: yes, as that was just done by the install-pinned/install-latest
+  register: datadog_signing_keys_install
+  when: not ansible_check_mode


### PR DESCRIPTION
This installs the datadog-signing-keys package built from https://github.com/DataDog/datadog-signing-keys/. Like this role, it can construct the APT keyring (which is technically not necessary, because the role does that), but it also contains keyrings and policy files for debsig to verify individual DEB package signatures.