### PR TITLE
[IMPROVEMENT] Do not sort yaml keys of check configurations

### DIFF
--- a/templates/checks.yaml.j2
+++ b/templates/checks.yaml.j2
@@ -1,1 +1,1 @@
-{{ agent_datadog_checks[item] | to_nice_yaml(indent=2, width=160) }}
+{{ agent_datadog_checks[item] | to_nice_yaml(indent=2, width=160, sort_keys=False) }}


### PR DESCRIPTION
to_nice_yaml will sort the keys by default which can cause the formatting of the generated yaml file to be incorrect. 

In this example case when you add the `log_processing_rules` section it will change the order and the type: file will end up being inside the `log_processing_rules` section causing the checks to fail. If you remove the `log_processing_rules` section then the yaml file will be correct.


This is defined in the playbook:
```yaml
nginx:
  init_config:
  instances:
    - nginx_status_url: "http://localhost/nginx_status"
  logs:
    - type: file
      path: /var/log/nginx/access.log
      service: nginx
      source: access
      sourcecategory: http_web_access
    - type: file
      path: /var/log/nginx/critical.log
      service: nginx
      source: critical
      sourcecategory: http_web_access
    - type: file
      path: /var/log/nginx/error.log
      service: nginx
      source: error
      sourcecategory: http_web_access
      log_processing_rules:
        - name: exclude_ckeditor
          type: exclude_at_match
          pattern: foobar
```

Here is the example `/etc/datadog-agent/conf.d/nginx.d/conf.yaml` file that gets generated when including the `log_processing_rules` section.

```yaml
init_config: null
instances:
- nginx_status_url: http://localhost/nginx_status
logs:
- path: /var/log/nginx/access.log
  service: nginx
  source: access
  sourcecategory: http_web_access
  type: file
- path: /var/log/nginx/critical.log
  service: nginx
  source: critical
  sourcecategory: http_web_access
  type: file
- log_processing_rules:
  - name: exclude_ckeditor
    pattern: foobar
    type: exclude_at_match
  path: /var/log/nginx/error.log
  service: nginx
  source: error
  sourcecategory: http_web_access
  type: file
```