### PR TITLE
Fix provisioning on Python 3 / Amazon Linux 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.retry
 .venv
 
+# Vagrant
+.vagrant
+
 # pre and post tasks folders (user defined)
 pre_tasks/
 post_tasks/

--- a/README.md
+++ b/README.md
@@ -548,6 +548,16 @@ On Debian Stretch, the `apt_key` module used by the role requires an additional 
     datadog_api_key: "<YOUR_DD_API_KEY>"
 ```
 
+### CentOS 6/7 with Python 3 interpreter and Ansible 2.10.x or below
+
+The `yum` Python module, which is used in this role to install the Agent on CentOS-based hosts, is only available on Python 2 if Ansible 2.10.x or below is used. In such cases, the `dnf` package manager would have to be used instead.
+
+However, `dnf` and the `dnf` Python module are not installed by default on CentOS-based hosts before CentOS 8. In this case, it is not possible to install the Agent when a Python 3 interpreter is used.
+
+This role fails early when this situation is detected to indicate that Ansible 2.11+ or a Python 2 interpreter is needed when installing the Agent on CentOS / RHEL < 8.
+
+To bypass this early failure detection (for instance, if `dnf` and the `python3-dnf` package are available on your host), set the `datadog_ignore_old_centos_python3_error` variable to `true`.
+
 ### Windows
 
 Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, installation of these versions is blocked (starting with version `3.3.0` of this role).

--- a/README.md
+++ b/README.md
@@ -548,14 +548,6 @@ On Debian Stretch, the `apt_key` module used by the role requires an additional 
     datadog_api_key: "<YOUR_DD_API_KEY>"
 ```
 
-### CentOS 6/7 with Python 3 interpreter
-
-The `yum` Python module, which is used in this role to install the Agent on CentOS-based hosts, is only available on Python 2. When a Python 3 interpreter is detected on a target host, the `dnf` package manager and the `dnf` Python module are used instead.
-
-However, `dnf` and the `dnf` Python module are not installed by default on CentOS-based hosts before CentOS 8. In this case, it is not possible to install the Agent when a Python 3 interpreter is used. This role fails early when this situation is detected to indicate that a Python 2 interpreter is needed when installing the Agent on CentOS / RHEL < 8.
-
-To bypass this early failure detection (for instance, if `dnf` and the `python3-dnf` package are available on your host), set the `datadog_ignore_old_centos_python3_error` variable to `true`.
-
 ### Windows
 
 Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, installation of these versions is blocked (starting with version `3.3.0` of this role).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,6 +85,13 @@ datadog_yum_gpgkey_20200908: "https://s3.amazonaws.com/public-signing-keys/DATAD
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
+# By default, we fail early & print a helpful message if an older Ansible version and Python 3
+# interpreter is used on CentOS < 8. The 'yum' module is only available on Python 2, and the 'python3-dnf'
+# package is not available before CentOS 8.
+# If set to true, this option removes this check and allows the install to proceed. Useful in specific setups
+# where an old CentOS host using a Python 3 interpreter does have 'dnf' (eg. through backports).
+datadog_ignore_old_centos_python3_error: false
+
 # By default, the role uses the official zypper Datadog repository for the chosen major version
 # Use the datadog_zypper_repo variable to override the repository used.
 datadog_zypper_repo: ""

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -85,13 +85,6 @@ datadog_yum_gpgkey_20200908: "https://s3.amazonaws.com/public-signing-keys/DATAD
 datadog_yum_gpgkey_20200908_sha256sum: "4d16c598d3635086762bd086074140d947370077607db6d6395b8523d5c23a7d"
 # Default zypper repo and keys
 
-# By default, we fail early & print a helpful message if a Python 3 interpreter is used on CentOS < 8, as
-# the 'yum' module is only available on Python 2, and the 'python3-dnf' package is not available before
-# CentOS 8.
-# If set to true, this option removes this check and allows the install to proceed. Useful in specific setups
-# where an old CentOS host using a Python 3 interpreter does have 'dnf' (eg. through backports).
-datadog_ignore_old_centos_python3_error: false
-
 # By default, the role uses the official zypper Datadog repository for the chosen major version
 # Use the datadog_zypper_repo variable to override the repository used.
 datadog_zypper_repo: ""

--- a/manual_tests/Vagrantfile
+++ b/manual_tests/Vagrantfile
@@ -1,3 +1,19 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.define "ubuntu", primary: true do |c|
+    c.vm.box = "ubuntu/trusty64"
+  end
+
+  config.vm.define "centos", autostart: false do |c|
+    c.vm.box = "centos/8"
+  end
+
+  config.vm.define "amazonlinux", autostart: false do |c|
+    c.vm.box = "bento/amazonlinux-2"
+  end
+
+  Dir["test_*.yml"].sort.each do |playbook|
+    config.vm.provision playbook, type: "ansible" do |ansible|
+      ansible.playbook = playbook
+    end
+  end
 end

