### PR TITLE
Don't display content of DDAGENTUSER_PASSWORD for Windows nodes

### DIFF
--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -3,10 +3,8 @@
     win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
   when: datadog_windows_ddagentuser_name | default('', true) | length > 0
 
-- name: Set DD Password Arg
-  set_fact:
-    win_install_args: "{{ win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
-  when: datadog_windows_ddagentuser_password | default('', true) | length > 0
+# NOTE: We don't set DD Password Arg here to prevent it from being printed;
+# we set it right before using win_install_args
 
 # check the registry. On upgrade, the location of the config file root will 
 # be set here.  

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -65,7 +65,13 @@
 
 - name: Show installation flags
   debug:
-    var: win_install_args
+    msg: "{{ win_install_args }}{% if datadog_windows_ddagentuser_password | default('', true) | length > 0 %} DDAGENTUSER_PASSWORD=<REDACTED>{% endif %}"
+
+# We set DD Password Arg here to prevent it from being printed in any kind of debug logs/messages prior usage
+- name: Set DD Password Arg
+  set_fact:
+    win_install_args: "{{ win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
+  when: datadog_windows_ddagentuser_password | default('', true) | length > 0
 
 - name: Install downloaded agent
   win_package:


### PR DESCRIPTION
Fixes #404. Do note that the password would still be printed in a very verbose run, when all commands are fully printed out.