### PR TITLE
[AGENT-12513] Fix Ansible check mode when installer/apm injection is enabled

### DIFF
--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -95,7 +95,7 @@
     name: "{{ item }}"
     state: stopped
     enabled: false
-  when: not datadog_skip_running_check and not datadog_enabled
+  when: not datadog_skip_running_check and not datadog_enabled and not ansible_check_mode
   with_list:
     - datadog-agent
     - datadog-agent-process

--- a/tasks/apm-inject-install.yml
+++ b/tasks/apm-inject-install.yml
@@ -8,26 +8,26 @@
   when: not ansible_check_mode and ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"]
 
 - name: Run dd-host-install
-  when: not datadog_installer_enabled or not datadog_installer_owns_injector
+  when: not ansible_check_mode and (not datadog_installer_enabled or not datadog_installer_owns_injector)
   block:
     - name: Check if dd-host-install needs to run
       command: dd-host-install --no-config-change --no-agent-restart --dry-run
       register: agent_dd_host_install_cmd
       changed_when: false
-      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"]
+      when: datadog_apm_instrumentation_enabled in ["all", "host"]
       failed_when: agent_dd_host_install_cmd.rc >= 2
 
     - name: Run APM host injection setup script
       command: dd-host-install --no-config-change --no-agent-restart
       notify: restart datadog-agent
-      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "host"] and agent_dd_host_install_cmd.rc == 1
+      when: datadog_apm_instrumentation_enabled in ["all", "host"] and agent_dd_host_install_cmd.rc == 1
       changed_when: true
 
     - name: Check if dd-container-install needs to run
       command: dd-container-install --dry-run
       register: agent_dd_container_install_cmd
       changed_when: false
-      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"]
+      when: datadog_apm_instrumentation_enabled in ["all", "docker"]
       failed_when: agent_dd_container_install_cmd.rc >= 2
 
     - name: Create Docker APM injection config file
@@ -42,5 +42,5 @@
     - name: Run APM host-docker injection (Docker) setup script
       # this command will change /etc/docker/daemon.json and reload docker if changes are made.
       command: dd-container-install
-      when: not ansible_check_mode and datadog_apm_instrumentation_enabled in ["all", "docker"] and agent_dd_container_install_cmd.rc == 1
+      when: datadog_apm_instrumentation_enabled in ["all", "docker"] and agent_dd_container_install_cmd.rc == 1
       changed_when: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -50,38 +50,38 @@
     DD_AGENT_MAJOR_VERSION: "{{ datadog_agent_major_version | default('') }}"
     DD_AGENT_MINOR_VERSION: "{{ datadog_agent_minor_version | default('') }}"
   ignore_errors: true
-  when: not datadog_installer_install_result.failed
+  when: not ansible_check_mode and not datadog_installer_install_result.failed
   changed_when: true
 
 - name: Check if installer owns datadog-agent package
   command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
   register: datadog_installer_owns_agent
-  when: not datadog_installer_bootstrap_result.failed
+  when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed
   changed_when: true
 
 - name: Check if installer owns apm injector package
   command: datadog-installer is-installed "{{ datadog_inject_apm_flavor }}"
   failed_when: datadog_installer_owns_injector_result.rc != 0 and datadog_installer_owns_injector_result.rc != 10
   register: datadog_installer_owns_injector_result
-  when: not datadog_installer_bootstrap_result.failed
+  when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed
   changed_when: true
 
 - name: Register if the installer owns apm injector package
   set_fact:
     datadog_installer_owns_injector: "{{ datadog_installer_owns_injector_result.rc == 0 }}"
-  when: not datadog_installer_bootstrap_result.failed
+  when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed
 
 - name: Disable agent install if owned by installer
   set_fact:
     agent_datadog_skip_install: true
-  when: not datadog_installer_bootstrap_result.failed and datadog_installer_owns_agent.rc == 0
+  when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed and datadog_installer_owns_agent.rc == 0
 
 - name: Query APM packages owned by installer
   command: datadog-installer is-installed "datadog-apm-library-{{ item }}"
   register: datadog_installer_owned_apm_packages
   loop: "{{ datadog_apm_instrumentation_libraries }}"
