### PR TITLE
Refactor integration-related tasks

### DIFF
--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -17,5 +17,5 @@
   when: ansible_facts.os_family == "Darwin"
 
 - name: Include Linux Integration Tasks
-  include_tasks: integration/macos.yml
+  include_tasks: integration/linux.yml
   when: ansible_facts.os_family != "Darwin" and ansible_facts.os_family != "Windows"

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -1,86 +1,21 @@
 ---
-- name: set agent binary path (windows)
-  set_fact:
-    datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
-  when: ansible_facts.os_family == "Windows"
-
-- name: set agent binary path (unix)
-  set_fact:
-    datadog_agent_binary_path: "{{ datadog_agent_binary_path_linux }}"
-  when: ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
-
-- name: set agent binary path (macOS)
-  set_fact:
-    datadog_agent_binary_path: "{{ datadog_agent_binary_path_macos }}"
-  when: ansible_facts.os_family == "Darwin"
-
-- name: set agent user for integration commmand (windows)
-  set_fact:
-    integration_command_user: "{{ integration_command_user_windows }}"
-  when: ansible_facts.os_family == "Windows"
-
-- name: set agent user for integration commmand (unix)
-  set_fact:
-    integration_command_user: "{{ integration_command_user_linux }}"
-  when: ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
-
-- name: set agent user for integration commmand (macOS)
-  set_fact:
-    integration_command_user: "{{ integration_command_user_macos }}"
-  when: ansible_facts.os_family == "Darwin"
-
 - name: Validate integrations actions
   fail:
     msg: "Unkown action '{{ item.value.action }}' for integration command ({{ item.key }}). Valid actions are 'install' and 'remove'"
   when: item.value.action != "install" and item.value.action != "remove"
   loop: "{{ datadog_integration|dict2items }}"
 
-# Remove Integrations
+# The Windows tasks use win_command, so if users don't have the "ansible.windows" collection
+# installed, parsing the task would fail even if the host is not Windows. By hiding the task
+# inside a conditionally included file, we can prevent this.
+- name: Include Windows Integration Tasks
+  include_tasks: integration/windows.yml
+  when: ansible_facts.os_family == "Windows"
 
-- name: Removing integrations (Unix, macOS)
-  command:
-    argv:
-      - "{{ datadog_agent_binary_path }}"
-      - integration
-      - remove
-      - "{{ item.key }}"
-  become: yes
-  become_user: "{{ integration_command_user }}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove" and ansible_facts.os_family != "Windows"
+- name: Include macOS Integration Tasks
+  include_tasks: integration/macos.yml
+  when: ansible_facts.os_family == "Darwin"
 
-- name: Removing integrations (Windows)
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
-  become: yes
-  become_user: "{{ integration_command_user }}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove" and ansible_facts.os_family == "Windows"
-
-# Install integrations
-
-- name: Install pinned version of integrations (Unix)
-  command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
-  become_user: "{{ integration_command_user }}"
-  vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
-
-- name: Install pinned version of integrations (Windows)
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
-  vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
-  become_user: "{{ integration_command_user }}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_facts.os_family == "Windows"
-
-- name: Install pinned version of integrations (macOS)
-  command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
-  become_user: "{{ integration_command_user }}"
-  vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_facts.os_family == "Darwin"
+- name: Include Linux Integration Tasks
+  include_tasks: integration/macos.yml
+  when: ansible_facts.os_family != "Darwin" and ansible_facts.os_family != "Windows"

--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -1,0 +1,24 @@
+# Remove integrations
+
+- name: Removing integrations
+  command:
+    argv:
+      - "{{ datadog_agent_binary_path }}"
+      - integration
+      - remove
+      - "{{ item.key }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "remove"
+
+# Install integrations
+
+- name: Installing pinned version of integrations
+  command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  vars:
+    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "install"

--- a/tasks/integration/linux.yml
+++ b/tasks/integration/linux.yml
@@ -1,0 +1,11 @@
+---
+- name: Set Agent binary path
+  set_fact:
+    datadog_agent_binary_path: "{{ datadog_agent_binary_path_linux }}"
+
+- name: Set Agent user for integration commmand
+  set_fact:
+    integration_command_user: "{{ integration_command_user_linux }}"
+
+- name: Include shared integration installation and removal tasks
+  include_tasks: integration/_linux-macos-shared.yml

--- a/tasks/integration/macos.yml
+++ b/tasks/integration/macos.yml
@@ -1,0 +1,11 @@
+---
+- name: Set Agent binary path
+  set_fact:
+    datadog_agent_binary_path: "{{ datadog_agent_binary_path_macos }}"
+
+- name: Set Agent user for integration commmand
+  set_fact:
+    integration_command_user: "{{ integration_command_user_macos }}"
+
+- name: Include shared integration installation and removal tasks
+  include_tasks: integration/_linux-macos-shared.yml

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -2,12 +2,10 @@
 - name: Set Agent binary path
   set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
-  when: ansible_facts.os_family == "Windows"
 
 - name: Set Agent user for integration commmand
   set_fact:
     integration_command_user: "{{ integration_command_user_windows }}"
-  when: ansible_facts.os_family == "Windows"
 
 # Remove integrations
 - name: Removing integrations

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -15,7 +15,7 @@
   become: yes
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove" and ansible_facts.os_family == "Windows"
+  when: item.value.action == "remove"
 
 # Install integrations
 - name: Installing pinned version of integrations
@@ -25,4 +25,4 @@
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   become_user: "{{ integration_command_user }}"
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install" and ansible_facts.os_family == "Windows"
+  when: item.value.action == "install"

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -1,0 +1,28 @@
+---
+- name: Set Agent binary path
+  set_fact:
+    datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
+  when: ansible_facts.os_family == "Windows"
+
+- name: Set Agent user for integration commmand
+  set_fact:
+    integration_command_user: "{{ integration_command_user_windows }}"
+  when: ansible_facts.os_family == "Windows"
+
+# Remove integrations
+- name: Removing integrations
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "remove" and ansible_facts.os_family == "Windows"
+
+# Install integrations
+- name: Installing pinned version of integrations
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
+  become: yes
+  vars:
+    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
+  become_user: "{{ integration_command_user }}"
+  loop: "{{ datadog_integration|dict2items }}"
+  when: item.value.action == "install" and ansible_facts.os_family == "Windows"


### PR DESCRIPTION
This change makes the code tidier and user-facing messages prettier. It also ensures that Windows tasks will only be imported on Windows, thus making the ansible.windows collection optional.

This fixes #450.