### PR TITLE
[NTWK-598] Remove top level key, unindent

### DIFF
--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -1,12 +1,11 @@
 # {{ ansible_managed }}
 
 {% if system_probe_config is defined and system_probe_config | default({}, true) | length > 0 -%}
-system_probe_config:
 {# The "first" option in indent() is only supported by jinja 2.10+
   while the old equivalent option "indentfirst" is removed in jinja 3.
   Using non-keyword argument in indent() to be backward compatible.
 #}
-{% filter indent(2, True) %}
+{% filter indent(0, True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}


### PR DESCRIPTION
Working on a support case where it seems that using this config generates an incorrect `system_probe.yaml`:

Take for example:
```yaml
system_probe_config:
  traceroute:
    enabled: true
```

The resulting `system_probe.yaml` would look like:

```yaml
system_probe_config:
  traceroute:
    enabled: true
```
But what we need to properly parse the config in the system-probe is:

```yaml
traceroute:
  enabled: true
```

I'm not an Ansible expert, but this looks like it should do the trick