### PR TITLE
Explicitly set `use: service` to ensure compatibility in CI 

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,7 @@
   service:
     name: datadog-agent-sysprobe
     state: restarted
+    use: service
   when: datadog_enabled and agent_datadog_sysprobe_enabled and not ansible_check_mode and
     not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
@@ -17,6 +18,7 @@
   service:
     name: datadog-installer
     state: restarted
+    use: service
   # The installer currently only setup its systemd unit when remote updates are enabled
   when: datadog_enabled and datadog_installer_enabled and datadog_remote_updates and
     not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -98,6 +98,7 @@
     name: datadog-agent
     state: started
     enabled: true
+    use: service
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
@@ -105,6 +106,7 @@
     name: datadog-agent-sysprobe
     state: started
     enabled: true
+    use: service
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and agent_datadog_sysprobe_enabled
 
 - name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
@@ -112,6 +114,7 @@
     name: "{{ item }}"
     state: stopped
     enabled: false
+    use: service
   when: not datadog_skip_running_check and not datadog_enabled and not ansible_check_mode
   with_list:
     - datadog-agent
@@ -125,6 +128,7 @@
     name: datadog-agent-sysprobe
     state: stopped
     enabled: false
+    use: service
   when: not datadog_skip_running_check and (not datadog_enabled or not agent_datadog_sysprobe_enabled)
     and agent_datadog_before_7180 and agent_datadog_sysprobe_installed
 
@@ -133,6 +137,7 @@
     name: datadog-agent-security
     state: stopped
     enabled: false
+    use: service
   when: not datadog_skip_running_check and not datadog_enabled
   failed_when: false # Since older versions of the Agent don't include the security agent
 

--- a/tasks/agent5-linux.yml
+++ b/tasks/agent5-linux.yml
@@ -29,6 +29,7 @@
     name: datadog-agent
     state: stopped
     enabled: false
+    use: service
   when: not datadog_skip_running_check and not datadog_enabled
 
 - name: Register all checks files present in datadog


### PR DESCRIPTION
Update all Ansible `service` tasks to explicitly include `use: service`. CircleCI was previously failing because it auto-detects the init system, which it does not have. With the `cgroupv2` update that initially broke some CI jobs, `PID 1` was interpreted as `pause` and hardcoding `use: service` for all service module tasks fixed the issue. 

from circleCI eng team:

> In v1 the service module worked by luck. It detects the init system and tries to use that. Containers don't really have init systems. It is supposed to fall back to the using the equivalent of use: service  but seems to pick up pid 1 and try and use it regardless. Whilst pid 1 wasn't a supported init system, it just so happened to be useable as if it were in v1. In v2, pid 1 is not usable in such a way. It also is called pause, which is why the error message mentions it. So by adding use: service we can skip that pid 1 detection and use the fallback method as it is supposed to.

CI was already fixed https://github.com/DataDog/ansible-datadog/pull/638 but this can prevent future issues if CI changes 