### PR TITLE
[FA] Fix default APM setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,6 +252,7 @@ jobs:
           name: "Check tracers are installed with the installer"
           command: |
             for tracer in ["java", "js", "dotnet", "python", "ruby"]; do
+              print "Checking $tracer";
               sudo datadog-installer is-installed datadog-apm-library-$tracer;
             done
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,13 +248,11 @@ jobs:
       - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_all.yaml"
       - run: sudo datadog-agent status || true
       - run: ps aux | grep -v grep | grep datadog-agent
-      - run:
-          name: "Check tracers are installed with the installer"
-          command: |
-            for tracer in ["java", "js", "dotnet", "python", "ruby"]; do
-              print "Checking $tracer";
-              sudo datadog-installer is-installed datadog-apm-library-$tracer;
-            done
+      - run: >
+          bash -c 'for tracer in ["java", "js", "dotnet", "python", "ruby"]; do
+            print "Checking $tracer";
+            sudo datadog-installer is-installed datadog-apm-library-$tracer;
+          done'
 
   test_installer:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -232,6 +232,29 @@ jobs:
       # verify that the emitted trace is in trace-agent log
       - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)
 
+  test_apm_injection_all:
+    parameters:
+      ansible_version:
+        type: string
+    
+    machine:
+      image: ubuntu-2204:2023.10.1 # includes docker and docker-compose
+
+    steps:
+      - checkout
+      # these repos have expired GPG keys and make APT fail (and we don't need them)
+      - run: sudo rm /etc/apt/sources.list.d/*
+      - run: pip3 install ansible==<<parameters.ansible_version>>
+      - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_all.yaml"
+      - run: sudo datadog-agent status || true
+      - run: ps aux | grep -v grep | grep datadog-agent
+      - run:
+          name: "Check tracers are installed with the installer"
+          command: |
+            for tracer in ["java", "js", "dotnet", "python", "ruby"]; do
+              sudo datadog-installer is-installed datadog-apm-library-$tracer;
+            done
+
   test_installer:
     parameters:
       ansible_version:
@@ -410,6 +433,11 @@ workflows:
               python: ["python3"]
 
       - test_apm_injection:
+          matrix:
+            parameters:
+              ansible_version: ["6.7.0"]
+
+      - test_apm_injection_all:
           matrix:
             parameters:
               ansible_version: ["6.7.0"]

--- a/ci_test/install_agent_7_apm_all.yaml
+++ b/ci_test/install_agent_7_apm_all.yaml
@@ -1,0 +1,9 @@
+---
+
+- hosts: all
+  roles:
+    - { role: "/home/circleci/project/" }
+  vars:
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_agent_major_version: 7
+    datadog_apm_instrumentation_enabled: "host"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -197,7 +197,7 @@ datadog_apm_instrumentation_enabled: ""
 # Example: `["java:1.23.0", "python:2.0.9"]`
 # You can see the available values in our official docs:
 # https://docs.datadoghq.com/tracing/trace_collection/library_injection_local
-datadog_apm_instrumentation_libraries: ["java", "js", "dotnet", "python", "ruby"]
+datadog_apm_instrumentation_libraries: []
 
 # Used to send telemetry data to datadog on installation
 datadog_apm_telemetry_endpoint: "https://instrumentation-telemetry-intake.{{ datadog_site | default('datadoghq.com') }}/api/v2/apmtelemetry"

--- a/tasks/apm-inject-check.yml
+++ b/tasks/apm-inject-check.yml
@@ -17,7 +17,8 @@
 - name: Default to list of packages rather than "all"
   set_fact:
     datadog_apm_instrumentation_libraries: ["java", "js", "dotnet", "python", "ruby"]
-  when: datadog_apm_instrumentation_libraries == ["all"]
+  when: datadog_apm_instrumentation_libraries == ["all"] or 
+    ((datadog_apm_instrumentation_enabled in ["docker", "host", "all"]) and (datadog_apm_instrumentation_libraries | length == 0))
 
 - name: Check if docker daemon config dir exists
   stat:

--- a/tasks/apm-inject-check.yml
+++ b/tasks/apm-inject-check.yml
@@ -17,7 +17,7 @@
 - name: Default to list of packages rather than "all"
   set_fact:
     datadog_apm_instrumentation_libraries: ["java", "js", "dotnet", "python", "ruby"]
-  when: datadog_apm_instrumentation_libraries == ["all"] or 
+  when: datadog_apm_instrumentation_libraries == ["all"] or
     ((datadog_apm_instrumentation_enabled in ["docker", "host", "all"]) and (datadog_apm_instrumentation_libraries | length == 0))
 
 - name: Check if docker daemon config dir exists


### PR DESCRIPTION
Fix default APM setup
Fill the default list if one of the following is True:
* `datadog_apm_instrumentation_libraries` is set as `all`
* `datadog_apm_instrumentation_libraries` is empty AND `datadog_apm_instrumentation_enabled` was set

Else, we use what's given in `datadog_apm_instrumentation_libraries`