--- a/manual_tests/inventory
+++ b/manual_tests/inventory
@@ -1,2 +1,2 @@
 [test_host]
-127.0.0.1 ansible_ssh_host=localhost ansible_ssh_user=vagrant ansible_ssh_port=2222 ansible_ssh_private_key_file=./ansible-datadog/manual_tests/.vagrant/machines/default/virtualbox/private_key
+127.0.0.1 ansible_ssh_host=localhost ansible_ssh_user=vagrant ansible_ssh_port=2222 ansible_ssh_private_key_file=./ansible-datadog/manual_tests/.vagrant/machines/ubuntu/virtualbox/private_key

--- a/manual_tests/readme.md
+++ b/manual_tests/readme.md
@@ -9,20 +9,19 @@ This is an example setup, based on vagrant + virtualbox, that allows to easily r
 
 ## Setup
 
-Run the Vagrantfile defined in `ansible-datadog/manual_tests`:
+From `ansible-datadog/manual_tests` directory:
 
-- provision VM: `vagrant up`
-- connect to the VM to check the configuration: `vagrant ssh`
-- when done, destroy VM when needed: `vagrant destroy -f`
+- provision VM: `vagrant up ubuntu --provision --provision-with test_7_full.yml`
+- when done, destroy VM if needed: `vagrant destroy -f`
 
-- From `ansible-datadog`'s parent directory, run:
+To test with different agent versions or configurations, replace
+`--provision-with` argument `test_7_full.yml` with any of the other
+`test_*.yml` files in this directory.
 
-```shell
-ansible-playbook ansible-datadog/manual_tests/test_7_full.yml -i ansible-datadog/manual_tests/inventory
-```
+To test on different operating systems, replace `ubuntu` with `centos` or `amazonlinux`.
 
-Note: Replace `test_7_full.yml` with any of the other yaml files on this directory.
-Note: If getting access denied errors, make sure Vagrant is forwarding the VM port 22 to the local port 2222. If using a different port, update the 'inventory' file
+If `vagrant up --provision` is used without any other parameters, all the
+playbooks are applied one by one on an Ubuntu machine.
 
 # Windows test setup from WSL
 

--- a/manual_tests/test_5_default.yml
+++ b/manual_tests/test_5_default.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
   roles:
-  - { role: ansible-datadog, become: yes }
+  - { role: ../../ansible-datadog, become: yes }
   vars:
     datadog_agent_major_version: 5

--- a/manual_tests/test_5_full.yml
+++ b/manual_tests/test_5_full.yml
@@ -1,6 +1,6 @@
 - hosts: all
   roles:
