### PR TITLE
Fix APM test scenario by adapting to the new system-tests repo layout

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
       - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .
-      - run: cd /tmp/system-tests/tests/onboarding/weblog/python/test-app-python-django && sudo docker-compose up --detach
+      - run: cd /tmp/system-tests/utils/build/virtual_machine/weblogs/python/test-app-python-container/docker-compose.yml && sudo docker-compose up --detach
       - run: curl localhost:5985
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
       - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .
-      - run: cd /tmp/system-tests/utils/build/virtual_machine/weblogs/python/test-app-python-container/docker-compose.yml && sudo docker-compose up --detach
+      - run: cd /tmp/system-tests/utils/build/virtual_machine/weblogs/python/test-app-python-container/ && sudo docker-compose up --detach
       - run: curl localhost:5985
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)


### PR DESCRIPTION
FWIW, if this happens again, we can pin the specific commit of the system-tests repository to prevent future breakage.