### PR TITLE
Install expired 2022 rpm gpg key only when needed on agent <= 7.35

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -64,12 +64,13 @@
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
         checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
+      when: agent_datadog_minor | int < 36
 
     - name: Import new RPM key (Expires in 2022)
       rpm_key:
         key: /tmp/DATADOG_RPM_KEY_E09422B3.public
         state: present
-      when: not ansible_check_mode
+      when: not ansible_check_mode and agent_datadog_minor | int < 36
 
     - name: Download new RPM key (Expires in 2024)
       get_url:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -58,7 +58,7 @@
         state: present
       when: not ansible_check_mode
 
-    - name: Download new RPM key (Expires in 2022)
+    - name: Download old RPM key (Expires in 2022)
       get_url:
         url: "{{ datadog_yum_gpgkey_e09422b3 }}"
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
@@ -66,7 +66,7 @@
         checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
       when: agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
-    - name: Import new RPM key (Expires in 2022)
+    - name: Import old RPM key (Expires in 2022)
       rpm_key:
         key: /tmp/DATADOG_RPM_KEY_E09422B3.public
         state: present

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -64,13 +64,13 @@
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
         checksum: "sha256:{{ datadog_yum_gpgkey_e09422b3_sha256sum }}"
-      when: agent_datadog_minor | int < 36
+      when: agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
     - name: Import new RPM key (Expires in 2022)
       rpm_key:
         key: /tmp/DATADOG_RPM_KEY_E09422B3.public
         state: present
-      when: not ansible_check_mode and agent_datadog_minor | int < 36
+      when: not ansible_check_mode and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
     - name: Download new RPM key (Expires in 2024)
       get_url:

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -47,7 +47,7 @@
         url: "{{ datadog_zypper_gpgkey_e09422b3 }}"
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
-      when: not agent_ddnewkey.stat.exists
+      when: not agent_ddnewkey.stat.exists and agent_datadog_minor | int < 36
 
 - name: Download E09422B3 key (Expires 2022) RPM key
   get_url:
@@ -55,13 +55,13 @@
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     checksum: sha256:{{ datadog_zypper_gpgkey_e09422b3_sha256sum }}
     mode: '600'
-  when: ansible_distribution_version|int >= 12
+  when: ansible_distribution_version|int >= 12 and agent_datadog_minor | int < 36
 
 - name: Import E09422B3 key (Expires 2022) RPM key
   rpm_key:
     key: /tmp/DATADOG_RPM_KEY_E09422B3.public
     state: present
-  when: not ansible_check_mode
+  when: not ansible_check_mode and agent_datadog_minor | int < 36
 
 - name: Check and download 20200908 key # Work around due to SNI check for SLES11
   when: ansible_distribution_version|int == 11

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -47,7 +47,7 @@
         url: "{{ datadog_zypper_gpgkey_e09422b3 }}"
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
-      when: not agent_ddnewkey.stat.exists and agent_datadog_minor | int < 36
+      when: not agent_ddnewkey.stat.exists and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Download E09422B3 key (Expires 2022) RPM key
   get_url:
@@ -55,13 +55,13 @@
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     checksum: sha256:{{ datadog_zypper_gpgkey_e09422b3_sha256sum }}
     mode: '600'
-  when: ansible_distribution_version|int >= 12 and agent_datadog_minor | int < 36
+  when: ansible_distribution_version|int >= 12 and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Import E09422B3 key (Expires 2022) RPM key
   rpm_key:
     key: /tmp/DATADOG_RPM_KEY_E09422B3.public
     state: present
-  when: not ansible_check_mode and agent_datadog_minor | int < 36
+  when: not ansible_check_mode and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Check and download 20200908 key # Work around due to SNI check for SLES11
   when: ansible_distribution_version|int == 11


### PR DESCRIPTION
Only download and install expired 2022 RPM gpg key on agent <= 7.35