### PR TITLE
add support for datadog-installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,25 @@ jobs:
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)
 
+  test_installer:
+    parameters:
+      ansible_version:
+        type: string
+      jinja2_native:
+        type: string
+        default: "false"
+      os:
+        type: string
+      inventory:
+        type: string
+        default: "ci.ini"
+    docker:
+      - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
+    steps:
+      - checkout
+      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
+      - run: datadog-installer version
+
 workflows:
   version: 2
   test_datadog_role:
@@ -326,3 +345,11 @@ workflows:
           matrix:
             parameters:
               ansible_version: ["6.7.0"]
+
+      - test_installer:
+         matrix:
+           parameters:
+              ansible_version: ["2_10", "3_4", "4_10", "5_3", "9_4"]
+              # There is no stable release of the installer on RHEL derivatives yet
+              # but we should include it as soon as possible
+              os: ["debian"]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|
 | `datadog_apm_instrumentation_libraries`     | List of APM libraries to install if `host` or `docker` injection is enabled (defaults to `["java", "js", "dotnet", "python", "ruby"]`). You can find the available values in [Inject Libraries Locally][24].|
 | `datadog_apm_instrumentation_docker_config` | Override Docker APM configuration. Read [configure Docker injection][23] for more details.|
+| `datadog_remote_updates`                    | Enable remote installation and updates through the datadog-installer.|
 
 ### Integrations
 

--- a/ci_test/install_installer.yaml
+++ b/ci_test/install_installer.yaml
@@ -1,0 +1,11 @@
+---
+
+- hosts: all
+  roles:
+    - { role: '/root/project/'}
+  vars:
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_enabled: false
+    datadog_skip_running_check: true
+    datadog_apm_instrumentation_enabled: host
+    datadog_remote_updates: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -268,3 +268,5 @@ datadog_macos_system_plist_file_path: "/Library/LaunchDaemons/{{ datadog_macos_s
 datadog_macos_etc_dir: "/opt/datadog-agent/etc"
 datadog_macos_logs_dir: "/opt/datadog-agent/logs"
 datadog_macos_run_dir: "/opt/datadog-agent/run"
+
+datadog_installer_enabled: false

--- a/tasks/apm-inject-install.yml
+++ b/tasks/apm-inject-install.yml
@@ -7,37 +7,40 @@
   include_tasks: pkg-redhat/install-apm-inject.yml
   when: not ansible_check_mode and ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"]
 
-- name: Check if dd-host-install needs to run
-  command: dd-host-install --no-config-change --no-agent-restart --dry-run
-  register: agent_dd_host_install_cmd
-  changed_when: false
-  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"]
-  failed_when: agent_dd_host_install_cmd.rc >= 2
+- name: Run dd-host-install
+  when: not datadog_installer_enabled or not datadog_installer_owns_injector
+  block:
+    - name: Check if dd-host-install needs to run
+      command: dd-host-install --no-config-change --no-agent-restart --dry-run
+      register: agent_dd_host_install_cmd
+      changed_when: false
+      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"]
+      failed_when: agent_dd_host_install_cmd.rc >= 2
 
-- name: Run APM host injection setup script
-  command: dd-host-install --no-config-change --no-agent-restart
-  notify: restart datadog-agent
-  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"] and agent_dd_host_install_cmd.rc == 1
-  changed_when: true
+    - name: Run APM host injection setup script
+      command: dd-host-install --no-config-change --no-agent-restart
+      notify: restart datadog-agent
+      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"] and agent_dd_host_install_cmd.rc == 1
+      changed_when: true
 
-- name: Check if dd-container-install needs to run
-  command: dd-container-install --dry-run
-  register: agent_dd_container_install_cmd
-  changed_when: false
-  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"]
-  failed_when: agent_dd_container_install_cmd.rc >= 2
+    - name: Check if dd-container-install needs to run
+      command: dd-container-install --dry-run
+      register: agent_dd_container_install_cmd
+      changed_when: false
+      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"]
+      failed_when: agent_dd_container_install_cmd.rc >= 2
 
