### PR TITLE
Move Windows version task to separate file to prevent dependency on ansible.windows

### DIFF
--- a/tasks/parse-version-windows.yml
+++ b/tasks/parse-version-windows.yml
@@ -1,0 +1,18 @@
+# NOTE: This won't work with rc / beta builds.
+- name: Get Windows Agent version
+  win_shell: |
+    $product_name = "Datadog Agent"
+    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
+    $installs = Get-WmiObject -query $query
+
+    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
+      Write-Host ""
+    } else {
+      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
+      Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
+    }
+  register: datadog_version_check_win
+  changed_when: false
+  failed_when: false
+  check_mode: no
+  when: ansible_facts.os_family == "Windows"

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -66,23 +66,11 @@
   check_mode: no
   when: ansible_facts.system is defined and ansible_facts.system == "Linux"
 
-# NOTE: This won't work with rc / beta builds.
-- name: Get Windows Agent version
-  win_shell: |
-    $product_name = "Datadog Agent"
-    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
-    $installs = Get-WmiObject -query $query
-
-    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
-      Write-Host ""
-    } else {
-      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
-      Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
-    }
-  register: datadog_version_check_win
-  changed_when: false
-  failed_when: false
-  check_mode: no
+# The task is win_shell, so if users don't have the "ansible.windows" collection installed,
+# parsing the task would fail even if the host is not Windows. By hiding the task inside
+# a conditionally included file, we can prevent this.
+- name: Include Windows Agent version tasks
+  include_tasks: parse-version-windows.yml
   when: ansible_facts.os_family == "Windows"
 
 - name: Set skip install flag if version already installed (Linux)


### PR DESCRIPTION
Fixes #413. Extracting the `win_shell` task to a separate file that gets included conditionally prevents ansible from failing on parsing the task when `ansible.windows` collection is not installed.