### PR TITLE
Speed up the conf.d checks

### DIFF
--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -18,20 +18,26 @@
   when: datadog_manage_config
   notify: "{{ agent_dd_notify_agent }}"
 
-- name: Register all checks directories present in datadog
+- name: Register all check configs present in datadog
   find:
     paths: "{{ agent_dd_config_dir }}/conf.d/"
     patterns:
-      - "*.d"
-    file_type: directory
-  register: agent_datadog_conf_directories
+      - "conf.yaml*"
+    recurse: true
+    depth: 2
+    file_type: file
+  register: agent_datadog_conf_paths
   when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in agent_datadog_tracked_checks
   file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\/conf\.yaml$') | list
+      | map('dirname') | map('basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_untracked_checks and item not in agent_datadog_tracked_checks
   notify: "{{ agent_dd_notify_agent }}"
 
@@ -39,7 +45,11 @@
   file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml.default"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\/conf\.yaml\.default$') | list
+      | map('dirname') | map('basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_default_checks and item not in agent_datadog_tracked_checks
   notify: "{{ agent_dd_notify_agent }}"
 
@@ -47,7 +57,11 @@
   file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml.example"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('basename') | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\/conf\.yaml\.example$') | list
+      | map('dirname') | map('basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_example_checks and item not in agent_datadog_tracked_checks
   notify: "{{ agent_dd_notify_agent }}"
 

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -7,21 +7,26 @@
   when: datadog_manage_config
   notify: restart datadog-agent-win
 
-- name: Register all checks directories present in datadog
+- name: Register all check configs present in datadog
   win_find:
     paths: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d"
     patterns:
-      - "*.d"
-    file_type: directory
-  register: agent_datadog_conf_directories
+      - "conf.yaml*"
+    recurse: true
+    depth: 2
+    file_type: file
+  register: agent_datadog_conf_paths
   when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in agent_datadog_tracked_checks
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('win_basename')
-    | list | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\\conf\.yaml$') | list
+      | map('win_dirname') | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_untracked_checks and item not in agent_datadog_tracked_checks
   notify: restart datadog-agent-win
 
@@ -29,8 +34,11 @@
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list
-    | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\\conf\.yaml\.default$') | list
+      | map('win_dirname') | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_default_checks and item not in agent_datadog_tracked_checks
   notify: restart datadog-agent-win
 
@@ -38,8 +46,11 @@
   win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.example"
     state: absent
-  loop: "{{ agent_datadog_conf_directories.files | map(attribute='path') | list | map('win_basename') | list
-    | map('regex_replace', '^(.*).d$', '\\1') | list }}"
+  loop: >-
+    {{
+      agent_datadog_conf_paths.files | map(attribute='path') | select('match', '.*\\conf\.yaml\.example$') | list
+      | map('win_dirname') | map('win_basename') | list | map('regex_replace', '^(.*).d$', '\1') | list
+    }}
   when: datadog_manage_config and datadog_disable_example_checks and item not in agent_datadog_tracked_checks
   notify: restart datadog-agent-win
 


### PR DESCRIPTION
When using the config options `datadog_disable_untracked_checks`, `datadog_disable_default_checks` or `datadog_disable_example_checks`, the Ansible run is very slow as it runs a separate task for every directory in the `conf.d` folder.

Instead, if we change the `find` call to look for conf.yaml* files in the subdirectories, we can filter the results and target specifically what we need, resulting in a much faster role.