### PR TITLE
Don't require APM to enable datadog-installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,8 +252,20 @@ jobs:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
-      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml" -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>" -e datadog_remote_updates="<<parameters.remote_updates>>"
-      - run: bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then datadog-installer version; elif command -v datadog-installer; then echo datadog-installer should not be installed; exit 2; else echo datadog-installer is not installed as expected; fi'
+      - run: >
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
+          -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
+          -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
+          -e datadog_remote_updates="<<parameters.remote_updates>>"
+      - run: >
+          bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
+              datadog-installer version;
+            elif command -v datadog-installer; then
+              echo datadog-installer should not be installed;
+              exit 2;
+            else
+              echo datadog-installer is not installed as expected;
+            fi'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,12 +244,16 @@ jobs:
       inventory:
         type: string
         default: "ci.ini"
+      apm_enabled:
+        type: string
+      remote_updates:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
-      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
-      - run: datadog-installer version
+      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml" -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>" -e datadog_remote_updates="<<parameters.remote_updates>>"
+      - run: bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then datadog-installer version; elif command -v datadog-installer; then echo datadog-installer should not be installed; exit 2; else echo datadog-installer is not installed as expected; fi'
 
 workflows:
   version: 2
@@ -351,3 +355,5 @@ workflows:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: ["debian", "centos", "amazonlinux2"]
+              apm_enabled: ["host", ""]
+              remote_updates: ["true", "false"]

--- a/ci_test/install_installer.yaml
+++ b/ci_test/install_installer.yaml
@@ -7,5 +7,3 @@
     datadog_api_key: "11111111111111111111111111111111"
     datadog_enabled: false
     datadog_skip_running_check: true
-    datadog_apm_instrumentation_enabled: host
-    datadog_remote_updates: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -211,6 +211,9 @@ datadog_apm_instrumentation_docker_config:
     - stderr
   config_sources: BASIC
 
+# Enable remote updates through datadog-installer
+datadog_remote_updates: false
+
 #
 # Internal variables
 # The following variables are for internal use only, do not modify them.

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -2,4 +2,4 @@
 - name: Enable installer
   set_fact:
     datadog_installer_enabled: true
-  when: datadog_apm_instrumentation_enabled | length > 0
+  when: datadog_apm_instrumentation_enabled | length > 0 or datadog_remote_updates | bool


### PR DESCRIPTION
This PR allows the datadog-installer to be enabled trough a new `remote_updates` variable