### PR TITLE
Pin Python to version 3.11 in macOS runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -200,7 +200,7 @@ jobs:
           command: brew install python3
       - run:
           name: Install Ansible
-          command: pip3 install ansible~=<<parameters.ansible_version>>
+          command: pip3 install --break-system-packages ansible~=<<parameters.ansible_version>>
       - test_agent_install_macos:
           version: "<<parameters.agent_version>>"
           python: "<<parameters.python>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - checkout
       - run:
           name: Install Python3
-          command: brew install python3.11
+          command: brew install python@3.11
       - run:
           name: Install Ansible
           command: pip3 install ansible~=<<parameters.ansible_version>>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,10 +197,10 @@ jobs:
       - checkout
       - run:
           name: Install Python3
-          command: brew install python3
+          command: brew install python3.11
       - run:
           name: Install Ansible
-          command: pip3 install --break-system-packages ansible~=<<parameters.ansible_version>>
+          command: pip3 install ansible~=<<parameters.ansible_version>>
       - test_agent_install_macos:
           version: "<<parameters.agent_version>>"
           python: "<<parameters.python>>"


### PR DESCRIPTION
Pin Python 3.11 which supports all Ansible versions we're testing with.

_Edit - this no longer applies, because some Ansible tested versions don't work with Python 3.12 which ships this pip version:_ We're now getting pip > 23.0.01 installed in macOS runners. This version now requires us to use the `--break-system-packages` switch to mix the pip-installed packages with system packages. We're fine with this because this is only a disposable CI environment.