-- name: Create Docker APM injection config file
-  template:
-    src: apm-inject-docker-config.yaml.j2
-    dest: /etc/datadog-agent/inject/docker_config.yaml
-    mode: "0640"
-    owner: root
-    group: "{{ datadog_group }}"
-  when: datadog_apm_instrumentation_docker_config
+    - name: Create Docker APM injection config file
+      template:
+        src: apm-inject-docker-config.yaml.j2
+        dest: /etc/datadog-agent/inject/docker_config.yaml
+        mode: "0640"
+        owner: root
+        group: "{{ datadog_group }}"
+      when: datadog_apm_instrumentation_docker_config
 
-- name: Run APM host-docker injection (Docker) setup script
-  # this command will change /etc/docker/daemon.json and reload docker if changes are made.
-  command: dd-container-install
-  when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"] and agent_dd_container_install_cmd.rc == 1
-  changed_when: true
+    - name: Run APM host-docker injection (Docker) setup script
+      # this command will change /etc/docker/daemon.json and reload docker if changes are made.
+      command: dd-container-install
+      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"] and agent_dd_container_install_cmd.rc == 1
+      changed_when: true

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -3,4 +3,3 @@
   set_fact:
     datadog_installer_enabled: true
   when: datadog_apm_instrumentation_enabled | length > 0
-

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -1,0 +1,6 @@
+---
+- name: Enable installer
+  set_fact:
+    datadog_installer_enabled: true
+  when: datadog_apm_instrumentation_enabled | length > 0
+

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -7,6 +7,7 @@
 - name: Start duration measurements
   command: "date +%s%N"
   register: datadog_installer_start_time
+  changed_when: True
 
 - name: Install datadog-installer package (dnf)
   dnf:
@@ -53,12 +54,14 @@
     DD_APM_INSTRUMENTATION_LANGUAGES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
   ignore_errors: true
   when: not datadog_installer_install_result.failed
+  changed_when: True
 
 - name: Check if installer owns datadog-agent package
-  shell: datadog-installer is-installed "{{ datadog_agent_flavor }}"
+  command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
   register: datadog_installer_owns_agent
   when: not datadog_installer_bootstrap_result.failed
+  changed_when: True
 
 - name: Disable agent install if owned by installer
   set_fact:
@@ -66,11 +69,12 @@
   when: datadog_installer_owns_agent.rc == 0
 
 - name: Query APM packages owned by installer
-  shell: datadog-installer is-installed "datadog-apm-library-{{ item }}"
+  command: datadog-installer is-installed "datadog-apm-library-{{ item }}"
   register: datadog_installer_owned_apm_packages
   loop: "{{ datadog_apm_instrumentation_libraries }}"
   when: not datadog_installer_bootstrap_result.failed
   failed_when: datadog_installer_owned_apm_packages.rc != 0 and datadog_installer_owned_apm_packages.rc != 10
+  changed_when: True
   environment:
     DD_API_KEY: "{{ datadog_api_key }}"
 

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -124,7 +124,7 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
-  ignore_errors: true
+  failed_when: false
 
 - name: Setup logs body
   set_fact:
@@ -155,4 +155,4 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
-  ignore_errors: true
+  failed_when: false

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -85,7 +85,9 @@
 - name: Filter APM packages owned by the installer
   set_fact:
     datadog_apm_instrumentation_libraries: "{{ datadog_apm_instrumentation_libraries | difference([item.item]) }}"
