### PR TITLE
Use agent_datadog_agent_windows_version instead of datadog_agent_windows_version

### DIFF
--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -18,11 +18,11 @@
 
 - name: Include Windows agent latest version install tasks
   include_tasks: win_agent_latest.yml
-  when: (not agent_datadog_skip_install) and (datadog_agent_windows_version is not defined)
+  when: (not agent_datadog_skip_install) and (agent_datadog_agent_windows_version is not defined)
 
 - name: Include Windows agent pinned version install tasks
   include_tasks: win_agent_version.yml
-  when: (not agent_datadog_skip_install) and (datadog_agent_windows_version is defined)
+  when: (not agent_datadog_skip_install) and (agent_datadog_agent_windows_version is defined)
 
 - name: Show URL var
   debug:


### PR DESCRIPTION
### What does this PR do?

Updates the `win_agent_latest.yml` / `win_agent_version.yml` inclusion tasks to use `agent_datadog_agent_windows_version`.

### Motivation

`datadog_agent_windows_version` doesn't exist anymore, the latest version of the Agent was always installed.