### PR TITLE
Import RPM keys directly from URL

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -25,39 +25,21 @@
         ) else 'yes'
       ) }}
 
-- name: Download current RPM key
-  get_url:
-    url: "{{ datadog_yum_gpgkey_current }}"
-    dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
-    force: yes
-
 - name: Import current RPM key
   rpm_key:
-    key: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    key: "{{ datadog_yum_gpgkey_current }}"
     state: present
   when: not ansible_check_mode
-
-- name: Download new RPM key (Expires in 2022)
-  get_url:
-    url: "{{ datadog_yum_gpgkey_e09422b3 }}"
-    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
-    checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
 
 - name: Import new RPM key (Expires in 2022)
   rpm_key:
-    key: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    key: "{{ datadog_yum_gpgkey_e09422b3 }}"
     state: present
   when: not ansible_check_mode
 
-- name: Download new RPM key (Expires in 2024)
-  get_url:
-    url: "{{ datadog_yum_gpgkey_20200908 }}"
-    dest: /tmp/DATADOG_RPM_KEY_20200908.public
-    checksum: "sha256:{{ datadog_yum_gpgkey_20200908_sha256sum }}"
-
 - name: Import new RPM key (Expires in 2024)
   rpm_key:
-    key: /tmp/DATADOG_RPM_KEY_20200908.public
+    key: "{{ datadog_yum_gpgkey_20200908 }}"
     state: present
   when: not ansible_check_mode
   


### PR DESCRIPTION
Forced downloads to `/tmp/` are not idempotent.

Closes #474.