### PR TITLE
Use ansible_managed instead of hardcoded message

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 [Main]
 

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 {% if datadog_site is defined
    and datadog_config["site"] is not defined -%}

--- a/templates/security-agent.yaml.j2
+++ b/templates/security-agent.yaml.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 {% if runtime_security_config is defined and runtime_security_config | default({}, true) | length > 0 -%}
 runtime_security_config:

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -1,4 +1,4 @@
-# Managed by Ansible
+# {{ ansible_managed }}
 
 {% if system_probe_config is defined and system_probe_config | default({}, true) | length > 0 -%}
 system_probe_config:


### PR DESCRIPTION
Makes use of [`{{ ansible_managed }}`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_module.html#synopsis) which defaults to "Ansible managed" instead of custom hardcoded message.