### PR TITLE
Properly set agent_win_install_args in all cases

### DIFF
--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -3,6 +3,10 @@
   set_fact:
     agent_datadog_windows_config_root: "{{ datadog_windows_config_root }}"
 
+- name: Initialize internal agent_win_install_args variable
+  set_fact:
+    agent_win_install_args: "{{ win_install_args }}"
+
 - name: Set DD Username Arg
   set_fact:
     agent_win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
@@ -80,10 +84,6 @@
   set_fact:
     agent_datadog_windows_config_root: "{{ agent_config_root_from_registry.value | regex_replace('\\\\$', '') }}"
   when: agent_config_root_from_registry.exists
-
-- name: Set Test
-  set_fact:
-    agent_win_install_args: "{{ agent_win_install_args }}"
 
 # Add the installation arguments to install Windows NPM.
 - name: Set Windows NPM flag


### PR DESCRIPTION
### What does this PR do?

Initializes `agent_win_install_args` to `win_install_args` in all cases.

Removes useless line that sets `agent_win_install_args` to itself.

### Motivation

`agent_win_install_args` is used in `pkg-windows.yml` and `pkg-windows-opts.yml`. It is supposed to be set in `pkg-windows-opts.yml`, but all tasks that set it do it only under certain conditions.

On a default install, the role crashes with:
```
{"msg": "The task includes an option with an undefined variable. The error was: 'agent_win_install_args' is undefined. 'agent_win_install_args' is undefined\n\nThe error appears to be in '/Users/kylian.serrania/.ansible/collections/ansible_collections/datadog/dd/roles/agent/tasks/pkg-windows-opts.yml': line 84, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set Test\n  ^ here\n"}
```