### PR TITLE
Disable logging of datadog_windows_ddagentuser_password

### DIFF
--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -79,6 +79,7 @@
   set_fact:
     agent_win_install_args: "{{ agent_win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
   when: datadog_windows_ddagentuser_password | default('', true) | length > 0
+  no_log: true
 
 - name: Uninstall agent to update optional features
   win_package:


### PR DESCRIPTION
Issue: https://github.com/DataDog/ansible-datadog/issues/562

FIX: Do not log password when verbosity is enabled