### PR TITLE
Fix datadog-installer handling on SUSE

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
           -e datadog_remote_updates="true"
       - run: >
           bash -c 'datadog-installer version;
-              if [ ! -d /opt/datadog-packages/agent ]; then
+              if [ ! -d /opt/datadog-packages/datadog-agent ]; then
                 echo "The agent should have been installed by the installer";
                 exit 1;
               fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,37 @@ jobs:
               fi
             fi'
 
+  test_installer_suse:
+    parameters:
+      ansible_version:
+        type: string
+      jinja2_native:
+        type: string
+        default: "false"
+      inventory:
+        type: string
+        default: "ci.ini"
+    docker:
+      - image: datadog/docker-library:ansible_suse_<<parameters.ansible_version>>
+    steps:
+      - checkout
+        # datadog-installer will bailout if there's no systemctl binary, and won't attempt to
+        # create the systemd folder to store its units
+        # Since we're running the tests in a docker container without systemd, we can "help" it
+        # proceed by pretending systemd is there
+      - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
+      - run: mkdir -p /etc/systemd/system/
+      - run: >
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
+          -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
+          -e datadog_remote_updates="true"
+      - run: >
+          bash -c 'datadog-installer version;
+              if [ -d /opt/datadog-agent ]; then
+                echo "The agent should NOT have been installed by the distribution";
+                exit 1;
+              fi'
+
 workflows:
   version: 2
   test_datadog_role:
@@ -386,3 +417,8 @@ workflows:
               os: ["debian", "centos", "amazonlinux2", "suse"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
+
+      - test_installer_suse:
+         matrix:
+           parameters:
+              ansible_version: ["2_10", "3_4", "4_10"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,6 +310,10 @@ jobs:
           -e datadog_remote_updates="true"
       - run: >
           bash -c 'datadog-installer version;
+              if [ ! -d /opt/datadog-packages/agent ]; then
+                echo "The agent should have been installed by the installer";
+                exit 1;
+              fi
               if [ -d /opt/datadog-agent ]; then
                 echo "The agent should NOT have been installed by the distribution";
                 exit 1;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -414,7 +414,7 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
-              os: ["debian", "centos", "amazonlinux2", "suse"]
+              os: ["debian", "centos", "amazonlinux2"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -383,6 +383,6 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
-              os: ["debian", "centos", "amazonlinux2"]
+              os: ["debian", "centos", "amazonlinux2", "suse"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -20,7 +20,7 @@
   include_tasks: pkg-redhat/install-installer-yum.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "yum"
 
-- name: Include installer YUM install task
+- name: Include installer DEB install task
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -24,6 +24,10 @@
   include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 
+- name: Include installer Zypper install task
+  include_tasks: pkg-suse/install-installer-zypper.yml
+  when: ansible_facts.os_family == "Suse" and not ansible_check_mode
+
 - name: Bootstrap the installer
   command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -130,6 +130,10 @@
   register: agent_datadog_zypper_repo_template
   when: datadog_manage_zypper_repofile
 
+- name: Include installer setup
+  include_tasks: installer-setup.yml
+  when: datadog_installer_enabled
+
 # refresh zypper repos only if the template changed
 - name: Refresh Datadog zypper_repos # noqa: command-instead-of-module
   command: zypper refresh datadog

--- a/tasks/pkg-suse/install-installer-zypper.yml
+++ b/tasks/pkg-suse/install-installer-zypper.yml
@@ -1,0 +1,7 @@
+---
+- name: Install latest datadog-installer package (zypper)
+  zypper:
+    name: "{{ datadog_installer_flavor }}"
+    state: latest # noqa package-latest
+  register: datadog_installer_install_result
+  ignore_errors: true


### PR DESCRIPTION
I completely overlooked the existing differences between SUSE and RHEL, causing the installer setup to be missing for that distribution