### PR TITLE
include datadog_skip_install

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,9 @@ role_version: 4.14.0
 # define if the datadog-agent services should be enabled
 datadog_enabled: yes
 
+# Whether the play should skip the agent install as a whole.
+datadog_skip_install: no
+
 # Whether the datadog.conf / datadog.yaml, system-probe.yaml, security-agent.yaml and checks config under conf.d are managed by Ansible
 datadog_manage_config: yes
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,24 +13,23 @@
 - name: Resolve datadog_tracked_checks later to defend against variable presidence issues arising from dynamically included null datadog_checks 
   include_tasks: sanitize-checks.yml
 
-# Also sets datadog_skip_install
 - name: Set Facts for Datadog Agent Major Version
   include_tasks: set-parse-version.yml
 
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml
-  when: ansible_facts.os_family == "Debian" and not datadog_skip_install
+  when: ansible_facts.os_family == "Debian" and (not datadog_skip_install|bool)
 
 # Only Ansible >= 3.0 knows that AlmaLinux belongs to "RedHat" family
 # (and latest bugfix releases of some 2.X)
 # For Rocky it is some 4.X and >= 5.0
 - name: RedHat Install Tasks
   include_tasks: pkg-redhat.yml
-  when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not datadog_skip_install
+  when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and (not datadog_skip_install|bool)
 
 - name: Suse Install Tasks
   include_tasks: pkg-suse.yml
-  when: ansible_facts.os_family == "Suse" and not datadog_skip_install
+  when: ansible_facts.os_family == "Suse" and (not datadog_skip_install|bool)
 
 # Note we don't check datadog_skip_install variable value for windows here,
 # because some tasks in pkg-windows.yml are carried out regardless of its value.

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -8,24 +8,24 @@
   win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
     dest: '%TEMP%\fix_6_14.ps1'
-  when: not datadog_skip_install and datadog_apply_windows_614_fix
+  when: (not datadog_skip_install|bool) and datadog_apply_windows_614_fix
 
 - name: Run 6.14.0/1 PowerShell fix
   win_shell: |
     Set-ExecutionPolicy Bypass -Scope Process -Force
     &$env:temp\fix_6_14.ps1
-  when: not datadog_skip_install and datadog_apply_windows_614_fix
+  when: (not datadog_skip_install|bool) and datadog_apply_windows_614_fix
 
 - include_tasks: win_agent_latest.yml
-  when: (not datadog_skip_install) and (datadog_agent_windows_version is not defined)
+  when: (not datadog_skip_install|bool) and (datadog_agent_windows_version is not defined)
 
 - include_tasks: win_agent_version.yml
-  when: (not datadog_skip_install) and (datadog_agent_windows_version is defined)
+  when: (not datadog_skip_install|bool) and (datadog_agent_windows_version is defined)
 
 - name: show URL var
   debug:
     var: dd_download_url
-  when: not datadog_skip_install
+  when: not datadog_skip_install|bool
 
 ## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
 - name: Set windows NPM installed
@@ -37,14 +37,14 @@
   win_file:
     path: '%TEMP%\ddagent.msi'
     state: absent
-  when: not datadog_skip_install
+  when: not datadog_skip_install|bool
 
 - name: Download windows datadog agent
   win_get_url:
     url: "{{ dd_download_url }}"
     dest: '%TEMP%\ddagent.msi'
   register: download_msi_result
-  when: (not datadog_skip_install) and (not ansible_check_mode)
+  when: (not datadog_skip_install|bool) and (not ansible_check_mode)
 
 - name: Create Binary directory root (if not default)
   win_file:
@@ -78,10 +78,10 @@
     path: "{{ download_msi_result.dest }}"
     arguments: "{{ win_install_args }}"
   register: datadog_agent_install
-  when: (not datadog_skip_install) and (not ansible_check_mode)
+  when: (not datadog_skip_install|bool) and (not ansible_check_mode)
 
 - name: Delete temporary msi
   win_file:
     path: "{{ download_msi_result.dest }}"
     state: absent
-  when: (not datadog_skip_install) and (not ansible_check_mode) and (download_msi_result.status_code == 200)
+  when: (not datadog_skip_install|bool) and (not ansible_check_mode) and (download_msi_result.status_code == 200)

--- a/tasks/set-parse-version.yml
+++ b/tasks/set-parse-version.yml
@@ -5,7 +5,7 @@
 
 - name: Initialize skip install flag to false
   set_fact:
-    datadog_skip_install: no
+    datadog_skip_install: "{{ datadog_skip_install | default(false) }}"
 
 - include_tasks: parse-version.yml
   when: datadog_agent_version | default('', true) | length > 0

--- a/tasks/set-parse-version.yml
+++ b/tasks/set-parse-version.yml
@@ -1,11 +1,8 @@
 ---
+
 - name: Convert datadog_agent_major_version to string
   set_fact:
     datadog_agent_major_version: "{{ datadog_agent_major_version | default('', true) | string }}"
-
-- name: Initialize skip install flag to false
-  set_fact:
-    datadog_skip_install: "{{ datadog_skip_install | default(false) }}"
 
 - include_tasks: parse-version.yml
   when: datadog_agent_version | default('', true) | length > 0


### PR DESCRIPTION
fixes #430

- Include a default datadog_skip_install variable set to false/no as default
- Don't override datadog_skip install in set-parse-version.yml but check if its set or use default false