### PR TITLE
Bump XCode version from 13.3.0 to 13.4.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,7 +192,7 @@ jobs:
         type: string
         default: "false"
     macos:
-      xcode: 13.3.0
+      xcode: 13.4.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ workflows:
 
       # centos = CentOS 7. CentOS <= 7 + Python3 is not supported,
       # as the yum module is Python2-only.
-      - test_install_downgrade: 
+      - test_install_downgrade:
           matrix:
             parameters:
               ansible_version: ["2_6", "2_7", "2_8", "2_9", "2_10", "3_4", "4_10"]
@@ -271,7 +271,7 @@ workflows:
               python: ["python3"]
 
       # Amazon Linux 2 has yum only by default => we only use Python 3 with Ansible >= 4.10
-      # because of the respawn_module functionality added to the yum module in 
+      # because of the respawn_module functionality added to the yum module in
       # https://github.com/ansible/ansible/commit/4c5ce5a1a9e79a845aff4978cfeb72a0d4ecf7d6
       - test_install:
           matrix:


### PR DESCRIPTION
13.3.0 isn't available anymore, causing all macOS tests to fail.