### PR TITLE
add ansible_managed to checks.yaml template

### DIFF
--- a/templates/checks.yaml.j2
+++ b/templates/checks.yaml.j2
@@ -1,1 +1,3 @@
+# {{ ansible_managed }}
+
 {{ agent_datadog_checks[item] | to_nice_yaml(indent=2, width=160, sort_keys=False) }}


### PR DESCRIPTION
this simply adds the ansible_managed line to the checks.yaml template
ansible_managed is in every other meaningful settings template included just not in the check config template