### PR TITLE
Allow using proxy for windows downloads

### DIFF
--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -17,6 +17,7 @@
   win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
     dest: '%TEMP%\fix_6_14.ps1'
+    proxy_url: "{{ http_proxy | default(omit) }}"
   when: not agent_datadog_skip_install and datadog_apply_windows_614_fix
 
 - name: Run 6.14.0/1 PowerShell fix
@@ -48,6 +49,7 @@
   win_get_url:
     url: "{{ agent_dd_download_url }}"
     dest: '%TEMP%\ddagent.msi'
+    proxy_url: "{{ http_proxy | default(omit) }}"
   register: agent_download_msi_result
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 


### PR DESCRIPTION
This fixes https://github.com/DataDog/ansible-datadog/issues/547