### PR TITLE
Make macOS user data query run in check mode

### DIFF
--- a/tasks/agent-macos.yml
+++ b/tasks/agent-macos.yml
@@ -7,6 +7,7 @@
     executable: /bin/bash
   changed_when: false
   register: macos_user_output
+  check_mode: no
 
 # This task is used to more cleanly format the variable contents.The ABOVE task's shell command returns a JSON
 # object as a string but nested in `.stdout`. Ansible has built in behavior that if it receives JSON data as


### PR DESCRIPTION
Extracting user data using `dscacheutil` is a non-destructive operation and hence can be safely run in check mode (and a lot of following tasks depend on its result, so we need to run it for the check mode run to have meaningful results).

Fixes https://github.com/DataDog/ansible-datadog/issues/439