### PR TITLE
Hard fail if api_key is not provided

### DIFF
--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -7,7 +7,7 @@
 {% endif %}
 
 {% if agent_datadog_config["api_key"] is not defined -%}
-  api_key: {{ datadog_api_key | default('youshouldsetthis') }}
+  api_key: {{ datadog_api_key }}
 {% endif %}
 
 {% if agent_datadog_config["use_mount"] is not defined -%}

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -11,7 +11,7 @@ dd_url: {{ datadog_url }}
 {% endif %}
 
 {% if agent_datadog_config["api_key"] is not defined -%}
-api_key: {{ datadog_api_key | default('youshouldsetthis') }}
+api_key: {{ datadog_api_key }}
 {% endif %}
 
 {% if agent_datadog_config | default({}, true) | length > 0 -%}


### PR DESCRIPTION

datadog.conf and datadog.yaml role has below line which sets a invalid default value for api_key. If agent_datadog_config["api_key"] or datadog_api_key vars are not provided then api_key in the datadog has 'youshouldsetthis' which fails to start datadog agent. Setting default here actual installs datadog but fails to start the agent until user notices.

{% if agent_datadog_config["api_key"] is not defined -%}
api_key: {{ datadog_api_key | default('youshouldsetthis') }}
{% endif %}
Its better to hard fail while the role is being executed so that the user will provide necessary mandator variables.


ref: https://github.com/DataDog/ansible-datadog/issues/504