### PR TITLE
chore(codeowners): udapte barx to agent-delivery

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
-*             @DataDog/agent-build-and-releases
+*             @DataDog/agent-delivery
 
 # Docs
-*README.md    @DataDog/agent-build-and-releases @DataDog/documentation
+*README.md    @DataDog/agent-delivery @DataDog/documentation


### PR DESCRIPTION
This PR updates the codeowners to the updated team name Agent Delivery