### PR TITLE
Revert "Import RPM keys directly from URL"

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -28,7 +28,8 @@
   get_url:
     url: "{{ datadog_yum_gpgkey_current }}"
     dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
-    force: yes
+    mode: 600
+    force: true
 
 - name: Import current RPM key
   rpm_key:
@@ -40,6 +41,7 @@
   get_url:
     url: "{{ datadog_yum_gpgkey_e09422b3 }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    mode: 600
     checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
 
 - name: Import new RPM key (Expires in 2022)
@@ -52,6 +54,7 @@
   get_url:
     url: "{{ datadog_yum_gpgkey_20200908 }}"
     dest: /tmp/DATADOG_RPM_KEY_20200908.public
+    mode: 600
     checksum: "sha256:{{ datadog_yum_gpgkey_20200908_sha256sum }}"
 
 - name: Import new RPM key (Expires in 2024)
@@ -60,9 +63,16 @@
     state: present
   when: not ansible_check_mode
 
+- name: Download new RPM key (Expires in 2028)
+  get_url:
+    url: "{{ datadog_yum_gpgkey_20280418 }}"
+    dest: /tmp/DATADOG_RPM_KEY_20280418.public
+    mode: 600
+    checksum: "sha256:{{ datadog_yum_gpgkey_20280418_sha256sum }}"
+
 - name: Import new RPM key (Expires in 2028)
   rpm_key:
-    key: "{{ datadog_yum_gpgkey_20280418 }}"
+    key: /tmp/DATADOG_RPM_KEY_20280418.public
     state: present
   when: not ansible_check_mode
 

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -24,21 +24,39 @@
         ) else 'yes'
       ) }}
 
+- name: Download current RPM key
+  get_url:
+    url: "{{ datadog_yum_gpgkey_current }}"
+    dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
+    force: yes
+
 - name: Import current RPM key
   rpm_key:
-    key: "{{ datadog_yum_gpgkey_current }}"
+    key: /tmp/DATADOG_RPM_KEY_CURRENT.public
     state: present
   when: not ansible_check_mode
+
+- name: Download new RPM key (Expires in 2022)
+  get_url:
+    url: "{{ datadog_yum_gpgkey_e09422b3 }}"
+    dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
+    checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
 
 - name: Import new RPM key (Expires in 2022)
   rpm_key:
-    key: "{{ datadog_yum_gpgkey_e09422b3 }}"
+    key: /tmp/DATADOG_RPM_KEY_E09422B3.public
     state: present
   when: not ansible_check_mode
 
+- name: Download new RPM key (Expires in 2024)
+  get_url:
+    url: "{{ datadog_yum_gpgkey_20200908 }}"
+    dest: /tmp/DATADOG_RPM_KEY_20200908.public
+    checksum: "sha256:{{ datadog_yum_gpgkey_20200908_sha256sum }}"
+
 - name: Import new RPM key (Expires in 2024)
   rpm_key:
-    key: "{{ datadog_yum_gpgkey_20200908 }}"
+    key: /tmp/DATADOG_RPM_KEY_20200908.public
     state: present
   when: not ansible_check_mode
 


### PR DESCRIPTION
Reverts DataDog/ansible-datadog#475 because this change would break the role if customers use `datadog_yum_gpgkey_*` with path to local file system (`file:///....`) As `rpm_key` module does not work with `file://` prefix