### PR TITLE
Switch Agent start mode to delayed on Windows

### DIFF
--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -82,7 +82,7 @@
   win_service:
     name: datadogagent
     state: started
-    start_mode: auto
+    start_mode: delayed
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent is disabled


### PR DESCRIPTION
This PR switches the services startup mode to `delayed` instead of `auto`.
This is is similar to what we do in the MSI Agent: https://github.com/DataDog/datadog-agent/blob/main/tools/windows/install-help/cal/stopservices.cpp#L631