### PR TITLE
Support Rocky and AlmaLinux, migrate CI tests from EOL'd CentOS 8 to Rocky Linux 8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ workflows:
               ansible_version: ["2_8", "2_9", "2_10"]
               agent_version: ["6", "7"]
               jinja2_native: ["true", "false"]
-              os: ["centos8"]
+              os: ["rocky8"]
               python: ["python3"]
 
       # Newer suse images only have Python 3 installed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,9 +21,12 @@
   include_tasks: pkg-debian.yml
   when: ansible_facts.os_family == "Debian" and not datadog_skip_install
 
+# Only Ansible >= 3.0 knows that AlmaLinux belongs to "RedHat" family
+# (and latest bugfix releases of some 2.X)
+# For Rocky it is some 4.X and >= 5.0
 - name: RedHat Install Tasks
   include_tasks: pkg-redhat.yml
-  when: ansible_facts.os_family == "RedHat" and not datadog_skip_install
+  when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not datadog_skip_install
 
 - name: Suse Install Tasks
   include_tasks: pkg-suse.yml

--- a/tasks/os-check.yml
+++ b/tasks/os-check.yml
@@ -2,4 +2,4 @@
 - name: Fail if OS is not supported
   fail:
     msg: "The Datadog Ansible role does not support your OS yet. Please email support@datadoghq.com to open a feature request."
-  when: ansible_facts.os_family not in ["RedHat", "Debian", "Suse", "Windows"]
+  when: ansible_facts.os_family not in ["RedHat", "Rocky", "AlmaLinux", "Debian", "Suse", "Windows"]

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -48,6 +48,8 @@
     datadog_version_finding_cmds:
       Debian: "dpkg -s {{ datadog_agent_flavor }} | grep '^Version:' | awk '{print $2}'"
       RedHat: "rpm -q --qf '%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
+      Rocky: "rpm -q --qf '%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
+      AlmaLinux: "rpm -q --qf '%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
       Suse: "rpm -q --qf '%{EPOCH}:%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
 
 - name: Create OS-specific version dict
@@ -55,6 +57,8 @@
     datadog_agent_os2version:
       Debian: "{{ datadog_agent_debian_version }}"
       RedHat: "{{ datadog_agent_redhat_version }}"
+      Rocky: "{{ datadog_agent_redhat_version }}"
+      AlmaLinux: "{{ datadog_agent_redhat_version }}"
       Suse: "{{ datadog_agent_suse_version }}"
       Windows: "{{ datadog_agent_windows_version }}"
 


### PR DESCRIPTION
Let's support Rocky Linux and AlmaLinux. For the CI part, CentOS 8 was EOL'd on 31st January 2022. We still need to test on a RHEL-compatible system, so let's switch to Rocky Linux.