-  when: not datadog_installer_bootstrap_result.failed
+  when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed
   failed_when: datadog_installer_owned_apm_packages.rc != 0 and datadog_installer_owned_apm_packages.rc != 10
   changed_when: true
   environment:
@@ -95,6 +95,7 @@
   set_fact:
     datadog_apm_instrumentation_libraries: "{{ datadog_apm_instrumentation_libraries | difference([item.item]) }}"
   when:
+    - not ansible_check_mode
     - item.rc == 0
     - not datadog_installer_bootstrap_result.failed
   loop: "{{ datadog_installer_owned_apm_packages.results }}"
@@ -106,6 +107,7 @@
       + [(item.item | regex_replace('[:]latest', '')  | regex_replace('^datadog-apm-library-', '') )]) }}"
   loop: "{{ datadog_installer_owned_apm_packages.results }}"
   when:
+    - not ansible_check_mode
     - item.rc == 0
     - not datadog_installer_bootstrap_result.failed
 
@@ -135,6 +137,7 @@
           packages_to_install=datadog_apm_instrumentation_libraries_unfiltered,
           packages_to_install_filtered=datadog_apm_instrumentation_libraries,
       )) }}"
+  when: not ansible_check_mode
 
 - name: Send Installer telemetry traces
   uri:
@@ -145,6 +148,7 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
+  when: not ansible_check_mode
   failed_when: false
 
 - name: Setup logs body
@@ -166,6 +170,7 @@
           stderr=datadog_installer_install_result.stderr | default('') + datadog_installer_bootstrap_result.stderr | default(''),\n
       )
       )}}"
+  when: not ansible_check_mode
 
 - name: Send Installer telemetry logs
   uri:
@@ -176,9 +181,10 @@
     headers:
       DD-Api-Key: "{{ datadog_api_key }}"
     body_format: json
+  when: not ansible_check_mode
   failed_when: false
 
 - name: Propagate failures after telemetry
   fail:
     msg: "Installer bootstrap failed: {{ datadog_installer_bootstrap_result.stderr }}"
-  when: datadog_installer_bootstrap_result.failed
+  when: not ansible_check_mode and datadog_installer_bootstrap_result.failed


### PR DESCRIPTION
### What does this PR do ?
* For the APM inject task, move the `not ansible_check_mode` condition to the parent `when`. We should not run any of the commands/file from `dd-host-install` in check mode which we were doing individually (except injecting the Docker config which we should not have done in check mode, so this "fixes" it incidentally)
* For the installer task, the playbook "depends" on `datadog_installer_install_result` which itself is only registered when not running in check mode, as coded in each `tasks/pkg-`, e.g.: https://github.com/DataDog/ansible-datadog/blob/a34e9623b9440c4f4ae11d19be1ac24a320e7936/tasks/pkg-debian/install-installer.yml#L8. Thus, we add `not ansible_check_mode` on all the subsequent steps that depend on this registry, as we should not run any bootstrap/installer command, nor attempt to send any telemetry in check mode
* In the main Agent linux task, do not try to check for services that might not exist (e.g. user never ran without `--check` yet)

### Motivation
Closes https://github.com/DataDog/ansible-datadog/issues/610

### QA instructions
Use a playbook with the installer:
#### Role
```yaml
- hosts: myhosts
  roles:
    - { role: ansible-datadog, become: yes }
  vars:
    datadog_api_key: baguette
    datadog_enabled: false
    datadog_apm_instrumentation_enabled: "host"
    datadog_apm_instrumentation_libraries: ["java:1", "python:2", "js:5", "dotnet:3", "ruby:2"]
```

#### Collection
```yaml
- hosts: myhosts
  tasks:
  - name: Import the Datadog Agent role from the DD collection
    import_role:
      name: datadog.dd.agent
  vars:
    datadog_api_key: baguette
    datadog_enabled: false
    datadog_apm_instrumentation_enabled: "host"
    datadog_apm_instrumentation_libraries: ["java:1", "python:2", "js:5", "dotnet:3", "ruby:2"]
```
Run it in check mode and ensure it does not error out: `ansible-playbook -i inventory.ini playbook.yml --check`
