### PR TITLE
[Windows] Force reinstall if configuration changed [AP-1946]

### DIFF
--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -110,3 +110,16 @@
   set_fact:
     agent_win_install_args: "{{ agent_win_install_args }} ADDLOCAL=MainApplication,NPM"
   when: agent_datadog_sysprobe_enabled
+
+# Check for potential config changes that require a reinstall:
+- name: Check NPM config change
+  set_fact:
+    agent_datadog_skip_install: false
+    agent_datadog_force_reinstall: true
+  # Starting from agent 7.45 the NPM driver is installed by default and gets
+  # reported as such regardless of the provided parameters. Since we don't
+  # want to force the install for nothing in those version, we skip the step
+  # when the agent is 7.45+
+  when: >-
+    (agent_datadog_skip_install and (agent_datadog_major | int <= 7) and (agent_datadog_minor | int < 45)) and
+    (("NPM" in datadog_windows_agent_active_config.stdout_lines) != agent_datadog_sysprobe_enabled)

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -48,7 +48,7 @@
     name: InstallPath
   register: agent_install_path_from_registry
 
-## validate the config path.  Only necessary if it's set in the registry alread (i.e. upgrade)
+## validate the config path.  Only necessary if it's set in the registry already (i.e. upgrade)
 ## Will fail the install if the caller has set the config root to a non-standard root, and that
 ## root is different than what's already present.
 - name: Validate config path

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -12,6 +12,22 @@
     agent_win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
   when: datadog_windows_ddagentuser_name | default('', true) | length > 0
 
+- name: Get Windows Agent config
+  win_shell: |
+    $installer = new-object -comobject WindowsInstaller.Installer
+    $agent_item = (Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*" -EA 0 | Where { $_.DisplayName -like "Datadog Agent*" }).PSChildName
+    if (!$agent_item) {
+      return
+    }
+    $features = $installer.features($agent_item)
+    ForEach ($f in $features) {
+      if (($f -ieq 'MainApplication') -or ($installer.FeatureState($agent_item, $f) -ne 3)) {
+        continue
+      }
+      Write-Host $f
+    }
+  register: datadog_windows_agent_active_config
+
 # NOTE: We don't set DD Password Arg here to prevent it from being printed;
 # we set it right before using agent_win_install_args
 

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -3,6 +3,10 @@
   set_fact:
     agent_datadog_windows_config_root: "{{ datadog_windows_config_root }}"
 
+- name: Initialize force reinstall value
+  set_fact:
+    agent_datadog_force_reinstall: false
+
 - name: Initialize internal agent_win_install_args variable
   set_fact:
     agent_win_install_args: "{{ win_install_args }}"

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -16,7 +16,7 @@
     agent_win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
   when: datadog_windows_ddagentuser_name | default('', true) | length > 0
 
-- name: Get Windows Agent config
+- name: Get Windows Agent features
   win_shell: |
     $installer = new-object -comobject WindowsInstaller.Installer
     $uninstall_key = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
@@ -31,7 +31,7 @@
       }
       Write-Host $f
     }
-  register: agent_windows_active_config
+  register: agent_windows_active_features
 
 # NOTE: We don't set DD Password Arg here to prevent it from being printed;
 # we set it right before using agent_win_install_args
@@ -113,14 +113,16 @@
   when: agent_datadog_sysprobe_enabled
 
 # Check for potential config changes that require a reinstall:
-- name: Check NPM config change
+- name: Check NPM feature change
   set_fact:
     agent_datadog_skip_install: false
     agent_datadog_force_reinstall: true
+  debug:
+    msg: "Forcing a reinstallation since enabled features have changed"
   # Starting from agent 7.45 the NPM driver is installed by default and gets
   # reported as such regardless of the provided parameters. Since we don't
   # want to force the install for nothing in those version, we skip the step
   # when the agent is 7.45+
   when: >-
     (agent_datadog_skip_install and (agent_datadog_major | int <= 7) and (agent_datadog_minor | int < 45)) and
-    (("NPM" in agent_windows_active_config.stdout_lines) != agent_datadog_sysprobe_enabled)
+    (("NPM" in agent_windows_active_features.stdout_lines) != agent_datadog_sysprobe_enabled)

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -19,7 +19,8 @@
 - name: Get Windows Agent config
   win_shell: |
     $installer = new-object -comobject WindowsInstaller.Installer
-    $agent_item = (Get-ItemProperty "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*" -EA 0 | Where { $_.DisplayName -like "Datadog Agent*" }).PSChildName
+    $uninstall_key = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
+    $agent_item = (Get-ItemProperty $uninstall_key -EA 0 | Where { $_.DisplayName -like "Datadog Agent*" }).PSChildName
     if (!$agent_item) {
       return
     }
@@ -30,7 +31,7 @@
       }
       Write-Host $f
     }
-  register: datadog_windows_agent_active_config
+  register: agent_windows_active_config
 
 # NOTE: We don't set DD Password Arg here to prevent it from being printed;
 # we set it right before using agent_win_install_args
@@ -122,4 +123,4 @@
   # when the agent is 7.45+
   when: >-
     (agent_datadog_skip_install and (agent_datadog_major | int <= 7) and (agent_datadog_minor | int < 45)) and
-    (("NPM" in datadog_windows_agent_active_config.stdout_lines) != agent_datadog_sysprobe_enabled)
+    (("NPM" in agent_windows_active_config.stdout_lines) != agent_datadog_sysprobe_enabled)

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -4,6 +4,15 @@
     msg: "The Datadog ansible role does not currently support Agent 5"
   when: agent_datadog_agent_major_version|int == 5
 
+## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
+- name: Set windows NPM installed
+  set_fact:
+    agent_datadog_sysprobe_enabled: "{{ network_config is defined and 'enabled' in (network_config | default({}, true)) and network_config['enabled'] }}"
+
+## Might override agent_datadog_skip_install
+- name: Include Windows opts tasks
+  include_tasks: pkg-windows-opts.yml
+
 - name: Download windows datadog agent 614 fix script
   win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
@@ -28,14 +37,6 @@
   debug:
     var: agent_dd_download_url
   when: not agent_datadog_skip_install
-
-## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
-- name: Set windows NPM installed
-  set_fact:
-    agent_datadog_sysprobe_enabled: "{{ network_config is defined and 'enabled' in (network_config | default({}, true)) and network_config['enabled'] }}"
-
-- name: Include Windows opts tasks
-  include_tasks: pkg-windows-opts.yml
 
 - name: Pre-Delete temporary msi
   win_file:

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -78,6 +78,12 @@
     agent_win_install_args: "{{ agent_win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
   when: datadog_windows_ddagentuser_password | default('', true) | length > 0
 
+- name: Uninstall agent to update optional features
+  win_package:
+    path: "{{ agent_download_msi_result.dest }}"
+    state: absent
+  when: not agent_datadog_skip_install and agent_datadog_force_reinstall
+
 - name: Install downloaded agent
   win_package:
     path: "{{ agent_download_msi_result.dest }}"


### PR DESCRIPTION
This PR adds support for optional features exposed by the MSI installer.
It will probe the available features and will trigger a reinstall if an optional features must be enabled/disabled (the installer doesn't support in place modification of the installed features)

While this is of limited interest given that the installer always installs all features since 7.46, this paves the way for future optional features that we might not want to systematically install