### PR TITLE
Add troubleshooting instructions about `service_facts` breaking Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,19 @@ If you are updating from **6.14.0 or 6.14.1 on Windows**, use the following step
 
 For more details, see [Critical Bug in Uninstaller for Datadog Agent 6.14.0 and 6.14.1 on Windows][11].
 
+### Ubuntu 20.04 broken by service_facts
+
+Running the `service_facts` module on Ubuntu 20.04 causes the following error:
+
+```
+localhost | FAILED! => {
+    "changed": false,
+    "msg": "Malformed output discovered from systemd list-unit-files: accounts-daemon.service                    enabled         enabled      "
+}
+```
+
+This can be fixed by [updating Ansible to `v2.9.8` or above](https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61).
+
 [1]: https://galaxy.ansible.com/Datadog/datadog
 [2]: https://github.com/DataDog/ansible-datadog
 [3]: https://docs.datadoghq.com/agent/autodiscovery
@@ -621,16 +634,3 @@ For more details, see [Critical Bug in Uninstaller for Datadog Agent 6.14.0 and 
 [13]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-linux.yml
 [14]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-win.yml
 [15]: https://www.datadoghq.com/blog/datadog-marketplace/
-
-### Ubuntu 20.04 broken by service_facts
-
-Running the `service_facts` module on Ubuntu 20.04 causes the following error:
-
-```
-localhost | FAILED! => {
-    "changed": false,
-    "msg": "Malformed output discovered from systemd list-unit-files: accounts-daemon.service                    enabled         enabled      "
-}
-```
-
-This can be fixed by [updating Ansible to `v2.9.8` or above](https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61).

--- a/README.md
+++ b/README.md
@@ -621,3 +621,16 @@ For more details, see [Critical Bug in Uninstaller for Datadog Agent 6.14.0 and 
 [13]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-linux.yml
 [14]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-win.yml
 [15]: https://www.datadoghq.com/blog/datadog-marketplace/
+
+### Ubuntu 20.04 broken by service_facts
+
+Running the `service_facts` module on Ubuntu 20.04 causes the following error:
+
+```
+localhost | FAILED! => {
+    "changed": false,
+    "msg": "Malformed output discovered from systemd list-unit-files: accounts-daemon.service                    enabled         enabled      "
+}
+```
+
+This can be fixed by [updating Ansible to `v2.9.8` or above](https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61).

--- a/README.md
+++ b/README.md
@@ -617,7 +617,7 @@ localhost | FAILED! => {
 }
 ```
 
-This can be fixed by [updating Ansible to `v2.9.8` or above](https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61).
+To fix this, [update Ansible to `v2.9.8` or above][16].
 
 [1]: https://galaxy.ansible.com/Datadog/datadog
 [2]: https://github.com/DataDog/ansible-datadog
@@ -634,3 +634,4 @@ This can be fixed by [updating Ansible to `v2.9.8` or above](https://github.com/
 [13]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-linux.yml
 [14]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-win.yml
 [15]: https://www.datadoghq.com/blog/datadog-marketplace/
+[16]: https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61


### PR DESCRIPTION
We received support cases related to Ansible < `v.2.9.8` breaking Ubuntu 20.04 when running the `service_facts` module. This PR adds a troubleshooting note about this specific issue.

There were [plans about adding it to the README](https://github.com/DataDog/ansible-datadog/issues/274#issuecomment-619831258) but it was still missing so here it is !