### PR TITLE
Fix datadog-installer install on RHEL derivatives

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,4 +350,4 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
-              os: ["debian", "centos", "amazonlinux2", "suse"]
+              os: ["debian", "centos", "amazonlinux2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,4 +350,4 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10", "5_3", "9_4"]
-              os: ["debian", "centos"]
+              os: ["debian", "centos", "amazonlinux2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -349,5 +349,5 @@ workflows:
       - test_installer:
          matrix:
            parameters:
-              ansible_version: ["2_10", "3_4", "4_10", "5_3", "9_4"]
+              ansible_version: ["2_10", "3_4", "4_10"]
               os: ["debian", "centos", "amazonlinux2"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,4 +350,4 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
-              os: ["debian", "centos", "amazonlinux2"]
+              os: ["debian", "centos", "amazonlinux2", "suse"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -350,6 +350,4 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10", "5_3", "9_4"]
-              # There is no stable release of the installer on RHEL derivatives yet
-              # but we should include it as soon as possible
-              os: ["debian"]
+              os: ["debian", "centos"]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -66,6 +66,8 @@ datadog_agent_flavor: "datadog-agent"
 # Default Package name for APM Library Injection APT and RPM installs.
 datadog_inject_apm_flavor: "datadog-apm-inject"
 
+datadog_installer_flavor: "datadog-installer"
+
 # Default apt repo and keyserver
 
 # By default, the role uses the official apt Datadog repository for the chosen major version

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -20,10 +20,6 @@
   include_tasks: pkg-redhat/install-installer-yum.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "yum"
 
-- name: Include installer SUSE install task
-  include_tasks: pkg-suse/install-installer-suse.yml
-  when: ansible_facts.os_family == "Suse" and not agent_datadog_skip_install
-
 - name: Include installer YUM install task
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -20,6 +20,10 @@
   include_tasks: pkg-redhat/install-installer-yum.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "yum"
 
+- name: Include installer SUSE install task
+  include_tasks: pkg-suse/install-installer-suse.yml
+  when: ansible_facts.os_family == "Suse" and not agent_datadog_skip_install
+
 - name: Include installer YUM install task
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -10,7 +10,7 @@
 
 - name: Install datadog-installer package (dnf)
   dnf:
-    name: "datadog-installer"
+    name: "{{ datadog_installer_flavor }}"
     update_cache: true
     state: latest # noqa package-latest
   register: datadog_installer_install_result
@@ -23,7 +23,7 @@
 
 - name: Install latest datadog-agent package (yum)
   yum:
-    name: "datadog-installer"
+    name: "{{ datadog_installer_flavor }}"
     update_cache: true
     state: latest # noqa package-latest
   register: datadog_installer_install_result
@@ -32,7 +32,7 @@
 
 - name: Install Datadog installer (apt)
   apt:
-    name: "datadog-installer"
+    name: "{{ datadog_installer_flavor }}"
     state: latest # noqa package-latest
     update_cache: true
     cache_valid_time: "{{ datadog_apt_cache_valid_time }}"

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -24,10 +24,6 @@
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 
-- name: debug
-  debug:
-    msg: "{{ datadog_installer_install_result }}"
-
 - name: Bootstrap the installer
   command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -8,37 +8,25 @@
   register: datadog_installer_start_time
   changed_when: true
 
-- name: Install datadog-installer package (dnf)
-  dnf:
-    name: "{{ datadog_installer_flavor }}"
-    update_cache: true
-    state: latest # noqa package-latest
-  register: datadog_installer_install_result
-  # Since we want to send telemetry including when the installation failed,
-  # we need to explicitely ignore failures and skip dependent task when one
-  # of its depedency failed
-  # By default ansible will stop on the first error
-  ignore_errors: true
+# Dispatch through an include_tasks in order to be able to use the same variable name
+# for the tasks results.
+# Doing the install here directly would always set the latest task to the used register
+# including when the task is skipped.
+- name: Include installer DNF install task
+  include_tasks: pkg-redhat/install-installer-dnf.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "dnf"
 
-- name: Install latest datadog-agent package (yum)
-  yum:
-    name: "{{ datadog_installer_flavor }}"
-    update_cache: true
-    state: latest # noqa package-latest
-  register: datadog_installer_install_result
-  ignore_errors: true
+- name: Include installer YUM install task
+  include_tasks: pkg-redhat/install-installer-yum.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "yum"
 
-- name: Install Datadog installer (apt)
-  apt:
-    name: "{{ datadog_installer_flavor }}"
-    state: latest # noqa package-latest
-    update_cache: true
-    cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
-  register: datadog_installer_install_result
-  ignore_errors: true
+- name: Include installer YUM install task
+  include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
+
+- name: debug
+  debug:
+    msg: "{{ datadog_installer_install_result }}"
 
 - name: Bootstrap the installer
   command: /usr/bin/datadog-bootstrap bootstrap

--- a/tasks/pkg-debian/install-installer.yml
+++ b/tasks/pkg-debian/install-installer.yml
@@ -1,0 +1,9 @@
+---
+- name: Install Datadog installer (apt)
+  apt:
+    name: "{{ datadog_installer_flavor }}"
+    state: latest # noqa package-latest
+    update_cache: true
+    cache_valid_time: "{{ datadog_apt_cache_valid_time }}"
+  register: datadog_installer_install_result
+  ignore_errors: true

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -136,6 +136,13 @@
          {{ agent_dd_apm_install_pkgs | default([], true) | join(' ') }}"
       when: agent_datadog_agent_redhat_version is not defined
 
+    - name: Include datadog-installer to includepgks
+      set_fact:
+        agent_datadog_includepkgs:
+          "{{ agent_datadog_includepkgs }} datadog-installer"
+      when: datadog_installer_enabled
+
+
     - name: Install Datadog Agent 5 yum repo
       yum_repository:
         name: datadog

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -139,7 +139,7 @@
     - name: Include datadog-installer to includepgks
       set_fact:
         agent_datadog_includepkgs:
-          "{{ agent_datadog_includepkgs }} datadog-installer"
+          "{{ agent_datadog_includepkgs }} {{ datadog_installer_flavor }}"
       when: datadog_installer_enabled
 
 

--- a/tasks/pkg-redhat/install-installer-dnf.yml
+++ b/tasks/pkg-redhat/install-installer-dnf.yml
@@ -1,0 +1,13 @@
+---
+- name: Install datadog-installer package (dnf)
+  dnf:
+    name: "{{ datadog_installer_flavor }}"
+    update_cache: true
+    state: latest # noqa package-latest
+  register: datadog_installer_install_result
+  # Since we want to send telemetry including when the installation failed,
+  # we need to explicitely ignore failures and skip dependent task when one
+  # of its depedency failed
+  # By default ansible will stop on the first error
+  ignore_errors: true
+

--- a/tasks/pkg-redhat/install-installer-dnf.yml
+++ b/tasks/pkg-redhat/install-installer-dnf.yml
@@ -10,4 +10,3 @@
   # of its depedency failed
   # By default ansible will stop on the first error
   ignore_errors: true
-

--- a/tasks/pkg-redhat/install-installer-yum.yml
+++ b/tasks/pkg-redhat/install-installer-yum.yml
@@ -1,0 +1,8 @@
+---
+- name: Install latest datadog-agent package (yum)
+  yum:
+    name: "{{ datadog_installer_flavor }}"
+    update_cache: true
+    state: latest # noqa package-latest
+  register: datadog_installer_install_result
+  ignore_errors: true

--- a/tasks/pkg-suse/install-installer.yml
+++ b/tasks/pkg-suse/install-installer.yml
@@ -1,7 +1,0 @@
----
-- name: Install datadog-installer (SUSE)
-  zypper:
-    name: "{{ datadog_installer_flavor }}"
-    state: latest # noqa package-latest
-  register: agent_datadog_agent_install
-

--- a/tasks/pkg-suse/install-installer.yml
+++ b/tasks/pkg-suse/install-installer.yml
@@ -1,0 +1,7 @@
+---
+- name: Install datadog-installer (SUSE)
+  zypper:
+    name: "{{ datadog_installer_flavor }}"
+    state: latest # noqa package-latest
+  register: agent_datadog_agent_install
+


### PR DESCRIPTION
The package was not mentionned in includepkgs, causing it not to be considered as available