-  when: item.rc == 0
+  when:
+    - item.rc == 0
+    - not datadog_installer_bootstrap_result.failed
   loop: "{{ datadog_installer_owned_apm_packages.results }}"
 
 - name: Stop duration measurements

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -99,20 +99,20 @@
       'template',
       'templates/installer-telemetry.j2',
       template_vars=dict(
-        trace_id=datadog_installer_trace_id,
-        hostname=ansible_hostname,
-        system=ansible_facts.system,
-        os_family=ansible_facts.os_family,
-        arch=ansible_facts.machine,
-        kernel=ansible_facts.kernel,
-        kernel_version=ansible_facts.kernel_version,
-        role_version=role_version,
-        rc=datadog_installer_bootstrap_result.rc if datadog_installer_bootstrap_result is defined else datadog_installer_install_result.rc,
-        stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
-        start_time=datadog_installer_start_time.stdout | int,
-        stop_time=datadog_installer_stop_time.stdout | int,
-        packages_to_install=datadog_apm_instrumentation_libraries_unfiltered,
-        packages_to_install_filtered=datadog_apm_instrumentation_libraries,
+          trace_id=datadog_installer_trace_id,
+          hostname=ansible_hostname,
+          system=ansible_facts.system,
+          os_family=ansible_facts.os_family,
+          arch=ansible_facts.machine,
+          kernel=ansible_facts.kernel,
+          kernel_version=ansible_facts.kernel_version,
+          role_version=role_version,
+          rc=datadog_installer_bootstrap_result.rc if datadog_installer_bootstrap_result is defined else datadog_installer_install_result.rc,
+          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+          start_time=datadog_installer_start_time.stdout | int,
+          stop_time=datadog_installer_stop_time.stdout | int,
+          packages_to_install=datadog_apm_instrumentation_libraries_unfiltered,
+          packages_to_install_filtered=datadog_apm_instrumentation_libraries,
       )) }}"
 
 - name: Send Installer telemetry traces
@@ -124,6 +124,7 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
+  ignore_errors: true
 
 - name: Setup logs body
   set_fact:
@@ -131,17 +132,17 @@
       'template',
       'templates/installer-logs.j2',
       template_vars=dict(
-        stop_time=datadog_installer_stop_time.stdout,
-        trace_id=datadog_installer_trace_id,
-        hostname=ansible_hostname,
-        system=ansible_facts.system,
-        os_family=ansible_facts.os_family,
-        arch=ansible_facts.machine,
-        kernel=ansible_facts.kernel,
-        kernel_version=ansible_facts.kernel_version,
-        role_version=role_version,
-        stdout=datadog_installer_install_result.stdout | default('') + datadog_installer_bootstrap_result.stdout | default(''),
-        stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+          stop_time=datadog_installer_stop_time.stdout,
+          trace_id=datadog_installer_trace_id,
+          hostname=ansible_hostname,
+          system=ansible_facts.system,
+          os_family=ansible_facts.os_family,
+          arch=ansible_facts.machine,
+          kernel=ansible_facts.kernel,
+          kernel_version=ansible_facts.kernel_version,
+          role_version=role_version,
+          stdout=datadog_installer_install_result.stdout | default('') + datadog_installer_bootstrap_result.stdout | default(''),
+          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
       )
       )}}"
 
@@ -154,3 +155,4 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
+  ignore_errors: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -7,7 +7,7 @@
 - name: Start duration measurements
   command: "date +%s%N"
   register: datadog_installer_start_time
-  changed_when: True
+  changed_when: true
 
 - name: Install datadog-installer package (dnf)
   dnf:
@@ -54,14 +54,14 @@
     DD_APM_INSTRUMENTATION_LANGUAGES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
   ignore_errors: true
   when: not datadog_installer_install_result.failed
-  changed_when: True
+  changed_when: true
 
 - name: Check if installer owns datadog-agent package
   command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
   register: datadog_installer_owns_agent
   when: not datadog_installer_bootstrap_result.failed
-  changed_when: True
+  changed_when: true
 
 - name: Disable agent install if owned by installer
   set_fact:
@@ -74,7 +74,7 @@
   loop: "{{ datadog_apm_instrumentation_libraries }}"
   when: not datadog_installer_bootstrap_result.failed
   failed_when: datadog_installer_owned_apm_packages.rc != 0 and datadog_installer_owned_apm_packages.rc != 10
-  changed_when: True
+  changed_when: true
   environment:
     DD_API_KEY: "{{ datadog_api_key }}"
 
@@ -91,10 +91,13 @@
 - name: Stop duration measurements
   command: "date +%s%N"
   register: datadog_installer_stop_time
