### PR TITLE
Add support for Universal Service Monitoring sysprobe configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,8 @@ The system probe is configured under the `system_probe_config` variable. Any var
 
 [Cloud Workload Security][8] is configured under the `runtime_security_config` variable. Any variables nested underneath are written to the `system-probe.yaml` and `security-agent.yaml`, in the `runtime_security_config` section.
 
+[Universal Service Monitoring][17] (USM) is configured under the `service_monitoring_config` variable. Any variables nested underneath are written to the `system-probe.yaml`, in the `service_monitoring_config` section.
+
 **Note for Windows users**: NPM is supported on Windows with Agent v6.27+ and v7.27+. It ships as an optional component that is only installed if `network_config.enabled` is set to true when the Agent is installed or upgraded. Because of this, existing installations might need to do an uninstall and reinstall of the Agent once to install the NPM component, unless the Agent is upgraded at the same time.
 
 #### Example configuration
@@ -211,6 +213,8 @@ datadog_config:
 system_probe_config:
   sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
 network_config:
+  enabled: true
+service_monitoring_config:
   enabled: true
 runtime_security_config:
   enabled: true
@@ -635,3 +639,4 @@ To fix this, [update Ansible to `v2.9.8` or above][16].
 [14]: https://github.com/DataDog/ansible-datadog/blob/main/tasks/agent-win.yml
 [15]: https://www.datadoghq.com/blog/datadog-marketplace/
 [16]: https://github.com/ansible/ansible/blob/stable-2.9/changelogs/CHANGELOG-v2.9.rst#id61
+[17]: https://docs.datadoghq.com/tracing/universal_service_monitoring/?tab=configurationfiles#enabling-universal-service-monitoring

--- a/ci_test/install_agent_6.yaml
+++ b/ci_test/install_agent_6.yaml
@@ -22,6 +22,8 @@
       sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
     network_config:
       enabled: true
+    service_monitoring_config:
+      enabled: true
     datadog_checks:
       process:
         init_config:

--- a/ci_test/install_agent_7.yaml
+++ b/ci_test/install_agent_7.yaml
@@ -22,6 +22,8 @@
       sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
     network_config:
       enabled: true
+    service_monitoring_config:
+      enabled: true
     runtime_security_config:
       enabled: true
     datadog_checks:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,7 @@ datadog_config: {}
 # default system-probe.yaml options
 system_probe_config: {}
 network_config: {}
+service_monitoring_config: {}
 
 # default checks enabled
 datadog_checks: {}

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -2,6 +2,11 @@
 - name: Populate service facts
   service_facts:
 
+- name: Set before 6/7.40.0 flag
+  set_fact:
+    datadog_before_7400: "{{ datadog_major is defined and datadog_minor is defined
+      and datadog_major | int < 8 and datadog_minor | int < 40 }}"
+
 - name: Set before 6/7.24.1 flag
   set_fact:
     datadog_before_7241: "{{ datadog_major is defined and datadog_minor is defined and datadog_bugfix is defined
@@ -69,6 +74,24 @@
       and datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check
     and (not datadog_before_7241)
+
+# Since 6/7.40.0, setting enabled: true in service_monitoring_config is enough to start the system-probe service:
+# https://docs.datadoghq.com/tracing/universal_service_monitoring/?tab=configurationfiles#enabling-universal-service-monitoring
+- name: Set system probe enabled (since 6/7.40.0)
+  set_fact:
+    datadog_sysprobe_enabled: "{{
+      ((system_probe_config is defined
+      and 'enabled' in (system_probe_config | default({}, true))
+      and system_probe_config['enabled'])
+      or (network_config is defined
+      and 'enabled' in (network_config | default({}, true))
+      and network_config['enabled'])
+      or (service_monitoring_config is defined
+      and 'enabled' in (service_monitoring_config | default({}, true))
+      and service_monitoring_config['enabled']))
+      and datadog_sysprobe_installed }}"
+  when: not datadog_skip_running_check
+    and (not datadog_before_7180)
 
 - name: Ensure datadog-agent is running
   service:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -91,7 +91,7 @@
       and service_monitoring_config['enabled']))
       and datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check
-    and (not datadog_before_7180)
+    and (not datadog_before_7400)
 
 - name: Ensure datadog-agent is running
   service:

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -22,6 +22,17 @@ network_config:
 {% endfilter %}
 {% endif %}
 
+{% if service_monitoring_config is defined and service_monitoring_config | default({}, true) | length > 0 -%}
+service_monitoring_config:
+{# The "first" option in indent() is only supported by jinja 2.10+
+  while the old equivalent option "indentfirst" is removed in jinja 3.
+  Using non-keyword argument in indent() to be backward compatible.
+#}
+{% filter indent(2, True) %}
+{{ service_monitoring_config | to_nice_yaml }}
+{% endfilter %}
+{% endif %}
+
 {% if runtime_security_config is defined and runtime_security_config | default({}, true) | length > 0 -%}
 runtime_security_config:
 {# The "first" option in indent() is only supported by jinja 2.10+


### PR DESCRIPTION
Closes: #457

As mentioned in #457, the Ansible stack doesn't currently support adding a `service_monitoring_config` into `system-probe.yaml` so this PR is an attempt to add that.

I'm very much pattern matching here so I wanted to open a PR with what I have currently to get some feedback: Mainly I'm unsure about some of the v6 CI pipelines which have configuration for v7 features.

I figure that is probably intentional to assert that v6 agents don't use v7 features?

Anyway, let me know if this is usable 🙂 