### PR TITLE
Don't install the agent when it is installed through the installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,10 @@ jobs:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
+        # datadog-installer will bailout if there's no systemctl binary, and won't attempt to
+        # create the systemd folder to store its units
+        # Since we're running the tests in a docker container without systemd, we can "help" it
+        # proceed by pretending systemd is there
       - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
       - run: mkdir -p /etc/systemd/system/
       - run: >

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,11 +260,19 @@ jobs:
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
+              if [ -d /opt/datadog-agent ]; then
+                echo "The agent should NOT have been installed by the distribution";
+                exit 1;
+              fi
             elif command -v datadog-installer; then
               echo datadog-installer should not be installed;
               exit 2;
             else
               echo datadog-installer is not installed as expected;
+              if [ ! -d /opt/datadog-agent ]; then
+                echo "The agent should have been installed by the distribution";
+                exit 1;
+              fi
             fi'
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       # these repos have expired GPG keys and make APT fail (and we don't need them)
       - run: sudo rm /etc/apt/sources.list.d/*
       - run: pip3 install ansible==<<parameters.ansible_version>>
-      - run: ansible-playbook -vv --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
+      - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
       - run: sudo datadog-agent status || true
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,8 @@ jobs:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
       - checkout
+      - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
+      - run: mkdir -p /etc/systemd/system/
       - run: >
           ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -vv
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       # these repos have expired GPG keys and make APT fail (and we don't need them)
       - run: sudo rm /etc/apt/sources.list.d/*
       - run: pip3 install ansible==<<parameters.ansible_version>>
-      - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
+      - run: ansible-playbook -vv --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_python.yaml"
       - run: sudo datadog-agent status || true
       - run: ps aux | grep -v grep | grep datadog-agent
       - run: git -C /tmp clone https://github.com/DataDog/system-tests.git

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,15 +260,18 @@ jobs:
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
-              if [ -d /opt/datadog-agent ]; then
-                echo "The agent should NOT have been installed by the distribution";
-                exit 1;
-              fi
             elif command -v datadog-installer; then
               echo datadog-installer should not be installed;
               exit 2;
             else
               echo datadog-installer is not installed as expected;
+            fi
+            if [ "<<parameters.remote_updates>>" = "true" ]; then
+              if [ -d /opt/datadog-agent ]; then
+                echo "The agent should NOT have been installed by the distribution";
+                exit 1;
+              fi
+            else
               if [ ! -d /opt/datadog-agent ]; then
                 echo "The agent should have been installed by the distribution";
                 exit 1;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,7 +259,7 @@ jobs:
       - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
       - run: mkdir -p /etc/systemd/system/
       - run: >
-          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -vv
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
           -e datadog_remote_updates="<<parameters.remote_updates>>"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -253,7 +253,7 @@ jobs:
     steps:
       - checkout
       - run: >
-          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -vv
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
           -e datadog_remote_updates="<<parameters.remote_updates>>"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,8 +16,9 @@
   service:
     name: datadog-installer
     state: restarted
-  when: datadog_enabled and datadog_installer_enabled and not ansible_check_mode and
-    not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
+  # The installer currently only setup its systemd unit when remote updates are enabled
+  when: datadog_enabled and datadog_installer_enabled and datadog_remote_updates and
+    not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
 # We can't add the Windows Agent service restart handler directly here because that makes the role require
 # the ansible.windows collection on all platforms. We only want it to be needed on Windows.

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,6 +12,13 @@
     state: restarted
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
+- name: restart datadog-installer  # noqa name[casing]
+  service:
+    name: datadog-installer
+    state: restarted
+  when: datadog_enabled and datadog_installer_enabled and not ansible_check_mode and
+    not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
+
 # We can't add the Windows Agent service restart handler directly here because that makes the role require
 # the ansible.windows collection on all platforms. We only want it to be needed on Windows.
 # Therefore, what we do is the following: when needed, our Windows tasks call this handler to require a

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -30,7 +30,7 @@
     agent_dd_config_dir: /etc/datadog-agent
     agent_dd_user: "{{ datadog_user }}"
     agent_dd_group: "{{ datadog_group }}"
-    agent_dd_notify_agent: restart datadog-agent
+    agent_dd_notify_agent: [restart datadog-agent, restart datadog-installer]
 
 - name: Create system-probe configuration file
   template:

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -32,7 +32,7 @@
     DATADOG_PARENT_ID: "{{ datadog_installer_trace_id }}"
     DD_SITE: "{{ datadog_site | default('datadoghq.com') }}"
     DD_API_KEY: "{{ datadog_api_key }}"
-    DD_REMOTE_UPDATES: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates else '' }}"
+    DD_REMOTE_UPDATES: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '' }}"
     DD_APM_INSTRUMENTATION_ENABLED: "{{ datadog_apm_instrumentation_enabled }}"
     DD_APM_INSTRUMENTATION_LIBRARIES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
   ignore_errors: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -80,6 +80,10 @@
     - not datadog_installer_bootstrap_result.failed
   loop: "{{ datadog_installer_owned_apm_packages.results }}"
 
+- name: debug APM libs
+  debug:
+    msg: "{{ datadog_apm_instrumentation_libraries }}"
+
 - name: Stop duration measurements
   command: "date +%s%N"
   register: datadog_installer_stop_time

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -39,10 +39,6 @@
   when: not datadog_installer_install_result.failed
   changed_when: true
 
-# Ensure the service exists now
-- name: Populate service facts
-  service_facts:
-
 - name: Check if installer owns datadog-agent package
   command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
@@ -83,10 +79,6 @@
     - item.rc == 0
     - not datadog_installer_bootstrap_result.failed
   loop: "{{ datadog_installer_owned_apm_packages.results }}"
-
-- name: debug APM libs
-  debug:
-    msg: "{{ datadog_apm_instrumentation_libraries }}"
 
 - name: Stop duration measurements
   command: "date +%s%N"

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -53,6 +53,10 @@
   when: not datadog_installer_bootstrap_result.failed
   changed_when: true
 
+- name: debug
+  debug:
+    msg: "owns agent rc: {{ datadog_installer_owns_agent }}"
+
 - name: Disable agent install if owned by installer
   set_fact:
     agent_datadog_skip_install: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -24,10 +24,6 @@
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 
-- name: debug remote updates
-  debug:
-    msg: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '' }}"
-
 - name: Bootstrap the installer
   command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -39,6 +39,10 @@
   when: not datadog_installer_install_result.failed
   changed_when: true
 
+# Ensure the service exists now
+- name: Populate service facts
+  service_facts:
+
 - name: Check if installer owns datadog-agent package
   command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -57,10 +57,6 @@
   when: not datadog_installer_bootstrap_result.failed
   changed_when: true
 
-- name: debug
-  debug:
-    msg: "owns agent rc: {{ datadog_installer_owns_agent }}"
-
 - name: Disable agent install if owned by installer
   set_fact:
     agent_datadog_skip_install: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -24,6 +24,10 @@
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 
+- name: debug remote updates
+  debug:
+    msg: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '' }}"
+
 - name: Bootstrap the installer
   command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -123,11 +123,11 @@
 
 - name: Include debian pinned version install task
   include_tasks: pkg-debian/install-pinned.yml
-  when: agent_datadog_agent_debian_version is defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_debian_version is defined
 
 - name: Include debian latest version install task
   include_tasks: pkg-debian/install-latest.yml
-  when: agent_datadog_agent_debian_version is not defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_debian_version is not defined
 
 - name: Install latest datadog-signing-keys package
   apt:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -254,8 +254,8 @@
 
 - name: Include redhat agent pinned version install task
   include_tasks: pkg-redhat/install-pinned.yml
-  when: agent_datadog_agent_redhat_version is defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_redhat_version is defined
 
 - name: Include redhat agent latest version install task
   include_tasks: pkg-redhat/install-latest.yml
-  when: agent_datadog_agent_redhat_version is not defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_redhat_version is not defined

--- a/tasks/pkg-redhat/install-installer-yum.yml
+++ b/tasks/pkg-redhat/install-installer-yum.yml
@@ -1,5 +1,5 @@
 ---
-- name: Install latest datadog-agent package (yum)
+- name: Install latest datadog-installer package (yum)
   yum:
     name: "{{ datadog_installer_flavor }}"
     update_cache: true

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -138,8 +138,8 @@
 
 - name: Include Suse agent pinned version install task
   include_tasks: pkg-suse/install-pinned.yml
-  when: agent_datadog_agent_suse_version is defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_suse_version is defined
 
 - name: Include Suse agent latest version install task
   include_tasks: pkg-suse/install-latest.yml
-  when: agent_datadog_agent_suse_version is not defined
+  when: not agent_datadog_skip_install and agent_datadog_agent_suse_version is not defined

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -133,7 +133,7 @@
 # refresh zypper repos only if the template changed
 - name: Refresh Datadog zypper_repos # noqa: command-instead-of-module
   command: zypper refresh datadog
-  when: agent_datadog_zypper_repo_template.changed and not ansible_check_mode
+  when: not agent_datadog_skip_install and agent_datadog_zypper_repo_template.changed and not ansible_check_mode
   changed_when: true
 
 - name: Include Suse agent pinned version install task


### PR DESCRIPTION
The detection was working correctly, but we were only abiding by the agent_datadog_skip_install flag on macOS and Windows