### PR TITLE
Prevent security-agent startup if it's not configured

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -195,7 +195,18 @@
     mode: 0640
     owner: "root"
     group: "{{ datadog_group }}"
-  when: datadog_manage_config
+  when: datadog_manage_config and (runtime_security_config is defined and runtime_security_config | default({}, true) | length > 0)
+  notify:
+    "{% if datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
+
+# Templates don't support the "state: absent" argument, so if the file was created in a previous run
+# and then runtime_security_config was completely removed, this is the only way to ensure
+# we remove the leftover config file.
+- name: Remove security-agent configuration file if security-agent is no longer configured
+  file:
+    path: /etc/datadog-agent/security-agent.yaml
+    state: absent
+  when: datadog_manage_config and (runtime_security_config is not defined or runtime_security_config | default({}, true) | length == 0)
   notify:
     "{% if datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 


### PR DESCRIPTION
Previously, we always created `security-agent.yaml` file, so the security agent would always start even if there was no configuration provided. Now we ensure this file is only present when there is explicit security agent configuration provided.