### PR TITLE
Add an integration test for APM injection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,7 +212,7 @@ jobs:
         type: string
 
     machine:
-      image: ubuntu-2004:202010-01 # includes docker 19.03.13, docker-compose 1.27.4
+      image: ubuntu-2204:2023.10.1 # includes docker and docker-compose
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,12 +217,12 @@ jobs:
     steps:
       - checkout
       - run: pip3 install ansible==<<parameters.ansible_version>>
-      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
+      - run: ansible-playbook --become-user root -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
       - run: dd-agent info || true
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
-      - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && docker build -t system-tests/local .
-      - run: cd /tmp//system-tests/tests/onboarding/weblog/python/test-app-python-django && docker-compose up --detach
+      - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .
+      - run: cd /tmp/system-tests/tests/onboarding/weblog/python/test-app-python-django && sudo docker-compose up --detach
       - run: curl localhost:5985
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,7 +216,7 @@ jobs:
 
     steps:
       - checkout
-      - run: pip3 install ansible~=<<parameters.ansible_version>>
+      - run: pip3 install ansible==<<parameters.ansible_version>>
       - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
       - run: dd-agent info || true
       - run: ps aux | grep -v grep | grep datadog-agent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,9 +216,11 @@ jobs:
 
     steps:
       - checkout
+      # these repos have expired GPG keys and make APT fail (and we don't need them)
+      - run: sudo rm /etc/apt/sources.list.d/*
       - run: pip3 install ansible==<<parameters.ansible_version>>
-      - run: ansible-playbook --become-user root -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
-      - run: dd-agent info || true
+      - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
+      - run: sudo datadog-agent status || true
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
       - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,27 @@ jobs:
           python: "<<parameters.python>>"
           jinja2_native: "<<parameters.jinja2_native>>"
 
+  test_apm_injection:
+    parameters:
+      ansible_version:
+        type: string
+
+    machine:
+      image: ubuntu-2004:202010-01 # includes docker 19.03.13, docker-compose 1.27.4
+
+    steps:
+      - checkout
+      - run: pip3 install ansible~=<<parameters.ansible_version>>
+      - run: ansible-playbook -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
+      - run: dd-agent info || true
+      - run: ps aux | grep -v grep | grep datadog-agent
+      - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
+      - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && docker build -t system-tests/local .
+      - run: cd /tmp//system-tests/tests/onboarding/weblog/python/test-app-python-django && docker-compose up --detach
+      - run: curl localhost:5985
+      # verify that the emitted trace is in trace-agent log
+      - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)
+
 workflows:
   version: 2
   test_datadog_role:
@@ -295,3 +316,8 @@ workflows:
               ansible_version: ["2.8", "2.9", "2.10", "3.4", "4.10"]
               agent_version: ["6_macos", "7_macos"]
               python: ["python3"]
+
+      - test_apm_injection:
+          matrix:
+            parameters:
+              ansible_version: ["4_10"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -320,4 +320,4 @@ workflows:
       - test_apm_injection:
           matrix:
             parameters:
-              ansible_version: ["4_10"]
+              ansible_version: ["6.7.0"]

--- a/ci_test/install_agent_7_apm_python.yaml
+++ b/ci_test/install_agent_7_apm_python.yaml
@@ -2,18 +2,7 @@
 
 - hosts: all
   roles:
-    - role: ansible-datadog
-  post_tasks:
-    - shell:
-        cmd: git -C /tmp clone https://github.com/DataDog/system-tests.git
-    - shell:
-        chdir: /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django
-        cmd: docker build -t system-tests/local .
-    - shell:
-        chdir: /tmp//system-tests/tests/onboarding/weblog/python/test-app-python-django
-        cmd: docker-compose up --detach
-    - shell:
-        cmd: curl localhost:5985
+    - { role: "/home/circleci/project/" }
   vars:
     datadog_api_key: "11111111111111111111111111111111"
     datadog_agent_major_version: 7

--- a/ci_test/install_agent_7_apm_python.yaml
+++ b/ci_test/install_agent_7_apm_python.yaml
@@ -1,0 +1,21 @@
+---
+
+- hosts: all
+  roles:
+    - role: ansible-datadog
+  post_tasks:
+    - shell:
+        cmd: git -C /tmp clone https://github.com/DataDog/system-tests.git
+    - shell:
+        chdir: /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django
+        cmd: docker build -t system-tests/local .
+    - shell:
+        chdir: /tmp//system-tests/tests/onboarding/weblog/python/test-app-python-django
+        cmd: docker-compose up --detach
+    - shell:
+        cmd: curl localhost:5985
+  vars:
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_agent_major_version: 7
+    datadog_apm_instrumentation_enabled: "all"
+    datadog_apm_instrumentation_languages: ["python"]


### PR DESCRIPTION
This PR adds a new test which verifies the APM injection functionality:
* It runs on a VM because it tries out the docker-injected tracing
* It configures Agent 7 with APM (Python tracer only) on the VM
* It builds and runs a simple Python Django app in a container and curls it
* It verifies that the trace-agent logfile contains a message that it received the trace