### PR TITLE
Revert "[NTWK-598] Remove top level key, unindent"

### DIFF
--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -1,11 +1,12 @@
 # {{ ansible_managed }}
 
 {% if system_probe_config is defined and system_probe_config | default({}, true) | length > 0 -%}
+system_probe_config:
 {# The "first" option in indent() is only supported by jinja 2.10+
   while the old equivalent option "indentfirst" is removed in jinja 3.
   Using non-keyword argument in indent() to be backward compatible.
 #}
-{% filter indent(0, True) %}
+{% filter indent(2, True) %}
 {{ system_probe_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}


### PR DESCRIPTION
Reverts DataDog/ansible-datadog#628

This change seems like it would break backward compatibility, we should revert for now.