-    - { role: ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
+    - { role: ../../ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
   vars:
     datadog_agent_major_version: 5
     datadog_api_key: "123456"

--- a/manual_tests/test_6_default.yml
+++ b/manual_tests/test_6_default.yml
@@ -1,6 +1,6 @@
 ---
 - hosts: all
   roles:
-  - { role: ansible-datadog, become: yes }
+  - { role: ../../ansible-datadog, become: yes }
   vars:
     datadog_agent_major_version: 6

--- a/manual_tests/test_6_full.yml
+++ b/manual_tests/test_6_full.yml
@@ -1,6 +1,6 @@
 - hosts: all
   roles:
-    - { role: ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
+    - { role: ../../ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
   vars:
     datadog_agent_major_version: 6
     datadog_api_key: "123456"

--- a/manual_tests/test_7_default.yml
+++ b/manual_tests/test_7_default.yml
@@ -1,4 +1,4 @@
 ---
 - hosts: all
   roles:
-  - { role: ansible-datadog, become: yes }
+  - { role: ../../ansible-datadog, become: yes }

--- a/manual_tests/test_7_full.yml
+++ b/manual_tests/test_7_full.yml
@@ -1,6 +1,6 @@
 - hosts: all
   roles:
-    - { role: ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
+    - { role: ../../ansible-datadog, become: yes }  # On Ansible < 1.9, use `sudo: yes` instead of `become: yes`
   vars:
     datadog_agent_major_version: 7
     datadog_api_key: "123456"

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,4 +1,13 @@
 ---
+- name: Fail early if Python 3 is used on CentOS / RHEL < 8 with old Ansible
+  fail:
+    msg: "The installation of the Agent on RedHat family systems using yum is not compatible with Python 3 with older Ansible versions.
+          To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8 or upgrade Ansible to version 2.11+"
+  when: (not datadog_ignore_old_centos_python3_error)
+        and (ansible_version.full is version("2.11", operator="lt", strict=True))
+        and (ansible_pkg_mgr == "yum")
+        and (ansible_facts.python.version.major | int >= 3)
+
 - name: Find out whether to set repo_gpgcheck or not
   # We turn off repo_gpgcheck on custom repos and on RHEL/CentOS 8.1 because
   # of https://bugzilla.redhat.com/show_bug.cgi?id=1792506

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,12 +1,4 @@
 ---
-- name: Fail early if Python 3 is used on CentOS / RHEL < 8
-  fail:
-    msg: "The installation of the Agent on CentOS / RHEL versions < 8 requires the 'yum' module, which is not compatible with Python 3.
-          To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8."
-  when: (not datadog_ignore_old_centos_python3_error)
-        and (ansible_facts.distribution_major_version | int <= 7)
-        and (ansible_facts.python.version.major | int >= 3)
-
 - name: Find out whether to set repo_gpgcheck or not
   # We turn off repo_gpgcheck on custom repos and on RHEL/CentOS 8.1 because
   # of https://bugzilla.redhat.com/show_bug.cgi?id=1792506

--- a/tasks/pkg-redhat/install-latest.yml
+++ b/tasks/pkg-redhat/install-latest.yml
@@ -5,7 +5,7 @@
     update_cache: yes
     state: latest  # noqa 403
   register: datadog_agent_install
-  when: not ansible_check_mode and ansible_facts.python.version.major | int >= 3
+  when: not ansible_check_mode and ansible_pkg_mgr == "dnf"
   notify: restart datadog-agent
 
 - name: Install latest datadog-agent package (yum)
@@ -14,5 +14,5 @@
     update_cache: yes
     state: latest  # noqa 403
   register: datadog_agent_install
-  when: not ansible_check_mode and ansible_facts.python.version.major | int < 3
+  when: not ansible_check_mode and ansible_pkg_mgr == "yum"
   notify: restart datadog-agent

--- a/tasks/pkg-redhat/install-pinned.yml
+++ b/tasks/pkg-redhat/install-pinned.yml
@@ -6,7 +6,7 @@
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
   register: datadog_agent_install
-  when: not ansible_check_mode and ansible_facts.python.version.major | int >= 3
+  when: not ansible_check_mode and ansible_pkg_mgr == "dnf"
   notify: restart datadog-agent
 
 - name: Install pinned datadog-agent package (yum)
@@ -16,5 +16,5 @@
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
   register: datadog_agent_install
-  when: not ansible_check_mode and ansible_facts.python.version.major | int < 3
+  when: not ansible_check_mode and ansible_pkg_mgr == "yum"
   notify: restart datadog-agent


### PR DESCRIPTION
### Fix provisioning on Python 3 / Amazon Linux 2.

This (c1db357d65b0c4445d53cb46ffee69ca98bd67d8) is the essence of this PR.

Don't use `python.version.major >= 3` condition to select `dnf` instead
of `yum`, because it breaks Python 3 on Amazon Linux 2 setups, where
`yum` is still used. Use `ansible_pkg_mgr` fact directly instead.

~Remove an explicit fail that's too defensive.~ Improve the explicit "fail early" task to take into account all the variables.

`Vagrantfile` to reproduce the problem:

```
Vagrant.configure("2") do |config|
  config.vm.define "amazonlinux" do |c|
    c.vm.box = "bento/amazonlinux-2"
  end

  # existence of Python 3 is enough to fail this role
  config.vm.provision "shell", inline: "yum install -y python3 python3-pip"

  config.vm.provision "ansible" do |ansible|
    ansible.playbook = "test_7_full.yml"
  end
end
```

Fixes: #406.

### Add manual testing for Centos 8 and Amazon Linux 2

(cb9d25b47d287a180aceedef7840238a0be3102d)

Add manual testing on Centos 8 and Amazon Linux 2

1. Extend manual tests setup to include more operating systems – modern
   RedHat-style one (Centos 8) that uses dnf, legacy RedHat-style one
   which uses yum (Amazon Linux 2). Keep Ubuntu as a default one.
2. Run Ansible on provisioned machines automatically. By default all
   playbooks are run. Now there is no need to change current working
   directory to interact with Ansible and Vagrant. There's also no need
   to modify inventory file if ports change. There're also no problems
   with SSH known hosts anymore.
3. Update `readme.md`.
4. Git ignore `.vagrant`.