### PR TITLE
reintroduce dependabot.yaml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
Dependabot was removed in https://github.com/DataDog/ansible-datadog/pull/394. This PR reintroduces it.