### PR TITLE
Modify integration updates task to prevent always changed status

### DIFF
--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -1,6 +1,20 @@
+# Check current state of the integrations
+
+- name: Check {{ item.key }} integration state
+  command:
+    argv:
+      - "{{ datadog_agent_binary_path }}"
+      - integration
+      - show
+      - -q
+      - "{{ item.key }}"
+  register: integration_version
+  failed_when: false # This task is supposed to fail when the integration is not installed
+  changed_when: false
+
 # Remove integrations
 
-- name: Removing integrations
+- name: Removing {{ item.key }} integration
   command:
     argv:
       - "{{ datadog_agent_binary_path }}"
@@ -9,16 +23,18 @@
       - "{{ item.key }}"
   become: yes
   become_user: "{{ integration_command_user }}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove"
+  when: 
+    - item.value.action == "remove"
+    - integration_version.stdout != ""
 
 # Install integrations
 
-- name: Installing pinned version of integrations
+- name: Installing pinned version of {{ item.key }} integration
   command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: yes
   become_user: "{{ integration_command_user }}"
   vars:
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install"
+  when:
+    - item.value.action == "install"
+    - integration_version.stdout | trim != item.value.version

--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -25,7 +25,7 @@
   become_user: "{{ integration_command_user }}"
   when: 
     - item.value.action == "remove"
-    - integration_version.stdout != ""
+    - integration_version.stdout | length > 0
 
 # Install integrations
 

--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -1,6 +1,6 @@
 # Check current state of the integration
 
-- name: Check {{ item.key }} integration state
+- name: Check integration state, integration={{ item.key }}
   command:
     argv:
       - "{{ datadog_agent_binary_path }}"
@@ -14,27 +14,29 @@
 
 # Remove integration
 
-- name: Removing {{ item.key }} integration
+- name: Removing integration, integration={{ item.key }}
   command:
     argv:
       - "{{ datadog_agent_binary_path }}"
       - integration
       - remove
       - "{{ item.key }}"
-  become: yes
+  become: true
   become_user: "{{ integration_command_user }}"
-  when: 
+  when:
     - item.value.action == "remove"
-    - integration_version.stdout | length > 0
+    - integration_version.rc == 0
+  changed_when: true
 
 # Install integration
 
-- name: Installing pinned version of {{ item.key }} integration
+- name: Installing pinned version of integration, integration={{ item.key }}
   command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
+  become: true
   become_user: "{{ integration_command_user }}"
   vars:
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   when:
     - item.value.action == "install"
     - integration_version.stdout | trim != item.value.version
+  changed_when: true

--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -1,4 +1,4 @@
-# Check current state of the integrations
+# Check current state of the integration
 
 - name: Check {{ item.key }} integration state
   command:
@@ -12,7 +12,7 @@
   failed_when: false # This task is supposed to fail when the integration is not installed
   changed_when: false
 
-# Remove integrations
+# Remove integration
 
 - name: Removing {{ item.key }} integration
   command:
@@ -27,7 +27,7 @@
     - item.value.action == "remove"
     - integration_version.stdout | length > 0
 
-# Install integrations
+# Install integration
 
 - name: Installing pinned version of {{ item.key }} integration
   command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"

--- a/tasks/integration/_windows-integration-update.yml
+++ b/tasks/integration/_windows-integration-update.yml
@@ -1,4 +1,4 @@
-# Check integration state
+# Check current state of the integrations
 
 - name: Check {{ item.key }} integration state
   win_command: "\"{{ datadog_agent_binary_path }}\" integration show -q {{ item.key }}"

--- a/tasks/integration/_windows-integration-update.yml
+++ b/tasks/integration/_windows-integration-update.yml
@@ -14,7 +14,7 @@
   become_user: "{{ integration_command_user }}"
   when: 
     - item.value.action == "remove"
-    - integration_version.stdout != ""
+    - integration_version.stdout | length > 0 
 
 # Install integration
 

--- a/tasks/integration/_windows-integration-update.yml
+++ b/tasks/integration/_windows-integration-update.yml
@@ -1,29 +1,31 @@
 # Check current state of the integrations
 
-- name: Check {{ item.key }} integration state
+- name: Check integration state, integration={{ item.key }}
   win_command: "\"{{ datadog_agent_binary_path }}\" integration show -q {{ item.key }}"
