### PR TITLE
Improve conditions for APM scripts dry-run flags

### DIFF
--- a/tasks/apm-inject-install.yml
+++ b/tasks/apm-inject-install.yml
@@ -11,18 +11,20 @@
   command: dd-host-install --no-config-change --no-agent-restart --dry-run
   register: agent_dd_host_install_cmd
   changed_when: false
+  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"]
   failed_when: agent_dd_host_install_cmd.rc >= 2
 
 - name: Run APM host injection setup script
   command: dd-host-install --no-config-change --no-agent-restart
   notify: restart datadog-agent
-  when: not ansible_check_mode and agent_dd_host_install_cmd.rc == 1 and datadog_apm_instrumentation_enabled in ["all", "host"]
+  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"] and agent_dd_host_install_cmd.rc == 1
   changed_when: true
 
 - name: Check if dd-container-install needs to run
   command: dd-container-install --dry-run
   register: agent_dd_container_install_cmd
   changed_when: false
+  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"]
   failed_when: agent_dd_container_install_cmd.rc >= 2
 
 - name: Create Docker APM injection config file
@@ -37,5 +39,5 @@
 - name: Run APM host-docker injection (Docker) setup script
   # this command will change /etc/docker/daemon.json and reload docker if changes are made.
   command: dd-container-install
-  when: not ansible_check_mode and agent_dd_container_install_cmd.rc == 1 and datadog_apm_instrumentation_enabled in ["all", "docker"]
+  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"] and agent_dd_container_install_cmd.rc == 1
   changed_when: true


### PR DESCRIPTION
We only need to run them when the specific instrumentation type (host/docker) is enabled because otherwise they'll be always run even if they're not necessary.