### PR TITLE
Properly detect when DEB package is actually installed

### DIFF
--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -52,7 +52,7 @@
 - name: Construct commands to find Agent version
   set_fact:
     agent_datadog_version_finding_cmds:
-      Debian: "dpkg -s {{ datadog_agent_flavor }} | grep '^Version:' | awk '{print $2}'"
+      Debian: "dpkg-query --showformat '${Status} ${Version}\n' --show {{ datadog_agent_flavor }} | grep installed | awk '{print $NF}'"
       RedHat: "{{ agent_datadog_rpm_version_finding_cmd }}"
       Rocky: "{{ agent_datadog_rpm_version_finding_cmd }}"
       AlmaLinux: "{{ agent_datadog_rpm_version_finding_cmd }}"


### PR DESCRIPTION
This fixes https://github.com/DataDog/ansible-datadog/issues/519 - `dpkg -s` will return information even for a package that's been uninstalled. We can use a different query and ensure the package is actually installed while extracting the version.