### PR TITLE
Add datadog_manage_config to disable changing the Agent config files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,17 @@ commands:
       - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml" -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>'
       - run: datadog-agent version
 
+  test_install_no_manage_config:
+    parameters:
+      version:
+        type: string
+      python:
+        type: string
+    steps:
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_<<parameters.version>>.yaml" -e '{"ansible_python_interpreter":"/usr/bin/<<parameters.python>>","datadog_manage_config":false}'
+      - run: bash -c '[ -f /etc/datadog-agent/datadog.yaml.example ] || [ -f /etc/dd-agent/datadog.conf.example ]'
+      - run: bash -c '[ ! -f /etc/datadog-agent/datadog.yaml ] && [ ! -f /etc/datadog-agent/system-probe.yaml ] && [ ! -f /etc/datadog-agent/security-agent.yaml ] && [ ! -f /etc/dd-agent/datadog.conf ]'
+
   downgrade_agent_5_23_0:
     parameters:
       python:
@@ -121,6 +132,24 @@ jobs:
           version: "<<parameters.agent_version>>"
           python: "<<parameters.python>>"
 
+  test_install_no_manage_config:
+    parameters:
+      ansible_version:
+        type: string
+      agent_version:
+        type: string
+      os:
+        type: string
+      python:
+        type: string
+    docker:
+      - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
+    steps:
+      - checkout
+      - test_install_no_manage_config:
+          version: "<<parameters.agent_version>>"
+          python: "<<parameters.python>>"
+
 workflows:
   version: 2
   test_datadog_role:
@@ -142,7 +171,16 @@ workflows:
               agent_version: ["5", "6", "7"]
               os: ["debian"]
               python: ["python3"]
-      
+
+      # Newer debian images only have Pythpn 3 installed
+      - test_install_no_manage_config:
+          matrix:
+            parameters:
+              ansible_version: ["2_10"]
+              agent_version: ["5", "7"]
+              os: ["debian"]
+              python: ["python3"]
+
       # centos = CentOS 7. CentOS <= 7 + Python3 is not supported,
       # as the yum module is Python2-only.
       - test_install_downgrade: 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,16 +1,18 @@
 ---
 role_version: 4.12.0
 
-# default system-probe.yaml options
-system_probe_config: {}
-
-network_config: {}
-
 # define if the datadog-agent services should be enabled
 datadog_enabled: yes
 
+# Whether the datadog.conf / datadog.yaml, system-probe.yaml, security-agent.yaml and checks config under conf.d are managed by Ansible
+datadog_manage_config: yes
+
 # default datadog.conf / datadog.yaml options
 datadog_config: {}
+
+# default system-probe.yaml options
+system_probe_config: {}
+network_config: {}
 
 # default checks enabled
 datadog_checks: {}

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -31,6 +31,7 @@
     mode: 0640
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
+  when: datadog_manage_config
   notify: restart datadog-agent
 
 - name: Register all checks directories present in datadog
@@ -47,7 +48,7 @@
     path: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_untracked_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent
 
 - name: Delete all default checks
@@ -55,7 +56,7 @@
     path: "/etc/datadog-agent/conf.d/{{ item }}.d/conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_default_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent
 
 - name: Ensure configuration directories are present for each Datadog check
@@ -66,6 +67,7 @@
     group: "{{ datadog_group }}"
     mode: 0755
   with_items: '{{ datadog_checks|list }}'
+  when: datadog_manage_config
 
 - name: Create a configuration file for each Datadog check
   template:
@@ -75,6 +77,7 @@
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
   with_items: "{{ datadog_checks|list }}"
+  when: datadog_manage_config
   notify: restart datadog-agent
 
 - name: Remove old configuration file for each Datadog check
@@ -82,6 +85,7 @@
     dest: "/etc/datadog-agent/conf.d/{{ item }}.yaml"
     state: absent
   with_items: "{{ datadog_checks|list }}"
+  when: datadog_manage_config
   notify: restart datadog-agent
 
 - name: Create system-probe configuration file
@@ -91,6 +95,7 @@
     mode: 0640
     owner: "root"
     group: "{{ datadog_group }}"
+  when: datadog_manage_config
   notify:
     "{% if datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 
@@ -179,6 +184,7 @@
     mode: 0640
     owner: "root"
     group: "{{ datadog_group }}"
+  when: datadog_manage_config
   notify:
     "{% if datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -23,6 +23,7 @@
     dest: /etc/datadog-agent
     state: directory
     mode: 0755
+  when: datadog_manage_config
 
 - name: Create main Datadog agent configuration file
   template:
