### PR TITLE
Only use datadog_zypper_repo variable for one purpose

### DIFF
--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -117,12 +117,12 @@
     owner: "root"
     group: "root"
     mode: 0644
-  register: datadog_zypper_repo
+  register: datadog_zypper_repo_template
 
 # refresh zypper repos only if the template changed
 - name: refresh Datadog zypper_repos  # noqa 503
   command: zypper refresh datadog
-  when: datadog_zypper_repo.changed and not ansible_check_mode
+  when: datadog_zypper_repo_template.changed and not ansible_check_mode
   args:
     warn: false  # silence warning about using zypper directly
 


### PR DESCRIPTION
Fixes #447 - when the `datadog_zypper_variable` is reused, it makes the role fail when ran twice in a row (for the second time, it would contain the result of creating the template from the first pass).