### PR TITLE
Fix idempotence issue with yum_repository for RHEL

### DIFF
--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -156,7 +156,7 @@
         description: Datadog, Inc.
         baseurl: "{{ datadog_agent5_yum_repo }}"
         enabled: true
-        includepkgs: "{{ agent_datadog_includepkgs }}"
+        includepkgs: "{{ agent_datadog_includepkgs | trim }}"
         repo_gpgcheck: false # we don't sign Agent 5 repodata
         gpgcheck: "{{ datadog_yum_gpgcheck }}"
         gpgkey: [
@@ -177,7 +177,7 @@
         description: Datadog, Inc.
         baseurl: "{{ datadog_agent6_yum_repo }}"
         enabled: true
-        includepkgs: "{{ agent_datadog_includepkgs }}"
+        includepkgs: "{{ agent_datadog_includepkgs | trim }}"
         repo_gpgcheck: "{{ agent_do_yum_repo_gpgcheck }}"
         gpgcheck: "{{ datadog_yum_gpgcheck }}"
         gpgkey: [
@@ -198,7 +198,7 @@
         description: Datadog, Inc.
         baseurl: "{{ datadog_agent7_yum_repo }}"
         enabled: true
-        includepkgs: "{{ agent_datadog_includepkgs }}"
+        includepkgs: "{{ agent_datadog_includepkgs | trim }}"
         repo_gpgcheck: "{{ agent_do_yum_repo_gpgcheck }}"
         gpgcheck: "{{ datadog_yum_gpgcheck }}"
         gpgkey: [
@@ -219,7 +219,7 @@
         description: Datadog, Inc.
         baseurl: "{{ datadog_yum_repo }}"
         enabled: true
-        includepkgs: "{{ agent_datadog_includepkgs }}"
+        includepkgs: "{{ agent_datadog_includepkgs | trim }}"
         repo_gpgcheck: "{{ agent_do_yum_repo_gpgcheck }}"
         gpgcheck: "{{ datadog_yum_gpgcheck }}"
         gpgkey: [


### PR DESCRIPTION
Issue occurs on Ansible 2.16 and Ansible 2.18 against RHEL 8 target hosts.

I use molecule to perform idempotence tests against our Ansible code and found that version `5.8.0` of the `datadog.dd` collection fails idempotence tests against our RHEL 8 instances.

```
[2025-01-27T17:28:02.248Z] CRITICAL Idempotence test failed because of the following tasks:
[2025-01-27T17:28:02.248Z] *  => datadog.dd.agent : Install Datadog Agent 7 yum repo
[2025-01-27T17:28:02.248Z] *  => datadog.dd.agent : Clean repo metadata if repo changed
[2025-01-27T17:28:02.248Z] *  => datadog.dd.agent : Refresh Datadog repository cache
```

Running molecule in diff mode returns that the `includepkgs` line is being modified:
```
TASK [datadog.dd.agent : Install Datadog Agent 7 yum repo] *********************
--- before: /etc/yum.repos.d/datadog.repo
+++ after: /etc/yum.repos.d/datadog.repo
@@ -6,7 +6,7 @@
 https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_B01082D3.public
 https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_FD4BF915.public
 https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_E09422B3.public
-includepkgs = datadog-agent-7.53.0-1 datadog-apm-inject
+includepkgs = datadog-agent-7.53.0-1 datadog-apm-inject 
 name = Datadog, Inc.
 repo_gpgcheck = 1
 ```
 
 Checking the fact that determines the value for this shows a whitespace at the end of the value that is causing the task to fail idempotence:
 `agent_datadog_includepkgs: 'datadog-agent-7.53.0-1 datadog-apm-inject '`
 
Ideally, the Datadog role should be passing each `includepkg` as a list and not a white-space seperate string even though the [documentation supports this format](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/yum_repository_module.html). Also this might be an oversight in how the yum_repository task [checks for changes in Ansible](https://github.com/ansible/ansible/blob/devel/lib/ansible/modules/yum_repository.py), but that is outside the scope of this role.

This behavior was only introduced in `5.8.0` with the change to how the role handles agent install skipping with [this change](https://github.com/DataDog/ansible-datadog/commit/aaced7a59f3f8b5b10a80926e51cb6e8c5ed4617#diff-3d0ff1709ca48add100327bb2a468e6c508fb92a159c64c4f99ad1df89d9bddeL53). Previously in `5.7.0`, it would install the agent and configure the repository. During the idempotence check, the agent would be installed and skip managing the YUM repo.