### PR TITLE
bump galaxy-importer dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-galaxy-importer==0.4.14
+galaxy-importer==0.4.25


### PR DESCRIPTION
This PR bumps the galaxy-importer dependency to fix a CVE. Note that galaxy-importer is not shipped to customers.

Closes https://github.com/DataDog/ansible-datadog/issues/614