+  changed_when: true
 
 - name: Setup telemetry body
   set_fact:
-    telemetry_body: "{{ lookup('template', 'templates/installer-telemetry.j2',
+    telemetry_body: "{{ lookup(
+      'template',
+      'templates/installer-telemetry.j2',
       template_vars=dict(
         trace_id=datadog_installer_trace_id,
         hostname=ansible_hostname,
@@ -124,7 +127,9 @@
 
 - name: Setup logs body
   set_fact:
-    logs_body: "{{ lookup('template', 'templates/installer-logs.j2',
+    logs_body: "{{ lookup(
+      'template',
+      'templates/installer-logs.j2',
       template_vars=dict(
         stop_time=datadog_installer_stop_time.stdout,
         trace_id=datadog_installer_trace_id,
@@ -149,4 +154,3 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
-

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -157,3 +157,8 @@
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
   failed_when: false
+
+- name: Propagate failures after telemetry
+  fail:
+    msg: "Installer bootstrap failed: {{ datadog_installer_bootstrap_result.stderr }}"
+  when: datadog_installer_bootstrap_result.failed

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -51,7 +51,7 @@
     DD_API_KEY: "{{ datadog_api_key }}"
     DD_REMOTE_UPDATES: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates else '' }}"
     DD_APM_INSTRUMENTATION_ENABLED: "{{ datadog_apm_instrumentation_enabled }}"
-    DD_APM_INSTRUMENTATION_LANGUAGES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
+    DD_APM_INSTRUMENTATION_LIBRARIES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
   ignore_errors: true
   when: not datadog_installer_install_result.failed
   changed_when: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -1,0 +1,148 @@
