### PR TITLE
Fix `test_install_downgrade` ci failures

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,6 +16,7 @@
   service:
     name: datadog-installer
     state: restarted
+    use: service
   # The installer currently only setup its systemd unit when remote updates are enabled
   when: datadog_enabled and datadog_installer_enabled and datadog_remote_updates and
     not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,13 +10,13 @@
   service:
     name: datadog-agent
     state: restarted
+    use: service
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
 - name: restart datadog-installer  # noqa name[casing]
   service:
     name: datadog-installer
     state: restarted
-    use: service
   # The installer currently only setup its systemd unit when remote updates are enabled
   when: datadog_enabled and datadog_installer_enabled and datadog_remote_updates and
     not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -21,6 +21,7 @@
     name: datadog-agent
     state: started
     enabled: true
+    use: service
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: (agent5) Ensure datadog-agent is not running


### PR DESCRIPTION
Previously, without any code changes, the upgrade to circle ci container runtime `cgroupv2` caused issues in the `test_install_downgrade` ci jobs -- `service` module calls were getting recognized as `pause` module calls instead.

I opened a support case with CircleCI and they're investigating further on their end, since I don't think any code changes in this repo caused the CI failures. But using `use` to force the `service` module resolves the CI issues.