### PR TITLE
Fix CI by pinning proper Agent 5 version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
       - run: bash -c '[ -f /etc/datadog-agent/datadog.yaml.example ] || [ -f /etc/dd-agent/datadog.conf.example ]'
       - run: bash -c '[ ! -f /etc/datadog-agent/datadog.yaml ] && [ ! -f /etc/datadog-agent/system-probe.yaml ] && [ ! -f /etc/datadog-agent/security-agent.yaml ] && [ ! -f /etc/dd-agent/datadog.conf ]'
 
-  downgrade_agent_5_32_9:
+  downgrade_agent_5_32:
     parameters:
       python:
         type: string
@@ -78,7 +78,7 @@ commands:
             - install_agent:
                 version: "<<parameters.version>>"
                 python: "<<parameters.python>>"
-      - downgrade_agent_5_32_9:
+      - downgrade_agent_5_32:
           python: "<<parameters.python>>"
 
   test_agent_install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,7 @@ commands:
       - run: bash -c '[ -f /etc/datadog-agent/datadog.yaml.example ] || [ -f /etc/dd-agent/datadog.conf.example ]'
       - run: bash -c '[ ! -f /etc/datadog-agent/datadog.yaml ] && [ ! -f /etc/datadog-agent/system-probe.yaml ] && [ ! -f /etc/datadog-agent/security-agent.yaml ] && [ ! -f /etc/dd-agent/datadog.conf ]'
 
-  downgrade_agent_5_23_0:
+  downgrade_agent_5_32_9:
     parameters:
       python:
         type: string
@@ -78,7 +78,7 @@ commands:
             - install_agent:
                 version: "<<parameters.version>>"
                 python: "<<parameters.python>>"
-      - downgrade_agent_5_23_0:
+      - downgrade_agent_5_32_9:
           python: "<<parameters.python>>"
 
   test_agent_install:

--- a/ci_test/downgrade_to_5.yaml
+++ b/ci_test/downgrade_to_5.yaml
@@ -6,7 +6,7 @@
   vars:
     datadog_api_key: "11111111111111111111111111111111"
     datadog_agent_major_version: 5
-    datadog_agent_version: 1:5.32.9-1
+    datadog_agent_version: "{{ '1:5.32.9-1' if ansible_facts.os_family in ['RedHat', 'Rocky', 'AlmaLinux'] else '1:5.32.8-1' }}"
     datadog_agent_allow_downgrade: yes
     datadog_config:
       tags: "mytag0, mytag1"

--- a/ci_test/downgrade_to_5.yaml
+++ b/ci_test/downgrade_to_5.yaml
@@ -6,7 +6,7 @@
   vars:
     datadog_api_key: "11111111111111111111111111111111"
     datadog_agent_major_version: 5
-    datadog_agent_version: 1:5.23.0-1
+    datadog_agent_version: 1:5.32.9-1
     datadog_agent_allow_downgrade: yes
     datadog_config:
       tags: "mytag0, mytag1"


### PR DESCRIPTION
We pin 5.32.9 on RHEL-like systems, but we use 5.32.8 everywhere else.