### PR TITLE
Fix distribution detection on Amazon Linux 2023

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -356,6 +356,22 @@ jobs:
       - run: >
           ansible-playbook -v -i ./ci_test/inventory/ci.ini "./ci_test/install_installer_over_pinned.yaml"
 
+  test_incorrect_rhel6_detect:
+    # Ensure some RHEL derivatives aren't incorrectly detected as RHEL 6
+    docker:
+      - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
+    parameters:
+      jinja2_native:
+        type: string
+        default: "false"
+      os:
+        type: string
+      ansible_version:
+        type: string
+    steps:
+      - checkout
+      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/ci.ini ./ci_test/install_agent_7_pinned.yaml
+      - run: datadog-agent version
 
 workflows:
   version: 2
@@ -472,3 +488,8 @@ workflows:
 
       - test_installer_over_pinned
 
+      - test_incorrect_rhel6_detect:
+         matrix:
+           parameters:
+              ansible_version: ["2_10", "3_4", "4_10"]
+              os: [ "amazonlinux2023"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,9 +366,9 @@ jobs:
         default: "false"
       os:
         type: string
-      python:
-        type: string
       ansible_version:
+        type: string
+      python:
         type: string
     steps:
       - checkout
@@ -493,6 +493,6 @@ workflows:
       - test_incorrect_rhel6_detect:
          matrix:
            parameters:
-              ansible_version: ["2_10", "3_4", "4_10"]
+              ansible_version: ["4_10"]
               os: [ "amazonlinux2023"]
-              python: ["python2"]
+              python: ["python3"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,11 +366,13 @@ jobs:
         default: "false"
       os:
         type: string
+      python:
+        type: string
       ansible_version:
         type: string
     steps:
       - checkout
-      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/ci.ini ./ci_test/install_agent_7_pinned.yaml
+      - run: ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -i ./ci_test/inventory/ci.ini ./ci_test/install_agent_7_pinned.yaml -e 'ansible_python_interpreter=/usr/bin/<<parameters.python>>'
       - run: datadog-agent version
 
 workflows:
@@ -493,3 +495,4 @@ workflows:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: [ "amazonlinux2023"]
+              python: ["python2"]

--- a/ci_test/install_agent_7_pinned.yaml
+++ b/ci_test/install_agent_7_pinned.yaml
@@ -1,0 +1,13 @@
+---
+
+- hosts: all
+  roles:
+    - { role: '/root/project/'}
+  vars:
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_enabled: false
+    # Target a version above 7.51 which is the last version supported on RHEL6 and similar
+    # This is to ensure we don't incorrectly detect some configurations as RHEL6
+    datadog_agent_version: '7.53.0'
+    # avoid checking that the agent is stopped for centos
+    datadog_skip_running_check: true

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -21,9 +21,12 @@
     msg: "Agent versions {{ agent_datadog_major }}.{{ datadog_agent_max_minor_version + 1 }} and above not supported by current OS (RHEL < 7 equivalent)."
   when: datadog_agent_max_minor_version is defined and agent_datadog_minor is defined and agent_datadog_minor | int > datadog_agent_max_minor_version
 
-- name: debug amazon facts
-  debug:
-    msg: '{{ ansible_facts }}'
+  # Some ansible versions appear to detect yum as the wanted package manager on AL2023.
+  # This can't work since AL2023 only ships python3 and the yum module needs python2
+- name: Ensure dnf is used on Amazon Linux 2023
+  set_fact:
+    ansible_pkg_mgr: dnf
+  when: ansible_facts.distribution == "Amazon" and ansible_facts.distribution_major_version | int >= 2023 and ansible_pkg_mgr == "yum"
 
 - name: Fail early if Python 3 is used on CentOS / RHEL < 8 with old Ansible
   fail:

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check for Centos < 7 and adjust features
-  when: ansible_facts.os_family == "RedHat"
+  when: ansible_facts.os_family == "RedHat" and ansible_distribution != "Amazon"
   block:
     - name: Get RHEL major version equivalent
       command: "rpm -E %{rhel}"  # noqa: command-instead-of-module

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -21,6 +21,10 @@
     msg: "Agent versions {{ agent_datadog_major }}.{{ datadog_agent_max_minor_version + 1 }} and above not supported by current OS (RHEL < 7 equivalent)."
   when: datadog_agent_max_minor_version is defined and agent_datadog_minor is defined and agent_datadog_minor | int > datadog_agent_max_minor_version
 
+- name: debug amazon facts
+  debug:
+    msg: '{{ ansible_facts }}'
+
 - name: Fail early if Python 3 is used on CentOS / RHEL < 8 with old Ansible
   fail:
     msg: "The installation of the Agent on RedHat family systems using yum is not compatible with Python 3 with older Ansible versions.


### PR DESCRIPTION
We are currently failing to detect the distribution on Amazon Linux 2023. It gets detected as RHEL with an unknown version, meaning it will be 0.
This causes the RHEL 6 and earlier logic to kick in, which means we can't install the agent 7.51+ on AL2023.

Additionally, this attempts to work around a questionable ansible behavior which insists on using the yum package manager, even though DNF is available. We in turn attempt to use the `yum` module which isn't compatible with python 3, which is the only python version available on AL2023

Should fix issues reported in AGENT-12306 and AGENT-12261