### PR TITLE
Use Get-ItemProperty to retrieve Windows Agent version

### DIFF
--- a/tasks/parse-version-windows.yml
+++ b/tasks/parse-version-windows.yml
@@ -3,13 +3,15 @@
 - name: Get Windows Agent version
   win_shell: |
     $product_name = "Datadog Agent"
-    $query = "Select Name,IdentifyingNumber,InstallDate,InstallLocation,ProductID,Version FROM Win32_Product where Name like '$product_name%'"
-    $installs = Get-WmiObject -query $query
+    $version=Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |
+    Select-Object DisplayName,DisplayVersion,PSChildName -unique |
+    Where-Object {$_.DisplayName -clike $product_name} |
+    Select-Object DisplayVersion -ExpandProperty DisplayVersion
 
-    if (!$installs -or ($installs.Count -eq 0) -or ($installs.Count -gt 1)) {
+    if (!$version) {
       Write-Host ""
     } else {
-      $ddmaj, $ddmin, $ddpatch, $ddbuild = $installs.Version.split(".")
+      $ddmaj, $ddmin, $ddpatch, $ddbuild = $version.split(".")
       Write-Host "$($ddmaj).$($ddmin).$($ddpatch)"
     }
   register: agent_datadog_version_check_win


### PR DESCRIPTION

This should close #526. 
It changes the Powershell function used to retrieve the version of the Windows Agent installed, which should speed up the playbook execution and avoid slow idempotency.
Thanks @ldemers777
