### PR TITLE
Enable Empty-string-compare rule

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,3 +2,6 @@
 # We ignore the FQCN rule on the role repository since FQCN is not compatible with older version of Ansible (Ansible =< 2.9)
 skip_list:
   - fqcn
+
+enable_list:
+  - empty-string-compare

--- a/ci_test/collection-structure-setup.sh
+++ b/ci_test/collection-structure-setup.sh
@@ -3,7 +3,7 @@
 pip install ansible-lint==6.17 galaxy-importer
 
 # lint the ansible-role alone
-ansible-lint -v --profile=production --exclude=galaxy.yml --exclude=meta/ --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/
+ansible-lint -v --exclude=galaxy.yml --exclude=meta/ --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/
 
 mkdir ansible_collections
 cd ansible_collections
@@ -23,4 +23,4 @@ done
 cd ansible_collections/datadog/dd/
 
 ls -la roles/agent/
-ansible-lint -v --profile=production --exclude=galaxy.yml --exclude=meta/
+ansible-lint -v --exclude=galaxy.yml --exclude=meta/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Check and resolve APM injection settings
   include_tasks: apm-inject-check.yml
-  when: datadog_apm_instrumentation_enabled != ""
+  when: datadog_apm_instrumentation_enabled | length > 0
 
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml
@@ -80,4 +80,4 @@
 
 - name: APM Host injection tasks
   include_tasks: apm-inject-install.yml
-  when: datadog_apm_instrumentation_enabled != ""
+  when: datadog_apm_instrumentation_enabled | length > 0


### PR DESCRIPTION
 Enable the empty-string-compare rule which is disabled by default on recent version of ansible-lint. 
To comply with ansible galaxy-importer linter

Removed `--profile production` from the ansible-lint command, otherwile it does not include opt-int rules included. Should not be a problem since by default it will run on all the profiles.