-  register: integration_version 
+  register: integration_version
   failed_when: false # This task is supposed to fail when the integration is not installed
   changed_when: false
-  
+
 # Remove integration
 
-- name: Removing {{ item.key }} integration 
+- name: Removing integration, integration={{ item.key }}
   win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
-  become: yes
+  become: true
   become_user: "{{ integration_command_user }}"
-  when: 
+  when:
     - item.value.action == "remove"
-    - integration_version.stdout | length > 0 
+    - integration_version.rc == 0
+  changed_when: true
 
 # Install integration
 
-- name: Installing pinned version of {{ item.key }} integration 
+- name: Installing pinned version of integration, integration={{ item.key }}
   win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
+  become: true
   vars:
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
   become_user: "{{ integration_command_user }}"
-  when: 
+  when:
     - item.value.action == "install"
     - integration_version.stdout | trim != item.value.version
+  changed_when: true

--- a/tasks/integration/_windows-integration-update.yml
+++ b/tasks/integration/_windows-integration-update.yml
@@ -1,0 +1,29 @@
+# Check integration state
+
+- name: Check {{ item.key }} integration state
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration show -q {{ item.key }}"
+  register: integration_version 
+  failed_when: false # This task is supposed to fail when the integration is not installed
+  changed_when: false
+  
+# Remove integration
+
+- name: Removing {{ item.key }} integration 
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
+  become: yes
+  become_user: "{{ integration_command_user }}"
+  when: 
+    - item.value.action == "remove"
+    - integration_version.stdout != ""
+
+# Install integration
+
+- name: Installing pinned version of {{ item.key }} integration 
+  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
+  become: yes
+  vars:
+    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
+  become_user: "{{ integration_command_user }}"
+  when: 
+    - item.value.action == "install"
+    - integration_version.stdout | trim != item.value.version

--- a/tasks/integration/linux.yml
+++ b/tasks/integration/linux.yml
@@ -9,4 +9,4 @@
 
 - name: Include shared integration installation and removal tasks
   include_tasks: integration/_linux-macos-shared.yml
-  loop: "{{ datadog_integration|dict2items }}"
+  loop: "{{ datadog_integration | dict2items }}"

--- a/tasks/integration/linux.yml
+++ b/tasks/integration/linux.yml
@@ -9,3 +9,4 @@
 
 - name: Include shared integration installation and removal tasks
   include_tasks: integration/_linux-macos-shared.yml
+  loop: "{{ datadog_integration|dict2items }}"

--- a/tasks/integration/macos.yml
+++ b/tasks/integration/macos.yml
@@ -9,4 +9,4 @@
 
 - name: Include shared integration installation and removal tasks
   include_tasks: integration/_linux-macos-shared.yml
-  loop: "{{ datadog_integration|dict2items }}"
+  loop: "{{ datadog_integration | dict2items }}"

--- a/tasks/integration/macos.yml
+++ b/tasks/integration/macos.yml
@@ -9,3 +9,4 @@
 
 - name: Include shared integration installation and removal tasks
   include_tasks: integration/_linux-macos-shared.yml
+  loop: "{{ datadog_integration|dict2items }}"

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -7,20 +7,7 @@
   set_fact:
     integration_command_user: "{{ integration_command_user_windows }}"
 
-# Remove integrations
-- name: Removing integrations
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
-  become: yes
-  become_user: "{{ integration_command_user }}"
+- name: Include integration installation and removal tasks
+  include_tasks: integration/_windows-integration-update.yml
   loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "remove"
 
-# Install integrations
-- name: Installing pinned version of integrations
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
-  become: yes
-  vars:
-    third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"
-  become_user: "{{ integration_command_user }}"
-  loop: "{{ datadog_integration|dict2items }}"
-  when: item.value.action == "install"

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -9,5 +9,4 @@
 
 - name: Include integration installation and removal tasks
   include_tasks: integration/_windows-integration-update.yml
-  loop: "{{ datadog_integration|dict2items }}"
-
+  loop: "{{ datadog_integration | dict2items }}"


### PR DESCRIPTION
Tasks responsible for installing or removing Datadog integrations always reported changed even if the integration was already up to date or already removed. 
Now the task will not have a "changed" status if the integration is already installed with the correct version or if it is already removed.

Tested on Ubuntu and Windows, works as expected

