### PR TITLE
Avoid usage of ansible_lsb to not depend on lsb-release package on Debian

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -48,7 +48,7 @@
     dest: "{{ datadog_apt_trusted_d_keyring }}"
     mode: "0644"
     remote_src: yes
-  when: ((ansible_distribution == 'Debian' and ansible_lsb.major_release|int < 9) or (ansible_distribution == 'Ubuntu' and ansible_lsb.major_release|int < 16)) and not ansible_check_mode
+  when: ((ansible_distribution == 'Debian' and ansible_distribution_major_version|int < 9) or (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version|int < 16)) and not ansible_check_mode
 
 - name: Ensure Datadog non-https repositories and repositories not using signed-by option are deprecated
   apt_repository:


### PR DESCRIPTION
Using `ansible_lsb` actually requires `lsb-release` package on Debian/Ubuntu, otherwise it won't contain some values. This PR makes the task use `ansible_distribution_major_version` which is a fact gathered regardless of `lsb-release` presence.

Fixes https://github.com/DataDog/ansible-datadog/issues/376.