### PR TITLE
[Fix] Correctly read install.json on remote computer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
       - checkout
       - run:
           name: Install Rosetta 2
-          command: sudo softwareupdate --install-rosetta
+          command: printf 'A\n' | sudo softwareupdate --install-rosetta
       - run:
           name: Install Python3
           command: brew install python@3.11

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,6 +196,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Install Rosetta 2
+          command: sudo softwareupdate --install-rosetta
+      - run:
           name: Install Python3
           command: brew install python@3.11
       - run:

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -105,7 +105,7 @@
 
 - name: Read remote install.json
   register: install_json_value
-  ansible.builtin.slurp:
+  slurp:
     src: "{{ agent_dd_config_dir }}/install.json"
   when: install_file.stat.exists
 

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -103,9 +103,15 @@
     path: "{{ agent_dd_config_dir }}/install.json"
   register: install_file
 
+- name: read remote install.json
+  register: install_json_value
+  ansible.builtin.slurp:
+    src: "{{ agent_dd_config_dir }}/install.json"
+  when: install_file.stat.exists
+
 - name: Parse install.json file if it exists
   set_fact:
-    install_info: "{{ lookup('file', install_file.stat.path) | from_json }}"
+    install_info: "{{ install_json_value.content | from_json }}"
   when: install_file.stat.exists
 
 - name: Generate uuid

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -111,12 +111,12 @@
 
 - name: Debug print install.json content
   debug:
-    msg: "install.json content :\n{{ install_json_value.content }}"
+    msg: "install.json content : {{ install_json_value.content }}"
   when: install_file.stat.exists
 
 - name: Parse install.json file if it exists
   set_fact:
-    install_info: "{{ install_json_value.content | from_json }}"
+    install_info: "{{ install_json_value.content | b64decode | from_json }}"
   when: install_file.stat.exists
 
 - name: Generate uuid

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -109,6 +109,11 @@
     src: "{{ agent_dd_config_dir }}/install.json"
   when: install_file.stat.exists
 
+- name: Debug print install.json content
+  debug:
+    msg: "install.json content :\n{{ install_json_value.content }}"
+  when: install_file.stat.exists
+
 - name: Parse install.json file if it exists
   set_fact:
     install_info: "{{ install_json_value.content | from_json }}"

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -103,7 +103,7 @@
     path: "{{ agent_dd_config_dir }}/install.json"
   register: install_file
 
-- name: read remote install.json
+- name: Read remote install.json
   register: install_json_value
   ansible.builtin.slurp:
     src: "{{ agent_dd_config_dir }}/install.json"

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -215,7 +215,7 @@
       register: agent_repofilecustom
       when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
 
-    - name: Clean repo metadata if repo changed # noqa: command-instead-of-module
+    - name: Clean repo metadata if repo changed # noqa: command-instead-of-module no-handler
       command: yum clean metadata --disablerepo="*" --enablerepo=datadog
       failed_when: false # Cleaning the metadata is only needed when downgrading a major version of the Agent, don't fail because of this
       when: agent_repofile5.changed or agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed
@@ -224,7 +224,7 @@
     # On certain version of dnf, gpg keys aren't imported into the local db with the package install task.
     # This rule assures that they are correctly imported into the local db and users won't have to manually accept
     # them if running dnf commands on the hosts.
-    - name: Refresh Datadog repository cache # noqa: command-instead-of-module
+    - name: Refresh Datadog repository cache # noqa: command-instead-of-module no-handler
       command: yum -y makecache --disablerepo="*" --enablerepo=datadog
       failed_when: false
       when: agent_repofile5.changed or agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed


### PR DESCRIPTION
Fix #574 

The `lookup` function only read in local files, switching to `slurp` instead

Adds Rosetta 2 on MacOS to run the agent since circle ci deprecated intel runners