### PR TITLE
Remove `warn` argument that is no longer available in newer Ansible

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -202,22 +202,18 @@
       register: agent_repofilecustom
       when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
 
-    - name: Clean repo metadata if repo changed # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
+    - name: Clean repo metadata if repo changed # noqa: command-instead-of-module
       command: yum clean metadata --disablerepo="*" --enablerepo=datadog
       failed_when: false # Cleaning the metadata is only needed when downgrading a major version of the Agent, don't fail because of this
-      args:
-        warn: false
       when: agent_repofile5.changed or agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed
       changed_when: true
 
     # On certain version of dnf, gpg keys aren't imported into the local db with the package install task.
     # This rule assures that they are correctly imported into the local db and users won't have to manually accept
     # them if running dnf commands on the hosts.
-    - name: Refresh Datadog repository cache # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
+    - name: Refresh Datadog repository cache # noqa: command-instead-of-module
       command: yum -y makecache --disablerepo="*" --enablerepo=datadog
       failed_when: false
-      args:
-        warn: false
       when: agent_repofile5.changed or agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed
       changed_when: true
 

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -131,11 +131,9 @@
   when: datadog_manage_zypper_repofile
 
 # refresh zypper repos only if the template changed
-- name: Refresh Datadog zypper_repos # noqa no-handler args[module] (args.warn is deprecated since Ansible 2.11)
+- name: Refresh Datadog zypper_repos # noqa: command-instead-of-module
   command: zypper refresh datadog
   when: agent_datadog_zypper_repo_template.changed and not ansible_check_mode
-  args:
-    warn: false # silence warning about using zypper directly
   changed_when: true
 
 - name: Include Suse agent pinned version install task


### PR DESCRIPTION
Fixes #564. Any execution path that hit any of the affected commands would fail on Ansible 7 and above.

Further context can be found in https://github.com/ansible/ansible/blob/v2.11.0/changelogs/CHANGELOG-v2.11.rst#deprecated-features.

I don't foresee any harm, other than possibly users on very old Ansible versions starting to see a warning about the existence of a module that could be used instead of some explicit command.

Note: I've tested this manually. I intend to follow this up with adding newer Ansible versions to the test matrices that we have, but that's gonna take a little bit more time and I'd rather put out this fix as soon as we can.