+---
+- name: Generate installer trace ID
+  set_fact:
+    datadog_installer_trace_id: "{{ 9999999999999999999 | random }}"
+  when: datadog_installer_enabled
+
+- name: Start duration measurements
+  command: "date +%s%N"
+  register: datadog_installer_start_time
+
+- name: Install datadog-installer package (dnf)
+  dnf:
+    name: "datadog-installer"
+    update_cache: true
+    state: latest # noqa package-latest
+  register: datadog_installer_install_result
+  # Since we want to send telemetry including when the installation failed,
+  # we need to explicitely ignore failures and skip dependent task when one
+  # of its depedency failed
+  # By default ansible will stop on the first error
+  ignore_errors: true
+  when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "dnf"
+
+- name: Install latest datadog-agent package (yum)
+  yum:
+    name: "datadog-installer"
+    update_cache: true
+    state: latest # noqa package-latest
+  register: datadog_installer_install_result
+  ignore_errors: true
+  when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "yum"
+
+- name: Install Datadog installer (apt)
+  apt:
+    name: "datadog-installer"
+    state: latest # noqa package-latest
+    update_cache: true
+    cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
+  register: datadog_installer_install_result
+  ignore_errors: true
+  when: ansible_facts.os_family == "Debian" and not ansible_check_mode
+
+- name: Bootstrap the installer
+  command: /usr/bin/datadog-bootstrap bootstrap
+  register: datadog_installer_bootstrap_result
+  environment:
+    DATADOG_TRACE_ID: "{{ datadog_installer_trace_id }}"
+    DATADOG_PARENT_ID: "{{ datadog_installer_trace_id }}"
+    DD_SITE: "{{ datadog_site | default('datadoghq.com') }}"
+    DD_API_KEY: "{{ datadog_api_key }}"
+    DD_REMOTE_UPDATES: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates else '' }}"
+    DD_APM_INSTRUMENTATION_ENABLED: "{{ datadog_apm_instrumentation_enabled }}"
+    DD_APM_INSTRUMENTATION_LANGUAGES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
+  ignore_errors: true
+  when: not datadog_installer_install_result.failed
+
+- name: Check if installer owns datadog-agent package
+  shell: datadog-installer is-installed "{{ datadog_agent_flavor }}"
+  failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
+  register: datadog_installer_owns_agent
+  when: not datadog_installer_bootstrap_result.failed
+
+- name: Disable agent install if owned by installer
+  set_fact:
+    agent_datadog_skip_install: true
+  when: datadog_installer_owns_agent.rc == 0
+
+- name: Query APM packages owned by installer
+  shell: datadog-installer is-installed "datadog-apm-library-{{ item }}"
+  register: datadog_installer_owned_apm_packages
+  loop: "{{ datadog_apm_instrumentation_libraries }}"
+  when: not datadog_installer_bootstrap_result.failed
+  failed_when: datadog_installer_owned_apm_packages.rc != 0 and datadog_installer_owned_apm_packages.rc != 10
+  environment:
+    DD_API_KEY: "{{ datadog_api_key }}"
+
+- name: Save APM packages before filtering
+  set_fact:
+    datadog_apm_instrumentation_libraries_unfiltered: "{{ datadog_apm_instrumentation_libraries }}"
+
+- name: Filter APM packages owned by the installer
+  set_fact:
+    datadog_apm_instrumentation_libraries: "{{ datadog_apm_instrumentation_libraries | difference([item.item]) }}"
+  when: item.rc == 0
+  loop: "{{ datadog_installer_owned_apm_packages.results }}"
+
+- name: Stop duration measurements
+  command: "date +%s%N"
+  register: datadog_installer_stop_time
+
+- name: Setup telemetry body
+  set_fact:
+    telemetry_body: "{{ lookup('template', 'templates/installer-telemetry.j2',
+      template_vars=dict(
+        trace_id=datadog_installer_trace_id,
+        hostname=ansible_hostname,
+        system=ansible_facts.system,
+        os_family=ansible_facts.os_family,
+        arch=ansible_facts.machine,
+        kernel=ansible_facts.kernel,
+        kernel_version=ansible_facts.kernel_version,
+        role_version=role_version,
+        rc=datadog_installer_bootstrap_result.rc if datadog_installer_bootstrap_result is defined else datadog_installer_install_result.rc,
+        stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+        start_time=datadog_installer_start_time.stdout | int,
+        stop_time=datadog_installer_stop_time.stdout | int,
+        packages_to_install=datadog_apm_instrumentation_libraries_unfiltered,
+        packages_to_install_filtered=datadog_apm_instrumentation_libraries,
+      )) }}"
+
+- name: Send Installer telemetry traces
+  uri:
+    url: "https://instrumentation-telemetry-intake.{{ datadog_site | default('datadoghq.com') }}/api/v2/apmtelemetry"
+    body: "{{ telemetry_body }}"
+    method: POST
+    status_code: [202]
+    headers:
+      DD-Api-Key: "{{ datadog_api_key }}"
+    body_format: json
+
+- name: Setup logs body
+  set_fact:
+    logs_body: "{{ lookup('template', 'templates/installer-logs.j2',
+      template_vars=dict(
+        stop_time=datadog_installer_stop_time.stdout,
+        trace_id=datadog_installer_trace_id,
+        hostname=ansible_hostname,
+        system=ansible_facts.system,
+        os_family=ansible_facts.os_family,
+        arch=ansible_facts.machine,
+        kernel=ansible_facts.kernel,
+        kernel_version=ansible_facts.kernel_version,
+        role_version=role_version,
+        stdout=datadog_installer_install_result.stdout | default('') + datadog_installer_bootstrap_result.stdout | default(''),
+        stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+      )
+      )}}"
+
+- name: Send Installer telemetry logs
+  uri:
+    url: "https://instrumentation-telemetry-intake.{{ datadog_site | default('datadoghq.com') }}/api/v2/apmtelemetry"
+    body: "{{ logs_body }}"
+    method: POST
+    status_code: [202]
+    headers:
+      DD-Api-Key: "{{ datadog_api_key }}"
+    body_format: json
+

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -62,6 +62,13 @@
   when: not datadog_installer_bootstrap_result.failed
   changed_when: true
 
