### PR TITLE
Remove temporary dir after apt key import

### DIFF
--- a/tasks/_apt-key-import.yml
+++ b/tasks/_apt-key-import.yml
@@ -81,3 +81,10 @@
   when: key_needs_import
   register: key_import_result
   changed_when: '"imported: 1" in key_import_result.stderr'
+
+- name: "Remove temporary directory for key manipulation"
+  file:
+    path: "{{ tempdir.path }}"
+    state: absent
+  when: key_needs_import
+  changed_when: false


### PR DESCRIPTION
Remove the temporary directory created by `_apt_key_import.yml` after
importing the key, so they don't pile up in the hosts' `/tmp` dirs.