### PR TITLE
Bump galaxy-importer and ansible-lint version

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,3 +5,7 @@ skip_list:
 
 enable_list:
   - empty-string-compare
+
+warn_list:
+  - var_naming
+  - idiom

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-galaxy-importer==0.4.25
+galaxy-importer==0.4.29


### PR DESCRIPTION
bumping `galaxy-importer` to 4.29 will also bump `ansible-lint` to 25.1.2