### PR TITLE
[BARX-405 ] Fix APM integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git
       - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .
-      - run: cd /tmp/system-tests/utils/build/virtual_machine/weblogs/python/test-app-python-container/ && sudo docker-compose up --detach
+      - run: sudo docker run -d --name test-app-python -p 5985:18080 system-tests/local:latest
       - run: curl localhost:5985
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)


### PR DESCRIPTION
The docker compose file was removed by https://github.com/DataDog/system-tests/commit/88b0b0d469657c4ac87e3592f7de5d1e1cc99ff2#diff-ebd3ce7ad22c7ee98619fd59c5dc94abbfddabfa1c906060053199b79888f312 and had the following content:
```
version: '3'
services:
  test-app-python:
    container_name: test-app-python
    image: system-tests/local:latest
    ports:
      - 5985:18080 
```
Let's not rely on it anymore