### PR TITLE
[BARX-405] Run linter

### DIFF
--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -116,7 +116,7 @@
           kernel_version=ansible_facts.kernel_version,
           role_version=role_version,
           rc=datadog_installer_bootstrap_result.rc if datadog_installer_bootstrap_result is defined else datadog_installer_install_result.rc,
-          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),\n
           start_time=datadog_installer_start_time.stdout | int,
           stop_time=datadog_installer_stop_time.stdout | int,
           packages_to_install=datadog_apm_instrumentation_libraries_unfiltered,
@@ -150,7 +150,7 @@
           kernel_version=ansible_facts.kernel_version,
           role_version=role_version,
           stdout=datadog_installer_install_result.stdout | default('') + datadog_installer_bootstrap_result.stdout | default(''),
-          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),
+          stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),\n
       )
       )}}"
 


### PR DESCRIPTION
The ansible-lint [job](https://app.circleci.com/pipelines/github/DataDog/ansible-datadog/1143/workflows/25a8b5d7-aca2-4aa3-a1b7-74130b91849e/jobs/98094) throws two warnings:
```
jinja[spacing]: Jinja2 spacing could be improved: {{ lookup( 'template', 'templates/installer-telemetry.j2', template_vars=dict( trace_id=datadog_installer_trace_id, hostname=ansible_hostname, system=ansible_facts.system, os_family=ansible_facts.os_family, arch=ansible_facts.machine, kernel=ansible_facts.kernel, kernel_version=ansible_facts.kernel_version, role_version=role_version, rc=datadog_installer_bootstrap_result.rc if datadog_installer_bootstrap_result is defined else datadog_installer_install_result.rc, stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''), start_time=datadog_installer_start_time.stdout | int, stop_time=datadog_installer_stop_time.stdout | int, packages_to_install=datadog_apm_instrumentation_libraries_unfiltered, packages_to_install_filtered=datadog_apm_instrumentation_libraries, )) }} -> {{ lookup(

jinja[spacing]: Jinja2 spacing could be improved: {{ lookup( 'template', 'templates/installer-logs.j2', template_vars=dict( stop_time=datadog_installer_stop_time.stdout, trace_id=datadog_installer_trace_id, hostname=ansible_hostname, system=ansible_facts.system, os_family=ansible_facts.os_family, arch=ansible_facts.machine, kernel=ansible_facts.kernel, kernel_version=ansible_facts.kernel_version, role_version=role_version, stdout=datadog_installer_install_result.stdout | default('') + datadog_installer_bootstrap_result.stdout | default(''), stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''), ) )}} -> {{ lookup(
```
It was difficult to find the cause of this because the recommendation was exactly the same. I use `ansible-lint --write` which added some `\n` everywhere. After removing all of them but one, the warning was not there anymore.