### PR TITLE
Feature: Add tasks for Linux and Windows to create custom Python checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,12 +112,13 @@ To configure a custom check use the configuration below. This creates the corres
 
 ##### Custom Python Checks
 
-To configure a custom check and to pass a Python check to the Playbook, please use the configuration below.  
-This requires the Datadog play / role to be part of a larger Playbook, with the value passed in being the relative filepath 
-to the actual task for [Linux](./tasks/agent-linux.yml) or [Windows](./tasks/agent-win.yml). 
-This is only available for Datadog v6+.  
+To pass a Python check to the playbook, use the configuration below. 
 
-The key should be the name of the file created in the checks directory `checks.d/{{ item }}.py`
+This configuration requires the Datadog play and role to be a part of the larger playbook where the value passed in is the relative file path to the actual task for [Linux](./tasks/agent-linux.yml) or [Windows](./tasks/agent-win.yml). 
+
+This is only available for Agent v6+.  
+
+The key should be the name of the file created in the checks directory `checks.d/{{ item }}.py`:
 
 ```yml
     datadog_checks:

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ To configure a custom check use the configuration below. This creates the corres
 
 To pass a Python check to the playbook, use the configuration below. 
 
-This configuration requires the Datadog play and role to be a part of the larger playbook where the value passed in is the relative file path to the actual task for [Linux](./tasks/agent-linux.yml) or [Windows](./tasks/agent-win.yml). 
+This configuration requires the Datadog [play and role](https://docs.ansible.com/ansible/latest/reference_appendices/playbooks_keywords.html#playbook-keywords) to be a part of the larger playbook where the value passed in is the relative file path to the actual task for [Linux](./tasks/agent-linux.yml) or [Windows](./tasks/agent-win.yml).
 
 This is only available for Agent v6+.  
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,25 @@ To configure a custom check use the configuration below. This creates the corres
           - some_data: true
 ```
 
+##### Custom Python Checks
+
+To configure a custom check and to pass a Python check to the Playbook, please use the configuration below.  
+This requires the Datadog play / role to be part of a larger Playbook, with the value passed in being the relative filepath 
+to the actual task for [Linux](./tasks/agent-linux.yml) or [Windows](./tasks/agent-win.yml). 
+This is only available for Datadog v6+.  
+
+The key should be the name of the file created in the checks directory `checks.d/{{ item }}.py`
+
+```yml
+    datadog_checks:
+      my_custom_check:
+        init_config:
+        instances:
+          - some_data: true
+    datadog_custom_checks:
+      my_custom_check: '../../../custom_checks/my_custom_check.py'
+```
+
 #### Autodiscovery
 
 When using Autodiscovery, there is no pre-processing nor post-processing on the YAML. This means every YAML section is added to the final configuration file, including `autodiscovery identifiers`.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,6 +15,9 @@ datadog_config: {}
 # default checks enabled
 datadog_checks: {}
 
+# custom Python checks
+datadog_custom_checks: {}
+
 # set this to `true` to delete untracked checks
 datadog_disable_untracked_checks: false
 

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -84,7 +84,7 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 
-- name: Create custom check file for each Custom check
+- name: Create custom check file for each custom check
   copy:
     src: "{{ datadog_custom_checks[item] }}"
     dest: "/etc/datadog-agent/checks.d/{{ item }}.py"

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -84,6 +84,16 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent
 
+- name: Create custom check file for each Custom check
+  copy:
+    src: "{{ datadog_custom_checks[item] }}"
+    dest: "/etc/datadog-agent/checks.d/{{ item }}.py"
+    mode: 0755
+    owner: "{{ datadog_user }}"
+    group: "{{ datadog_group }}"
+  with_items: "{{ datadog_custom_checks|list }}"
+  notify: restart datadog-agent
+
 - name: Create system-probe configuration file
   template:
     src: system-probe.yaml.j2

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -51,7 +51,7 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
-- name: Create custom check file for each Custom check
+- name: Create custom check file for each custom check
   copy:
     src: "{{ datadog_custom_checks[item] }}"
     dest: "{{ datadog_windows_config_root }}\\checks.d\\{{ item }}.py"

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -51,6 +51,13 @@
   with_items: "{{ datadog_checks|list }}"
   notify: restart datadog-agent-win
 
+- name: Create custom check file for each Custom check
+  copy:
+    src: "{{ datadog_custom_checks[item] }}"
+    dest: "{{ datadog_windows_config_root }}\\checks.d\\{{ item }}.py"
+  with_items: "{{ datadog_custom_checks|list }}"
+  notify: restart datadog-agent-win
+
 - name: Ensure datadog-trace-agent and datadog-process-agent are not disabled
   win_service:
     name: "{{ item }}"


### PR DESCRIPTION
The files for these checks must be included in the parent playbook as the path must be relative to the task, or else an absolute path on the local file-system.
Requires Agent v6+

Fixes: #315

1. Let me know if tests need created / updated for checking this - it has been tested on machines I have been using
2. Let me know if you would prefer it done another way
