### PR TITLE
AP-1597 Add noqa args[module] to task using args.warn

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -104,7 +104,7 @@
   register: repofilecustom
   when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
 
-- name: Clean repo metadata if repo changed # noqa no-handler
+- name: Clean repo metadata if repo changed # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
   command: yum clean metadata --disablerepo="*" --enablerepo=datadog
   failed_when: false # Cleaning the metadata is only needed when downgrading a major version of the Agent, don't fail because of this
   args:
@@ -115,7 +115,7 @@
 # On certain version of dnf, gpg keys aren't imported into the local db with the package install task.
 # This rule assures that they are correctly imported into the local db and users won't have to manually accept
 # them if running dnf commands on the hosts.
-- name: Refresh Datadog repository cache # noqa no-handler
+- name: Refresh Datadog repository cache # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
   command: yum -y makecache --disablerepo="*" --enablerepo=datadog
   failed_when: false
   args:

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -103,7 +103,7 @@
   when: datadog_manage_zypper_repofile
 
 # refresh zypper repos only if the template changed
-- name: Refresh Datadog zypper_repos # noqa no-handler
+- name: Refresh Datadog zypper_repos # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
   command: zypper refresh datadog
   when: datadog_zypper_repo_template.changed and not ansible_check_mode
   args:


### PR DESCRIPTION
Using args.warn: false in `command` module creates a warning because it deprecated wince Ansible 2.11. We just ignore the rule because we do not want customers using ansible < 2.11 to have new warnings when updating the role.