+- name: Check if installer owns apm injector package
+  command: datadog-installer is-installed "{{ datadog_inject_apm_flavor }}"
+  failed_when: datadog_installer_owns_injector.rc != 0 and datadog_installer_owns_injector.rc != 10
+  register: datadog_installer_owns_injector
+  when: not datadog_installer_bootstrap_result.failed
+  changed_when: true
+
 - name: Disable agent install if owned by installer
   set_fact:
     agent_datadog_skip_install: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -2,7 +2,6 @@
 - name: Generate installer trace ID
   set_fact:
     datadog_installer_trace_id: "{{ 9999999999999999999 | random }}"
-  when: datadog_installer_enabled
 
 - name: Start duration measurements
   command: "date +%s%N"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,7 +32,6 @@
 
 - name: Configure Datadog Installer
   include_tasks: installer-config.yml
-  when: datadog_apm_instrumentation_enabled | length > 0
 
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,10 @@
   include_tasks: apm-inject-check.yml
   when: datadog_apm_instrumentation_enabled | length > 0
 
+- name: Configure Datadog Installer
+  include_tasks: installer-config.yml
+  when: datadog_apm_instrumentation_enabled | length > 0
+
 - name: Debian Install Tasks
   include_tasks: pkg-debian.yml
   when: ansible_facts.os_family == "Debian" and not agent_datadog_skip_install

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -117,6 +117,10 @@
     update_cache: true
   when: (datadog_apt_repo | length > 0) and (not ansible_check_mode)
 
+- name: Include installer setup
+  include_tasks: installer-setup.yml
+  when: datadog_installer_enabled
+
 - name: Include debian pinned version install task
   include_tasks: pkg-debian/install-pinned.yml
   when: agent_datadog_agent_debian_version is defined

--- a/tasks/pkg-debian/install-apm-inject.yml
+++ b/tasks/pkg-debian/install-apm-inject.yml
@@ -19,7 +19,7 @@
     state: latest # noqa package-latest
     update_cache: true
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  when: not ansible_check_mode
+  when: not ansible_check_mode and (not datadog_installer_enabled or not datadog_installer_owns_injector)
 
 - name: Install APM tracer libraries
   apt:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -236,6 +236,10 @@
         state: absent
       with_items: [5, 6, 7, custom]
 
+- name: Include installer setup
+  include_tasks: installer-setup.yml
+  when: datadog_installer_enabled
+
 - name: Include redhat agent pinned version install task
   include_tasks: pkg-redhat/install-pinned.yml
   when: agent_datadog_agent_redhat_version is defined

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,5 +1,5 @@
 ---
-- name: Set upper bound last supported Agent version for Centos < 7
+- name: Check for Centos < 7 and adjust features
   when: ansible_facts.os_family == "RedHat"
   block:
     - name: Get RHEL major version equivalent
@@ -11,6 +11,10 @@
       set_fact:
         datadog_agent_max_minor_version: 51
       when: rhel_version.stdout | int < 7
+    - name: Disable datadog installer
+      set_fact:
+        datadog_installer_enabled: false
+      when: datadog_installer_enabled and rhel_version.stdout | int < 7
 
 - name: Fail if specified agent version is above maximum supported by Centos < 7 and equivalent
   fail:

--- a/tasks/pkg-redhat/install-apm-inject.yml
+++ b/tasks/pkg-redhat/install-apm-inject.yml
@@ -12,7 +12,7 @@
     name: 'datadog-apm-inject'
     update_cache: true
     state: latest # noqa package-latest
-  when: not ansible_check_mode and ansible_pkg_mgr == "dnf"
+  when: not ansible_check_mode and ansible_pkg_mgr == "dnf" and (not datadog_installer_enabled or not datadog_installer_owns_injector)
 
 - name: Install APM inject libraries (dnf)
   dnf:
@@ -28,7 +28,7 @@
     name: 'datadog-apm-inject'
     update_cache: true
     state: latest # noqa package-latest
-  when: not ansible_check_mode and ansible_pkg_mgr == "yum"
+  when: not ansible_check_mode and ansible_pkg_mgr == "yum" and (not datadog_installer_enabled or not datadog_installer_owns_injector)
 
 - name: Install APM inject libraries (yum)
   yum:

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -14,6 +14,10 @@ dd_url: {{ datadog_url }}
 api_key: {{ datadog_api_key }}
 {% endif %}
 
