### PR TITLE
Check `datadog_checks` to avoid misconfiguration

### DIFF
--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -5,4 +5,8 @@
 - name: Resolve datadog_tracked_checks
   set_fact:
     datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks | default([], true) }}"
-  
+
+- name: Check variables
+  assert:
+    that:
+      - datadog_checks is mapping

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -6,7 +6,7 @@
   set_fact:
     datadog_tracked_checks: "{{ datadog_checks | list + datadog_additional_checks | default([], true) }}"
 
-- name: Check variables
+- name: Check that datadog_checks is a mapping
   assert:
     that:
       - datadog_checks is mapping


### PR DESCRIPTION
A misconfiguration like:

```yaml
roles:
  - { name: datadog.datadog, datadog_checks: _datadog_checks }
```

leads to looping over a string and creating a lot of directories in `/etc/datadog-agent/conf.d/`. I propose to add a check for this.