### PR TITLE
Prettify and fix yaml indentations

### DIFF
--- a/templates/checks.yaml.j2
+++ b/templates/checks.yaml.j2
@@ -1,1 +1,1 @@
-{{ datadog_checks[item] | to_nice_yaml }}
+{{ datadog_checks[item] | to_nice_yaml(indent=2) }}


### PR DESCRIPTION
Having the following example playbooks vars:
```yaml
    datadog_checks:
      rabbitmq:
        init_config:
        instances:
          - rabbitmq_api_url: 'http://localhost:15672/api/'
            user: 'admin'
            password: 'password'
```
Will output this default template behavior(ugly and unclean yaml structure):
```yaml
    init_config: null
    instances:
    -   password: password
        rabbitmq_api_url: http://localhost:15672/api/
        user: admin
```
Because of:
```yaml
{{ datadog_checks[item] | to_nice_yaml }}
```

Adding `indent=2` results in a much better and cleaner output:
```yaml
   init_config: null
   instances:
   - password: password
     rabbitmq_api_url: http://localhost:15672/api/
     user: admin
```