### PR TITLE
[System Probe] add system_probe_other_config as catch all

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ The system probe is configured under the `system_probe_config` variable. Any var
 
 [Compliance][18] is configured under the `compliance_config` variable. Any variables nested underneath are written to the `security-agent.yaml`, in the `compliance_config` section.
 
+All other configuration for the system-probe that does not live under any of the above keys should be configured under the `system_probe_other_config` variable. Any variables nested underneath are written to the top level
+of `system-probe.yaml`.
+
 **Note for Windows users**: NPM is supported on Windows with Agent v6.27+ and v7.27+. It ships as an optional component that is only installed if `network_config.enabled` is set to true when the Agent is installed or upgraded. Because of this, existing installations might need to do an uninstall and reinstall of the Agent once to install the NPM component, unless the Agent is upgraded at the same time.
 
 #### Example configuration
@@ -268,6 +271,9 @@ service_monitoring_config:
   enabled: true
 runtime_security_config:
   enabled: true
+system_probe_other_config:
+  traceroute:
+    enabled: true
 ```
 
 **Note**: This configuration works with Agent 6.24.1+ and 7.24.1+. For older Agent versions, see the [Network Performance Monitoring][9] documentation on how to enable system-probe.

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ The system probe is configured under the `system_probe_config` variable. Any var
 
 [Compliance][18] is configured under the `compliance_config` variable. Any variables nested underneath are written to the `security-agent.yaml`, in the `compliance_config` section.
 
-All other configuration for the system-probe that does not live under any of the above keys should be configured under the `system_probe_other_config` variable. Any variables nested underneath are written to the top level
+All other configuration for the system probe that does not live under any of the above keys should be configured under the `system_probe_other_config` variable. Any variables nested underneath are written to the top level
 of `system-probe.yaml`.
 
 **Note for Windows users**: NPM is supported on Windows with Agent v6.27+ and v7.27+. It ships as an optional component that is only installed if `network_config.enabled` is set to true when the Agent is installed or upgraded. Because of this, existing installations might need to do an uninstall and reinstall of the Agent once to install the NPM component, unless the Agent is upgraded at the same time.

--- a/ci_test/install_agent_6.yaml
+++ b/ci_test/install_agent_6.yaml
@@ -24,6 +24,9 @@
       enabled: true
     service_monitoring_config:
       enabled: true
+    system_probe_other_config:
+      traceroute:
+        enabled: true
     datadog_checks:
       process:
         init_config:

--- a/ci_test/install_agent_7.yaml
+++ b/ci_test/install_agent_7.yaml
@@ -26,6 +26,9 @@
       enabled: true
     runtime_security_config:
       enabled: true
+    system_probe_other_config:
+      traceroute:
+        enabled: true
     datadog_checks:
       process:
         init_config:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ datadog_config: {}
 system_probe_config: {}
 network_config: {}
 service_monitoring_config: {}
+system_probe_other_config: {}
 
 # default checks enabled
 datadog_checks: {}

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -6,6 +6,12 @@
     agent_datadog_before_7400: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_major
       | int < 8 and agent_datadog_minor | int < 40 }}"
 
+- name: Set before 6/7.61.0 flag
+  set_fact:
+    datadog_before_7610: "{{ datadog_major is defined and datadog_minor is defined and datadog_bugfix is defined
+      and datadog_major | int < 8
+      and (datadog_minor | int < 61) }}"
+
 - name: Set before 6/7.24.1 flag
   set_fact:
     agent_datadog_before_7241: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_bugfix is defined
@@ -65,6 +71,16 @@
       network_config['enabled']) or (service_monitoring_config is defined and
       'enabled' in (service_monitoring_config | default({}, true)) and service_monitoring_config['enabled'])) and agent_datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check and (not agent_datadog_before_7400)
+
+# Since 6/7.61.0, setting system_probe_other_config is enough to start the system-probe service:
+- name: Set system probe enabled (since 6/7.61.0)
+  set_fact:
+    agent_datadog_sysprobe_enabled: "{{ ((system_probe_config is defined and 'enabled' in (system_probe_config | default({}, true)) and
+      system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
+      network_config['enabled']) or (service_monitoring_config is defined and
+      'enabled' in (service_monitoring_config | default({}, true)) and service_monitoring_config['enabled'])) or
+      (system_probe_other_config is defined and (system_probe_other_config is mapping | default({}, true)) and system_probe_other_config | length > 0) and agent_datadog_sysprobe_installed }}"
+  when: not datadog_skip_running_check and (not agent_datadog_before_7610)
 
 - name: Create system-probe configuration file
   template:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -8,7 +8,7 @@
 
 - name: Set before 6/7.61.0 flag
   set_fact:
-    datadog_before_7610: "{{ datadog_major is defined and datadog_minor is defined and datadog_bugfix is defined
+    agent_datadog_before_7610: "{{ datadog_major is defined and datadog_minor is defined and datadog_bugfix is defined
       and datadog_major | int < 8
       and (datadog_minor | int < 61) }}"
 
@@ -79,7 +79,8 @@
       system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
       network_config['enabled']) or (service_monitoring_config is defined and
       'enabled' in (service_monitoring_config | default({}, true)) and service_monitoring_config['enabled'])) or
-      (system_probe_other_config is defined and (system_probe_other_config is mapping | default({}, true)) and system_probe_other_config | length > 0) and agent_datadog_sysprobe_installed }}"
+      (system_probe_other_config is defined and (system_probe_other_config is mapping | default({}, true)) and 
+      system_probe_other_config | length > 0) and agent_datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check and (not agent_datadog_before_7610)
 
 - name: Create system-probe configuration file

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -79,7 +79,7 @@
       system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
       network_config['enabled']) or (service_monitoring_config is defined and
       'enabled' in (service_monitoring_config | default({}, true)) and service_monitoring_config['enabled'])) or
-      (system_probe_other_config is defined and (system_probe_other_config is mapping | default({}, true)) and 
+      (system_probe_other_config is defined and (system_probe_other_config is mapping | default({}, true)) and
       system_probe_other_config | length > 0) and agent_datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check and (not agent_datadog_before_7610)
 

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -43,3 +43,13 @@ runtime_security_config:
 {{ runtime_security_config | to_nice_yaml }}
 {% endfilter %}
 {% endif %}
+
+{% if system_probe_other_config is defined and system_probe_other_config | default({}, true) | length > 0 -%}
+{# The "first" option in indent() is only supported by jinja 2.10+
+  while the old equivalent option "indentfirst" is removed in jinja 3.
+  Using non-keyword argument in indent() to be backward compatible.
+#}
+{% filter indent(0, True) %}
+{{ system_probe_other_config | to_nice_yaml }}
+{% endfilter %}
+{% endif %}

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -49,7 +49,5 @@ runtime_security_config:
   while the old equivalent option "indentfirst" is removed in jinja 3.
   Using non-keyword argument in indent() to be backward compatible.
 #}
-{% filter indent(0, True) %}
 {{ system_probe_other_config | to_nice_yaml }}
-{% endfilter %}
 {% endif %}

--- a/templates/system-probe.yaml.j2
+++ b/templates/system-probe.yaml.j2
@@ -45,9 +45,5 @@ runtime_security_config:
 {% endif %}
 
 {% if system_probe_other_config is defined and system_probe_other_config | default({}, true) | length > 0 -%}
-{# The "first" option in indent() is only supported by jinja 2.10+
-  while the old equivalent option "indentfirst" is removed in jinja 3.
-  Using non-keyword argument in indent() to be backward compatible.
-#}
 {{ system_probe_other_config | to_nice_yaml }}
 {% endif %}


### PR DESCRIPTION
_**Note to reviewers: I don't not have experience with Ansible, so I'd like some guidance/eyes to make sure I'm making the proper changes here.**_

The existing Ansible configuration for system-probe requires that every new module in system-probe be either added under `system_probe_config` in the `system-probe.yaml` or adding a new configuration key in `templates/system-probe.yaml.j2`.

For example, the `traceroute` module of system-probe must be defined at the top level of `system-probe.yaml` as shown here:
```yaml
system_probe_config:
  some_configs:
    something: true

traceroute:
  enabled: true
```

Today, there's no way to generate a `system-probe.yaml` with this configuration. With this change, the intent is that configuring a module like `traceroute` should be the same process as is for config keys in `datadog.yaml` which as far as I can tell this does.

A new configuration key is added to `templates/system-probe.yaml.j2`, `system_probe_other_config`. All of the keys under this mapping should be copied to the top level of the generated `system-probe.yaml`.

The Ansible config for `traceroute` then becomes:
```yaml
system_probe_other_config:
  traceroute:
    enabled: true
```

Additionally, this PR attempts to make sure the `system-probe` is enabled whenever ANY key underneath `system_probe_other_config` is set.