@@ -41,7 +42,7 @@
     - "*.d"
     file_type: directory
   register: datadog_conf_directories
-  when: datadog_disable_untracked_checks or datadog_disable_default_checks
+  when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in datadog_tracked_checks
   file:

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -4,6 +4,7 @@
     #FIXME: should have permissions set to only be readable by ddagentuser
     src: datadog.yaml.j2
     dest: "{{ datadog_windows_config_root }}\\datadog.yaml"
+  when: datadog_manage_config
   notify: restart datadog-agent-win
 
 - name: Register all checks directories present in datadog
@@ -20,7 +21,7 @@
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_untracked_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent-win
 
 - name: Delete default checks
@@ -28,7 +29,7 @@
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
   loop: "{{ datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_default_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent-win
 
 - name: Ensure configuration directories are present for each Datadog check
@@ -36,12 +37,14 @@
     path: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.d"
     state: directory
   with_items: '{{ datadog_checks|list }}'
+  when: datadog_manage_config
 
 - name: Create a configuration file for each Datadog check
   win_template:
     src: checks.yaml.j2
     dest: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
   with_items: "{{ datadog_checks|list }}"
+  when: datadog_manage_config
   notify: restart datadog-agent-win
 
 - name: Remove old configuration file for each Datadog check
@@ -49,6 +52,7 @@
     path: "{{ datadog_windows_config_root }}\\conf.d\\{{ item }}.yaml"
     state: absent
   with_items: "{{ datadog_checks|list }}"
+  when: datadog_manage_config
   notify: restart datadog-agent-win
 
 - name: Ensure datadog-trace-agent and datadog-process-agent are not disabled
@@ -64,6 +68,7 @@
   win_template:
     src: system-probe.yaml.j2
     dest: "{{ datadog_windows_config_root }}\\system-probe.yaml"
+  when: datadog_manage_config
   notify: restart datadog-agent-win
 
 - name: Ensure datadog-agent is running

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -14,7 +14,7 @@
     - "*.d"
     file_type: directory
   register: datadog_conf_directories
-  when: datadog_disable_untracked_checks or datadog_disable_default_checks
+  when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in datadog_tracked_checks
   win_file:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -4,6 +4,7 @@
     dest: /etc/dd-agent
     state: directory
     mode: 0755
+  when: datadog_manage_config
 
 - name: (agent5) Create main Datadog agent configuration file
   template:
@@ -36,7 +37,7 @@
     - "*.yaml"
     file_type: file
   register: datadog_conf_files
-  when: datadog_disable_untracked_checks
+  when: datadog_manage_config and datadog_disable_untracked_checks
 
 - name: Register all checks files present in datadog
   find:
@@ -45,7 +46,7 @@
     - "*.yaml.default"
     file_type: file
   register: datadog_conf_files_default
-  when: datadog_disable_default_checks
+  when: datadog_manage_config and datadog_disable_default_checks
 
 - name: Delete checks not present in datadog_tracked_checks
   file:

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -12,6 +12,7 @@
     owner: "{{ datadog_user }}"
     group: "{{ datadog_group }}"
     mode: 0644 #FIXME: should have permissions set to only be readable by owner
+  when: datadog_manage_config
   notify: restart datadog-agent
 
 - name: (agent5) Ensure datadog-agent is running
@@ -51,7 +52,7 @@
     path: "/etc/dd-agent/conf.d/{{ item }}.yaml"
     state: absent
   loop: "{{ datadog_conf_files.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).yaml$', '\\1') | list }}"
-  when: datadog_disable_untracked_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_untracked_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent
 
 - name: Delete default checks
@@ -60,7 +61,7 @@
     state: absent
   loop: "{{ datadog_conf_files_default.files | map(attribute='path') | list
              | map('basename') | list | map('regex_replace', '^(.*).yaml.default$', '\\1') | list }}"
-  when: datadog_disable_default_checks and item not in datadog_tracked_checks
+  when: datadog_manage_config and datadog_disable_default_checks and item not in datadog_tracked_checks
   notify: restart datadog-agent
 
 - name: (agent5) Create a configuration file for each Datadog check
@@ -71,4 +72,5 @@
     group: "{{ datadog_group }}"
     mode: 0644 #FIXME: should have permissions set to only be readable by owner
   with_items: "{{ datadog_checks|list }}"
+  when: datadog_manage_config
   notify: restart datadog-agent


### PR DESCRIPTION
Adds a new variable `datadog_manage_config` that defaults to `true` but can be set to `false`. Doing so will make our role not change any of the Agent config files when it runs. This allows using the role to update the Agent if manual modifications have been made to the config files without overwriting them.