### PR TITLE
Pin ansible-lint to 5.4.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,8 @@ jobs:
       - image: datadog/docker-library:ansible_debian_2_10
     steps:
       - checkout
-      - run: pip install ansible-lint
+      # TODO: upgrade ansible-lint to latest (will require updating the image for this task)
+      - run: pip install ansible-lint==5.4.0
       - run: ansible-lint -v .
 
   test_install_downgrade:


### PR DESCRIPTION
Newest ansible-lint 6.0.0 can't be (easily) installed along ansible 2.10. We could upgrade the linting image to 5.3, which doesn't have this problem, but ansible-lint 6.0.0 has become very opinionated and requires multitude of changes. Let's do that after we merge #426 to not require rebases there.