### PR TITLE
Redhat : Refresh Datadog repository cache

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -146,7 +146,9 @@
     warn: no
   when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
-# On certain version of dnf, gpg keys aren't imported into the local db. This rule assure that they are correctly imported into the local db.
+# On certain version of dnf, gpg keys aren't imported into the local db with the package install task.
+# This rule assures that they are correctly imported into the local db and users won't have to manually accept
+# them if running dnf commands on the hosts.
 - name: Refresh Datadog repository cache # noqa 503
   command: yum -y makecache --disablerepo="*" --enablerepo=datadog
   failed_when: false

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -146,6 +146,10 @@
     warn: no
   when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
+- name: Refresh Datadog repository cache
+  command: yum -y makecache --disablerepo="*" --enablerepo=datadog
+  when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
+
 - name: Remove old yum repo files
   yum_repository:
     name: "ansible_datadog_{{ item }}"

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -146,7 +146,7 @@
     warn: no
   when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
-- name: Refresh Datadog repository cache
+- name: Refresh Datadog repository cache # noqa 503
   command: yum -y makecache --disablerepo="*" --enablerepo=datadog
   failed_when: false
   args:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -146,6 +146,7 @@
     warn: no
   when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
+# On certain version of dnf, gpg keys aren't imported into the local db. This rule assure that they are correctly imported into the local db.
 - name: Refresh Datadog repository cache # noqa 503
   command: yum -y makecache --disablerepo="*" --enablerepo=datadog
   failed_when: false

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -148,6 +148,9 @@
 
 - name: Refresh Datadog repository cache
   command: yum -y makecache --disablerepo="*" --enablerepo=datadog
+  failed_when: false
+  args:
+    warn: no
   when: repofile5.changed or repofile6.changed or repofile7.changed or repofilecustom.changed
 
 - name: Remove old yum repo files


### PR DESCRIPTION
Fix a support issue by ensuring that dnf keys are imported into the local db.