### PR TITLE
Fix security-agent.yaml.j2

### DIFF
--- a/templates/security-agent.yaml.j2
+++ b/templates/security-agent.yaml.j2
@@ -10,6 +10,7 @@ runtime_security_config:
 {{ runtime_security_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}
+
 {% if compliance_config is defined and compliance_config | default({}, true) | length > 0 -%}
 compliance_config:
 {# The "first" option in indent() is only supported by jinja 2.10+


### PR DESCRIPTION
Missing line break seems to cause the `compliance_config` variable to be indented and therefore placed within the `runtime_security_config` variable which leads to an incorrect configuration for CSM.