+{% if datadog_remote_updates is defined -%}
+remote_updates: {{ datadog_remote_updates }}
+{% endif -%}
+
 {% if agent_datadog_config | default({}, true) | length > 0 -%}
 {{ agent_datadog_config | to_nice_yaml }}
 {% endif %}

--- a/templates/installer-logs.j2
+++ b/templates/installer-logs.j2
@@ -1,0 +1,36 @@
+{
+    "api_version": "v2",
+    "request_type": "logs",
+    "tracer_time": "{{ stop_time }}",
+    "runtime_id": "{{ trace_id }}",
+    "seq_id": 2,
+    "origin": "ansible",
+    "host": {
+        "hostname": "{{ hostname }}",
+        "os": "{{ system }}",
+        "distribution": "{{ os_family }}",
+        "architecture": "{{ arch }}",
+        "kernel_version": "{{ kernel }}",
+        "kernel_release": "{{ kernel_version }}"
+    },
+    "application": {
+        "service_name": "datadog-ansible",
+        "service_version": "{{ role_version }}",
+        "language_name": "UNKNOWN",
+        "language_version": "n/a",
+        "tracer_version": "n/a"
+    },
+    "payload": {
+        "logs": [{
+            "message": "{{ stdout }}",
+            "level": "DEBUG",
+            "trace_id": {{ datadog_installer_trace_id }},
+            "span_id": {{ datadog_installer_trace_id }}
+        },{
+            "message": "{{ stderr }}",
+            "level": "ERROR",
+            "trace_id": {{ datadog_installer_trace_id }},
+            "span_id": {{ datadog_installer_trace_id }}
+        }]
+    }
+}

--- a/templates/installer-telemetry.j2
+++ b/templates/installer-telemetry.j2
@@ -1,0 +1,52 @@
+{
+    "api_version": "v2",
+    "request_type": "traces",
+    "tracer_time": {{ stop_time }},
+    "runtime_id": "{{ trace_id }}",
+    "seq_id": 1,
+    "origin": "ansible",
+    "host": {
+        "hostname": "{{ hostname }}",
+        "os": "{{ system }}",
+        "distribution": "{{ os_family }}",
+        "architecture": "{{ arch }}",
+        "kernel_version": "{{ kernel }}",
+        "kernel_release": "{{ kernel_version }}"
+    },
+    "application": {
+        "service_name": "datadog-ansible",
+        "service_version": "{{ role_version }}",
+        "language_name": "UNKNOWN",
+        "language_version": "n/a",
+        "tracer_version": "n/a"
+    },
+    "payload": {
+        "traces": [[{
+            "service": "datadog-ansible",
+            "name": "install_installer",
+            "resource": "install_installer",
+            "trace_id": {{ trace_id }},
+            "span_id": {{ trace_id }},
+            "parent_id": 0,
+            "start": {{ start_time }},
+            "duration": {{ stop_time - start_time }},
+            "error": {{ rc }},
+            "meta": {
+                "language": "yaml",
+                "exit_code": {{ rc }},
+                "error": {
+                    "message": "{{ stderr }}"
+                },
+                "version": "{{ role_version }}",
+                "packages_to_install": "{{ packages_to_install }}",
+                "packages_to_install_after_installer": "{{ packages_to_install_filtered }}"
+            },
+            "metrics": {
+                "_trace_root": 1,
+                "_top_level": 1,
+                "_dd.top_level": 1,
+                "_sampling_priority_v1": 2
+            }
+        }]]
+    }
+}


### PR DESCRIPTION
This PR adds initial support for the datadog-installer.
It will install it if APM is enabled, as is the case for the install script, and will delegate installation of the injector and tracer libraries to it. 
Installation of tracer libraries are now gated behind a check that ensures the installer doesn't currently own that package.
It also provides telemetry similar to what the install script provides
BARX-381