### PR TITLE
Fix version comparison task when using ansible-core RC version

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,9 +1,4 @@
 ---
-
-- name: Print all available facts
-  ansible.builtin.debug:
-    var: ansible_version
-
 - name: Fail early if Python 3 is used on CentOS / RHEL < 8 with old Ansible
   fail:
     msg: "The installation of the Agent on RedHat family systems using yum is not compatible with Python 3 with older Ansible versions.

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,10 +1,20 @@
 ---
+
+- name: Print all available facts
+  ansible.builtin.debug:
+    var: ansible_version
+
 - name: Fail early if Python 3 is used on CentOS / RHEL < 8 with old Ansible
   fail:
     msg: "The installation of the Agent on RedHat family systems using yum is not compatible with Python 3 with older Ansible versions.
           To run this role, use a Python 2 interpreter on hosts running CentOS / RHEL < 8 or upgrade Ansible to version 2.11+"
+  # We can't compare ansible_version.full with 2.11 in the condition below, because ansible's
+  # `semver` and `strict` version_type don't recognize it as a valid version and the `loose`
+  # version_type considers it to be a post-release. It seems that the best course of action
+  # is to explicitly use just major.minor for comparison with 2.11.
+  # See https://github.com/ansible/ansible/issues/78288
   when: (not datadog_ignore_old_centos_python3_error)
-        and (ansible_version.full is version("2.11", operator="lt", strict=True))
+        and ("{}.{}".format(ansible_version.major, ansible_version.minor) is version("2.11", operator="lt", version_type="strict"))
         and (ansible_pkg_mgr == "yum")
         and (ansible_facts.python.version.major | int >= 3)
 

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -9,7 +9,7 @@
   # is to explicitly use just major.minor for comparison with 2.11.
   # See https://github.com/ansible/ansible/issues/78288
   when: (not datadog_ignore_old_centos_python3_error)
-        and ("{}.{}".format(ansible_version.major, ansible_version.minor) is version("2.11", operator="lt", version_type="strict"))
+        and ("{}.{}".format(ansible_version.major, ansible_version.minor) is version("2.11", operator="lt", strict=True))
         and (ansible_pkg_mgr == "yum")
         and (ansible_facts.python.version.major | int >= 3)
 


### PR DESCRIPTION
Fixes #445. As reported in https://github.com/ansible/ansible/issues/78288, RC versions don't work in the `version` test, so we work around this by using just `major.minor` for comparison with `2.11`.