### PR TITLE
 Add executable args to work with set -o pipefail

### DIFF
--- a/tasks/_apt-key-import.yml
+++ b/tasks/_apt-key-import.yml
@@ -25,10 +25,12 @@
     agent_keyring_url: "{{ item.value }}"
 
 - name: Find out whether key is already imported, key = {{ agent_key_fingerprint }}
-  shell: >
-    set -o pipefail &&
-    gpg --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }}
-    --list-keys --with-fingerprint --with-colons | grep {{ agent_key_fingerprint }}
+  shell:
+    cmd: >
+      set -o pipefail &&
+      gpg --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }}
+      --list-keys --with-fingerprint --with-colons | grep {{ agent_key_fingerprint }}
+    executable: /bin/bash
   register: agent_key_exists_result
   failed_when: false # we expect the command to fail when the key is not found; we never want this task to fail
   changed_when: agent_key_exists_result.rc != 0

--- a/tasks/agent-macos.yml
+++ b/tasks/agent-macos.yml
@@ -22,6 +22,7 @@
 - name: Load user group data
   shell:
     cmd: "set -o pipefail && dscacheutil -q group -a gid {{ agent_macos_user_data.gid }} | grep '^name: ' | awk '{ print $2 }'"
+    executable: /bin/bash
   register: agent_macos_user_group
   changed_when: false
 

--- a/tasks/parse-version-macos.yml
+++ b/tasks/parse-version-macos.yml
@@ -1,6 +1,8 @@
 ---
 - name: Get macOS Agent version
-  shell: set -o pipefail && {{ datadog_agent_binary_path_macos }} version | grep 'Agent ' | awk '{print $2}'
+  shell:
+    cmd: set -o pipefail && {{ datadog_agent_binary_path_macos }} version | grep 'Agent ' | awk '{print $2}'
+    executable: /bin/bash
   register: agent_datadog_version_check_macos
   changed_when: false
   failed_when: false


### PR DESCRIPTION
set -o pipefail was always failing on some OS, because we need to specify the shell used.