### PR TITLE
[README] Add openSUSE/SLES `community.general` install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Note that the install instructions in this document describe installation of the
   ```shell
   ansible-galaxy collection install ansible.windows
   ```
-- When using with Ansible 2.10 to manage openSUSE/SLES hosts, requires the `community.general` collection to be installed:
+- When using with Ansible 2.10+ to manage openSUSE/SLES hosts, requires the `community.general` collection to be installed:
 
   ```shell
   ansible-galaxy collection install community.general

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Note that the install instructions in this document describe installation of the
   ```shell
   ansible-galaxy collection install ansible.windows
   ```
+- When using with Ansible 2.10 to manage openSUSE/SLES hosts, requires the `community.general` collection to be installed:
+
+  ```shell
+  ansible-galaxy collection install community.general
+  ```
 
 ### Installation
 


### PR DESCRIPTION
It's missing from this README though it's in [the collection's](https://github.com/ansible-collections/Datadog/blob/main/README.md).