### PR TITLE
don't create system probe config when it's disabled

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -76,7 +76,6 @@
   when: datadog_manage_config and not datadog_skip_running_check and agent_datadog_sysprobe_enabled
   notify: "{% if agent_datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 
-
 - name: Ensure datadog-agent is running
   service:
     name: datadog-agent

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -32,16 +32,6 @@
     agent_dd_group: "{{ datadog_group }}"
     agent_dd_notify_agent: [restart datadog-agent, restart datadog-installer]
 
-- name: Create system-probe configuration file
-  template:
-    src: system-probe.yaml.j2
-    dest: /etc/datadog-agent/system-probe.yaml
-    mode: "0640"
-    owner: root
-    group: "{{ datadog_group }}"
-  when: datadog_manage_config
-  notify: "{% if agent_datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
-
 - name: Set system probe installed
   set_fact:
     agent_datadog_sysprobe_installed: "{{ ansible_facts.services['datadog-agent-sysprobe'] is defined or
@@ -75,6 +65,17 @@
       network_config['enabled']) or (service_monitoring_config is defined and
       'enabled' in (service_monitoring_config | default({}, true)) and service_monitoring_config['enabled'])) and agent_datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check and (not agent_datadog_before_7400)
+
+- name: Create system-probe configuration file
+  template:
+    src: system-probe.yaml.j2
+    dest: /etc/datadog-agent/system-probe.yaml
+    mode: "0640"
+    owner: root
+    group: "{{ datadog_group }}"
+  when: datadog_manage_config and agent_datadog_sysprobe_enabled
+  notify: "{% if agent_datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
+
 
 - name: Ensure datadog-agent is running
   service:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -73,7 +73,7 @@
     mode: "0640"
     owner: root
     group: "{{ datadog_group }}"
-  when: datadog_manage_config and agent_datadog_sysprobe_enabled
+  when: datadog_manage_config and not datadog_skip_running_check and agent_datadog_sysprobe_enabled
   notify: "{% if agent_datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 
 


### PR DESCRIPTION
This matches the behavior of the install script
[BARX-560]

[BARX-560]: https://datadoghq.atlassian.net/browse/BARX-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