### PR TITLE
Bump ansible-lint to 25.1.2 and fix compatibility issues

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,8 +1,4 @@
 ---
-# We ignore the FQCN rule on the role repository since FQCN is not compatible with older version of Ansible (Ansible =< 2.9)
-skip_list:
-  - fqcn
-
 enable_list:
   - empty-string-compare
 

--- a/.ansible/roles/datadog.datadog
+++ b/.ansible/roles/datadog.datadog
@@ -1,0 +1,1 @@
+/Users/sarah.wang/go/src/github.com/DataDog/ansible-datadog

--- a/.ansible/roles/datadog.datadog
+++ b/.ansible/roles/datadog.datadog
@@ -1,1 +1,0 @@
-/Users/sarah.wang/go/src/github.com/DataDog/ansible-datadog

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -377,7 +377,7 @@ workflows:
       - test_install_downgrade:
           matrix:
             parameters:
-              ansible_version: ["2_8", "2_9", "2_10", "3_4", "4_10"]
+              ansible_version: ["2_10", "3_4", "4_10"]
               agent_version: ["6", "7"]
               os: ["rocky8"]
               python: ["python3"]
@@ -386,7 +386,7 @@ workflows:
       - test_install_downgrade:
           matrix:
             parameters:
-              ansible_version: ["2_6", "2_7", "2_8", "2_10", "3_4", "4_10", "5_3", "9_4"]
+              ansible_version: ["2_10", "3_4", "4_10", "5_3", "9_4"]
               agent_version: ["6", "7"]
               os: ["debian"]
               python: ["python3"]
@@ -405,7 +405,7 @@ workflows:
       - test_install:
           matrix:
             parameters:
-              ansible_version: ["2_8", "2_10", "3_4", "4_10", "9_4"]
+              ansible_version: ["2_10", "3_4", "4_10", "9_4"]
               agent_version: ["6", "7"]
               jinja2_native: ["true", "false"]
               os: ["rocky8"]
@@ -415,7 +415,7 @@ workflows:
       - test_install:
           matrix:
             parameters:
-              ansible_version: ["2_8", "2_10", "3_4", "4_10", "9_4"]
+              ansible_version: ["2_10", "3_4", "4_10", "9_4"]
               agent_version: ["6", "7"]
               os: ["suse"]
               python: ["python3"]
@@ -431,7 +431,7 @@ workflows:
       - test_install_macos:
           matrix:
             parameters:
-              ansible_version: ["2.8", "2.9", "2.10", "3.4", "4.10"]
+              ansible_version: ["2.10", "3.4", "4.10"]
               agent_version: ["6_macos", "7_macos"]
               python: ["python3"]
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The Datadog Agent Ansible role is available through 2 different channels:
 
 Version `4` of the role and version `5` of the collection install the Datadog Agent v7 by default.
 
-Version `5` of the role and version `6` of the collection no longer support Python 2 and Agent 5. It also no longer supports older versions of Amazon Linux 2 and CentOS. 
+Version `5` of the role and version `6` of the collection no longer support Python 2, Agent 5, or Ansible versions below 2.10. It also no longer supports older versions of Amazon Linux 2 and CentOS. 
 
 ## Setup
 
@@ -19,14 +19,14 @@ Note that the install instructions in this document describe installation of the
 
 ### Requirements
 
-- Requires Ansible v2.6+.
+- Requires Ansible v2.10+.
 - Supports most Debian and RHEL-based Linux distributions, macOS, and Windows.
-- When using with Ansible 2.10+ to manage Windows hosts, requires the `ansible.windows` collection to be installed:
+- Requires the `ansible.windows` collection to be installed:
 
   ```shell
   ansible-galaxy collection install ansible.windows
   ```
-- When using with Ansible 2.10+ to manage openSUSE/SLES hosts, requires the `community.general` collection to be installed:
+- Requires the `community.general` collection to be installed:
 
   ```shell
   ansible-galaxy collection install community.general

--- a/ci_test/ansible_lint.sh
+++ b/ci_test/ansible_lint.sh
@@ -72,8 +72,8 @@ popd
 pip install -r requirements-ansible-lint.txt
 
 # lint the ansible-role alone
-ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/
+ansible-lint -v --exclude=galaxy.yml -- exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=roles/agent/.venv/
 
 cd ansible_collections/datadog/ || exit
 ls -la roles/agent/
-ansible-lint -v --exclude=galaxy.yml --exclude=meta/
+ansible-lint -v --exclude=galaxy.yml --exclude=meta/ --exclude=roles/agent/.venv/

--- a/ci_test/ansible_lint.sh
+++ b/ci_test/ansible_lint.sh
@@ -72,7 +72,7 @@ popd
 pip install -r requirements-ansible-lint.txt
 
 # lint the ansible-role alone
-ansible-lint -v --exclude=galaxy.yml -- exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=roles/agent/.venv/
+ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=roles/agent/.venv/
 
 cd ansible_collections/datadog/ || exit
 ls -la roles/agent/

--- a/ci_test/ansible_lint.sh
+++ b/ci_test/ansible_lint.sh
@@ -72,8 +72,8 @@ popd
 pip install -r requirements-ansible-lint.txt
 
 # lint the ansible-role alone
-ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=roles/agent/.venv/
+ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=.ansible/ --exclude=.venv/
 
 cd ansible_collections/datadog/ || exit
 ls -la roles/agent/
-ansible-lint -v --exclude=galaxy.yml --exclude=meta/ --exclude=roles/agent/.venv/
+ansible-lint -v --exclude=galaxy.yml --exclude=meta/ --exclude=.ansible/ --exclude=.venv/

--- a/handlers/main-macos.yml
+++ b/handlers/main-macos.yml
@@ -8,21 +8,21 @@
 # to finish and if it's in progress for a longer time, bootstrap fails. We use the old
 # unload/load combo because they actually wait.
 - name: Unload datadog-agent service
-  command: "launchctl unload -wF {{ datadog_macos_system_plist_file_path }}"
+  ansible.builtin.command: "launchctl unload -wF {{ datadog_macos_system_plist_file_path }}"
   become: true
   check_mode: false
   when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Darwin"
   changed_when: true
 
 - name: Load datadog-agent service
-  command: "launchctl load -wF {{ datadog_macos_system_plist_file_path }}"
+  ansible.builtincommand: "launchctl load -wF {{ datadog_macos_system_plist_file_path }}"
   become: true
   check_mode: false
   when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Darwin"
   changed_when: true
 
 - name: Restart datadog-agent service
-  command: "launchctl kickstart -k system/{{ datadog_macos_service_name }}"
+  ansible.builtincommand: "launchctl kickstart -k system/{{ datadog_macos_service_name }}"
   become: true
   register: command_result
   check_mode: false

--- a/handlers/main-macos.yml
+++ b/handlers/main-macos.yml
@@ -15,14 +15,14 @@
   changed_when: true
 
 - name: Load datadog-agent service
-  ansible.builtincommand: "launchctl load -wF {{ datadog_macos_system_plist_file_path }}"
+  ansible.builtin.command: "launchctl load -wF {{ datadog_macos_system_plist_file_path }}"
   become: true
   check_mode: false
   when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Darwin"
   changed_when: true
 
 - name: Restart datadog-agent service
-  ansible.builtincommand: "launchctl kickstart -k system/{{ datadog_macos_service_name }}"
+  ansible.builtin.command: "launchctl kickstart -k system/{{ datadog_macos_service_name }}"
   become: true
   register: command_result
   check_mode: false

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -4,7 +4,7 @@
 # However, this is here because this is a "handler-like" task that is dynamically
 # included by a handler task in handlers/main.yml.
 - name: Restart Windows datadogagent service
-  win_service:
+  ansible.builtin.win_service:
     name: datadogagent
     state: restarted
     force_dependent_services: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -31,7 +31,7 @@
 # The include_tasks loads the handlers/main-win.yml file, which contains the real service restart task
 # (which depends on ansible.windows), and runs it, triggering the Windows Agent restart.
 - name: restart datadog-agent-win # noqa name[casing]
-  include_tasks: handlers/main-win.yml
+  ansible.builtin.include_tasks: handlers/main-win.yml
 
 # When needed, our macOS tasks call this handler to require a
 # macOS Agent restart (through notify: restart datadog-agent-macos).
@@ -39,4 +39,4 @@
 # The include_tasks loads the handlers/main-macos.yml file, which contains the real service restart task
 # and runs it, triggering the macOS Agent restart.
 - name: restart datadog-agent-macos # noqa name[casing]
-  include_tasks: handlers/main-macos.yml
+  ansible.builtin.include_tasks: handlers/main-macos.yml

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: restart datadog-agent-sysprobe # noqa name[casing]
-  service:
+  ansible.builtin.service:
     name: datadog-agent-sysprobe
     state: restarted
     use: service
@@ -8,14 +8,14 @@
     not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
 - name: restart datadog-agent # noqa name[casing]
-  service:
+  ansible.builtin.service:
     name: datadog-agent
     state: restarted
     use: service
   when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
 - name: restart datadog-installer  # noqa name[casing]
-  service:
+  ansible.builtin.service:
     name: datadog-installer
     state: restarted
     use: service

--- a/manual_tests/test_6_full.yml
+++ b/manual_tests/test_6_full.yml
@@ -44,9 +44,9 @@
             port: 22
             username: root
             password: changeme
-            sftp_check: True
+            sftp_check: true
             private_key_file:
-            add_missing_keys: True
+            add_missing_keys: true
       nginx:
         init_config:
         instances:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -5,7 +5,7 @@ galaxy_info:
   author: 'Brian Akins, Dustin Brown & Datadog'
   description: Install Datadog agent and configure checks
   license: Apache2
-  min_ansible_version: '2.8'
+  min_ansible_version: '2.10'
   github_branch: main
   platforms:
     - name: Ubuntu

--- a/requirements-ansible-lint.txt
+++ b/requirements-ansible-lint.txt
@@ -1,1 +1,1 @@
-ansible-lint==6.22.2
+ansible-lint==25.1.2

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create Datadog agent config directory
-  file:
+  ansible.builtin.file:
     dest: "{{ agent_dd_config_dir }}"
     state: directory
     mode: "0755"
@@ -9,7 +9,7 @@
   when: datadog_manage_config
 
 - name: Create main Datadog agent configuration file
-  template:
+  ansible.builtin.template:
     src: datadog.yaml.j2
     dest: "{{ agent_dd_config_dir }}/datadog.yaml"
     mode: "0640"
@@ -19,7 +19,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Register all check configs present in datadog
-  find:
+  ansible.builtin.find:
     paths: "{{ agent_dd_config_dir }}/conf.d/"
     patterns:
       - "conf.yaml*"
@@ -30,7 +30,7 @@
   when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in agent_datadog_tracked_checks
-  file:
+  ansible.builtin.file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml"
     state: absent
   loop: >-
@@ -42,7 +42,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Delete all default checks
-  file:
+  ansible.builtin.file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml.default"
     state: absent
   loop: >-
@@ -54,7 +54,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Delete all example checks
-  file:
+  ansible.builtin.file:
     path: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml.example"
     state: absent
   loop: >-
@@ -66,7 +66,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Ensure configuration directories are present for each Datadog check
-  file:
+  ansible.builtin.file:
     dest: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d"
     state: directory
     owner: "{{ agent_dd_user }}"
@@ -87,7 +87,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Remove old configuration file for each Datadog check
-  file:
+  ansible.builtin.file:
     dest: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.yaml"
     state: absent
   with_items: "{{ agent_datadog_checks | list }}"
@@ -95,7 +95,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Create custom check file for each custom check
-  copy:
+  ansible.builtin.copy:
     src: "{{ datadog_custom_checks[item] }}"
     dest: "{{ agent_dd_config_dir }}/checks.d/{{ item }}.py"
     mode: "0755"
@@ -113,23 +113,23 @@
     mode: "0644"
 
 - name: Check if install.json exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ agent_dd_config_dir }}/install.json"
   register: install_file
 
 - name: Read remote install.json
   register: install_json_value
-  slurp:
+  ansible.builtin.slurp:
     src: "{{ agent_dd_config_dir }}/install.json"
   when: install_file.stat.exists
 
 - name: Debug print install.json content
-  debug:
+  ansible.builtin.debug:
     msg: "install.json content : {{ install_json_value.content }}"
   when: install_file.stat.exists
 
 - name: Parse install.json file if it exists
-  set_fact:
+  ansible.builtin.set_fact:
     install_info: "{{ install_json_value.content | b64decode | from_json }}"
   when: install_file.stat.exists
 
@@ -138,32 +138,32 @@
   check_mode: false
   block:
     - name: Generate uuid based on /proc/sys/kernel/random/uuid
-      command: cat /proc/sys/kernel/random/uuid
+      ansible.builtin.command: cat /proc/sys/kernel/random/uuid
       register: uuid_cmd
       changed_when: false
 
   rescue:
     - name: Generate uuid using uuidgen
-      command: uuidgen
+      ansible.builtin.command: uuidgen
       register: uuid_cmd
       changed_when: false
 
 - name: Set install signature from file if it exists
-  set_fact:
+  ansible.builtin.set_fact:
     install_signature:
       install_id: "{{ install_info.install_id }}"
       install_time: "{{ install_info.install_time }}"
   when: install_file.stat.exists
 
 - name: Generate install signature
-  set_fact:
+  ansible.builtin.set_fact:
     install_signature:
       install_id: "{{ uuid_cmd.stdout }}"
       install_time: "{{ ansible_date_time.epoch }}"
   when: not install_file.stat.exists
 
 - name: Create installation json file
-  template:
+  ansible.builtin.template:
     src: install.json.j2
     dest: "{{ agent_dd_config_dir }}/install.json"
     owner: "{{ agent_dd_user }}"

--- a/tasks/_agent-linux-macos-shared.yml
+++ b/tasks/_agent-linux-macos-shared.yml
@@ -76,7 +76,7 @@
   when: datadog_manage_config
 
 - name: Create a configuration file for each Datadog check
-  template:
+  ansible.builtin.template:
     src: checks.yaml.j2
     dest: "{{ agent_dd_config_dir }}/conf.d/{{ item }}.d/conf.yaml"
     mode: "0640"
@@ -105,7 +105,7 @@
   notify: "{{ agent_dd_notify_agent }}"
 
 - name: Create installation information file
-  template:
+  ansible.builtin.template:
     src: install_info.j2
     dest: "{{ agent_dd_config_dir }}/install_info"
     owner: "{{ agent_dd_user }}"

--- a/tasks/_apt-key-import.yml
+++ b/tasks/_apt-key-import.yml
@@ -20,12 +20,12 @@
 # the key to `datadog_apt_usr_share_keyring`.
 
 - name: Set local variables for processed key {{ item.key }}
-  set_fact:
+  ansible.builtin.set_fact:
     agent_key_fingerprint: "{{ item.key }}"
     agent_keyring_url: "{{ item.value }}"
 
 - name: Find out whether key is already imported, key = {{ agent_key_fingerprint }}
-  shell:
+  ansible.builtin.shell:
     cmd: >
       set -o pipefail &&
       gpg --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }}
@@ -37,17 +37,17 @@
   when: agent_key_fingerprint != datadog_apt_key_current_name # we always want to import the CURRENT key
 
 - name: Set local helper variable for determining key import (when not {{ datadog_apt_key_current_name }})
-  set_fact:
+  ansible.builtin.set_fact:
     agent_key_needs_import: "{{ 'false' if agent_key_exists_result.rc == 0 else 'true' }}"
   when: agent_key_fingerprint != datadog_apt_key_current_name
 
 - name: Set local helper variable for determining key import (when {{ datadog_apt_key_current_name }})
-  set_fact:
+  ansible.builtin.set_fact:
     agent_key_needs_import: "true"
   when: agent_key_fingerprint == datadog_apt_key_current_name
 
 - name: Create temporary directory for key manipulation
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
     suffix: keys
   register: agent_tempdir
@@ -55,7 +55,7 @@
   changed_when: false
 
 - name: Download url to import key. url,key = {{ agent_keyring_url, agent_key_fingerprint }}
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ agent_keyring_url }}"
     dest: "{{ agent_tempdir.path }}/{{ agent_key_fingerprint }}"
     force: true
@@ -65,19 +65,19 @@
 
 # gpg --dearmor called on a binary keyring does nothing
 - name: Ensure downloaded file for key is a binary keyring, key={{ agent_key_fingerprint }}
-  shell: "cat {{ agent_tempdir.path }}/{{ agent_key_fingerprint }}
+  ansible.builtin.shell: "cat {{ agent_tempdir.path }}/{{ agent_key_fingerprint }}
           | gpg --dearmor > {{ agent_tempdir.path }}/binary.gpg" # noqa risky-shell-pipe
   when: agent_key_needs_import
   changed_when: false
 
 - name: Extract the required key from the binary keyring (when not {{ datadog_apt_key_current_name }})
-  shell: "gpg --no-default-keyring --keyring {{ agent_tempdir.path }}/binary.gpg
+  ansible.builtin.shell: "gpg --no-default-keyring --keyring {{ agent_tempdir.path }}/binary.gpg
           --export {{ agent_key_fingerprint }} > {{ agent_tempdir.path }}/single.gpg"
   when: agent_key_fingerprint != datadog_apt_key_current_name and agent_key_needs_import
   changed_when: false
 
 - name: Extract the required key from the binary keyring (when {{ datadog_apt_key_current_name }})
-  copy:
+  ansible.builtin.copy:
     src: "{{ agent_tempdir.path }}/binary.gpg"
     dest: "{{ agent_tempdir.path }}/single.gpg"
     mode: "0600"
@@ -86,14 +86,14 @@
   changed_when: false
 
 - name: Import key to keyring, key,keyring={{ agent_key_fingerprint, datadog_apt_usr_share_keyring }}
-  shell: cat {{ agent_tempdir.path }}/single.gpg |
+  ansible.builtin.shell: cat {{ agent_tempdir.path }}/single.gpg |
     gpg --no-default-keyring --keyring {{ datadog_apt_usr_share_keyring }} --import --batch # noqa risky-shell-pipe
   when: agent_key_needs_import
   register: agent_key_import_result
   changed_when: '"imported: 1" in agent_key_import_result.stderr'
 
 - name: Remove temporary directory for key manipulation
-  file:
+  ansible.builtin.file:
     path: "{{ agent_tempdir.path }}"
     state: absent
   when: agent_key_needs_import

--- a/tasks/_remove_rpm_keys.yml
+++ b/tasks/_remove_rpm_keys.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure GPG key is not present in the RPM db, key={{ item }}
-  rpm_key:
+  ansible.builtin.rpm_key:
     state: absent
     key: "{{ item }}"
   when: not ansible_check_mode

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -1,29 +1,29 @@
 ---
 - name: Populate service facts
-  service_facts:
+  ansible.builtin.service_facts:
 - name: Set before 6/7.40.0 flag
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_before_7400: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_major
       | int < 8 and agent_datadog_minor | int < 40 }}"
 
 - name: Set before 6/7.61.0 flag
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_before_7610: "{{ datadog_major is defined and datadog_minor is defined and datadog_bugfix is defined
       and datadog_major | int < 8
       and (datadog_minor | int < 61) }}"
 
 - name: Set before 6/7.24.1 flag
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_before_7241: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_bugfix is defined
       and agent_datadog_major | int < 8 and (agent_datadog_minor | int < 24 or (agent_datadog_minor | int == 24 and agent_datadog_bugfix | int < 1)) }}"
 
 - name: Set before 6/7.18.0 flag
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_before_7180: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_major
       | int < 8 and agent_datadog_minor | int < 18 }}"
 
 - name: Add user to additional groups, user="{{ datadog_user }}"
-  user:
+  ansible.builtin.user:
     name: "{{ datadog_user }}"
     groups: "{{ datadog_additional_groups }}"
     append: true
@@ -31,7 +31,7 @@
   notify: restart datadog-agent
 
 - name: Include configuration setup tasks
-  include_tasks: _agent-linux-macos-shared.yml
+  ansible.builtin.include_tasks: _agent-linux-macos-shared.yml
   vars:
     agent_dd_config_dir: /etc/datadog-agent
     agent_dd_user: "{{ datadog_user }}"
@@ -39,7 +39,7 @@
     agent_dd_notify_agent: [restart datadog-agent, restart datadog-installer]
 
 - name: Set system probe installed
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_installed: "{{ ansible_facts.services['datadog-agent-sysprobe'] is defined or
       ansible_facts.services['datadog-agent-sysprobe.service'] is defined }}"
   when: not datadog_skip_running_check
@@ -48,7 +48,7 @@
 # agent_datadog_minor is only defined when a specific Agent version is given
 # (see tasks/parse-version.yml)
 - name: Set system probe enabled (before 6/7.24.1)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_enabled: "{{ system_probe_config is defined and 'enabled' in (system_probe_config | default({}, true)) and
       system_probe_config['enabled'] and agent_datadog_sysprobe_installed }}"
   when: not datadog_skip_running_check and agent_datadog_before_7241
@@ -56,7 +56,7 @@
 # Since 6/7.24.1, setting enabled: true in network_config is enough to start the system-probe service:
 # https://docs.datadoghq.com/network_monitoring/performance/setup/?tab=agent#setup
 - name: Set system probe enabled (since 6/7.24.1)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_enabled: "{{ ((system_probe_config is defined and 'enabled' in (system_probe_config | default({}, true)) and
       system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
       network_config['enabled'])) and agent_datadog_sysprobe_installed }}"
@@ -65,7 +65,7 @@
 # Since 6/7.40.0, setting enabled: true in service_monitoring_config is enough to start the system-probe service:
 # https://docs.datadoghq.com/tracing/universal_service_monitoring/?tab=configurationfiles#enabling-universal-service-monitoring
 - name: Set system probe enabled (since 6/7.40.0)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_enabled: "{{ ((system_probe_config is defined and 'enabled' in (system_probe_config | default({}, true)) and
       system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
       network_config['enabled']) or (service_monitoring_config is defined and
@@ -74,7 +74,7 @@
 
 # Since 6/7.61.0, setting system_probe_other_config is enough to start the system-probe service:
 - name: Set system probe enabled (since 6/7.61.0)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_enabled: "{{ ((system_probe_config is defined and 'enabled' in (system_probe_config | default({}, true)) and
       system_probe_config['enabled']) or (network_config is defined and 'enabled' in (network_config | default({}, true)) and
       network_config['enabled']) or (service_monitoring_config is defined and
@@ -84,7 +84,7 @@
   when: not datadog_skip_running_check and (not agent_datadog_before_7610)
 
 - name: Create system-probe configuration file
-  template:
+  ansible.builtin.template:
     src: system-probe.yaml.j2
     dest: /etc/datadog-agent/system-probe.yaml
     mode: "0640"
@@ -94,7 +94,7 @@
   notify: "{% if agent_datadog_before_7180 %}restart datadog-agent-sysprobe{% else %}restart datadog-agent{% endif %}"
 
 - name: Ensure datadog-agent is running
-  service:
+  ansible.builtin.service:
     name: datadog-agent
     state: started
     enabled: true
@@ -102,7 +102,7 @@
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
-  service:
+  ansible.builtin.service:
     name: datadog-agent-sysprobe
     state: started
     enabled: true
@@ -110,7 +110,7 @@
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and agent_datadog_sysprobe_enabled
 
 - name: Ensure datadog-agent, datadog-agent-process and datadog-agent-trace are not running
-  service:
+  ansible.builtin.service:
     name: "{{ item }}"
     state: stopped
     enabled: false
@@ -124,7 +124,7 @@
 # Stop system-probe manually on Agent versions < 6/7.18, as it was not tied
 # to the main Agent service: https://github.com/DataDog/datadog-agent/pull/4883
 - name: Ensure datadog-agent-sysprobe is stopped if disabled or not installed (before 6/7.18.0)
-  service:
+  ansible.builtin.service:
     name: datadog-agent-sysprobe
     state: stopped
     enabled: false
@@ -133,7 +133,7 @@
     and agent_datadog_before_7180 and agent_datadog_sysprobe_installed
 
 - name: Ensure datadog-agent-security is not running
-  service:
+  ansible.builtin.service:
     name: datadog-agent-security
     state: stopped
     enabled: false
@@ -142,7 +142,7 @@
   failed_when: false # Since older versions of the Agent don't include the security agent
 
 - name: Create security-agent configuration file
-  template:
+  ansible.builtin.template:
     src: security-agent.yaml.j2
     dest: /etc/datadog-agent/security-agent.yaml
     mode: "0640"
@@ -155,7 +155,7 @@
 # and then runtime_security_config was completely removed, this is the only way to ensure
 # we remove the leftover config file.
 - name: Remove security-agent configuration file if security-agent is no longer configured
-  file:
+  ansible.builtin.file:
     path: /etc/datadog-agent/security-agent.yaml
     state: absent
   when: datadog_manage_config and (runtime_security_config is not defined or runtime_security_config | default({}, true) | length == 0)

--- a/tasks/agent-macos.yml
+++ b/tasks/agent-macos.yml
@@ -61,7 +61,7 @@
 # file in the .dmg, we would also have to update this. Fortunately this seems
 # to basically never happen, so I think it's an acceptable downside.
 - name: Add system LaunchDaemon plist file
-  template:
+  ansible.builtin.template:
     src: com.datadoghq.agent.plist.j2
     dest: "{{ datadog_macos_system_plist_file_path }}"
     owner: 0
@@ -76,7 +76,7 @@
     agent_groupname: "{{ agent_macos_user_group.stdout }}"
 
 - name: Include configuration setup tasks
-  import_tasks: _agent-linux-macos-shared.yml
+  ansible.builtin.import_tasks: _agent-linux-macos-shared.yml
   vars:
     agent_dd_config_dir: "{{ datadog_macos_etc_dir }}"
     agent_dd_user: "{{ agent_macos_user_data.uid }}"
@@ -85,7 +85,7 @@
   become: true
 
 - name: Set permissions for DataDog Directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     owner: "{{ agent_macos_user_data.uid }}"
     group: "{{ agent_macos_user_data.gid }}"

--- a/tasks/agent-macos.yml
+++ b/tasks/agent-macos.yml
@@ -2,7 +2,7 @@
 # NOTE: the DMG gets installed as ansible_user, but we then configure it to run
 # under datadog_macos_user and remove the user-specific config for ansible_user
 - name: Load user data
-  shell:
+  ansible.builtin.shell:
     cmd: "set -o pipefail && dscacheutil -q user -a name {{ datadog_macos_user }} |
       awk 'BEGIN { RS=\"\\n\"; ORS=\" \" } /uid:/ { print \"{ \\\"uid\\\": \" $2\",\" } /gid:/ { print
       \"\\\"gid\\\": \" $2 \" }\"}'"
@@ -16,11 +16,11 @@
 # a string it will automatically convert it to the corresponding object. This enables us to get multiple values
 # out of the ABOVE task preventing us from having to run 2 similar commands.
 - name: Extract JSON user data as variable object
-  set_fact:
+  ansible.builtin.set_fact:
     agent_macos_user_data: "{{ agent_macos_user_output.stdout }}"
 
 - name: Load user group data
-  shell:
+  ansible.builtin.shell:
     cmd: "set -o pipefail && dscacheutil -q group -a gid {{ agent_macos_user_data.gid }} | grep '^name: ' | awk '{ print $2 }'"
     executable: /bin/bash
   register: agent_macos_user_group
@@ -30,26 +30,26 @@
 # created launchctl service for the user and also a login item
 
 - name: Find out if user LaunchAgent is running
-  shell:
+  ansible.builtin.shell:
     cmd: "launchctl print gui/$(id -u)/{{ datadog_macos_service_name }}"
   register: agent_user_service_created
   changed_when: false
   failed_when: false
 
 - name: Unload and stop user LaunchAgent
-  shell:
+  ansible.builtin.shell:
     cmd: "launchctl bootout gui/$(id -u)/{{ datadog_macos_service_name }}"
   when: agent_user_service_created.rc == 0
   changed_when: false
 
 - name: Remove user login item
-  command: |-
+  ansible.builtin.command: |-
     osascript -e 'tell application "System Events" to if login item "Datadog Agent" exists then delete login item "Datadog Agent"'
   when: agent_user_service_created.rc == 0
   changed_when: false
 
 - name: Remove user LaunchAgent plist file
-  file:
+  ansible.builtin.file:
     path: /Users/{{ ansible_user }}/{{ datadog_macos_user_plist_file_path }}
     state: absent
 

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create main Datadog agent configuration file
-  win_template:
+  ansible.windows.win_template:
     # FIXME: should have permissions set to only be readable by ddagentuser
     src: datadog.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\datadog.yaml"
@@ -8,7 +8,7 @@
   notify: restart datadog-agent-win
 
 - name: Register all check configs present in datadog
-  win_find:
+  ansible.windows.win_find:
     paths: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d"
     patterns:
       - "conf.yaml*"
@@ -19,7 +19,7 @@
   when: datadog_manage_config and (datadog_disable_untracked_checks or datadog_disable_default_checks)
 
 - name: Delete checks not present in agent_datadog_tracked_checks
-  win_file:
+  ansible.windows.win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml"
     state: absent
   loop: >-
@@ -31,7 +31,7 @@
   notify: restart datadog-agent-win
 
 - name: Delete default checks
-  win_file:
+  ansible.windows.win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.default"
     state: absent
   loop: >-
@@ -43,7 +43,7 @@
   notify: restart datadog-agent-win
 
 - name: Delete example checks
-  win_file:
+  ansible.windows.win_file:
     path: "{{ ansible_facts.env['ProgramData'] }}\\Datadog\\conf.d\\{{ item }}.d\\conf.yaml.example"
     state: absent
   loop: >-
@@ -55,14 +55,14 @@
   notify: restart datadog-agent-win
 
 - name: Ensure configuration directories are present for each Datadog check
-  win_file:
+  ansible.windows.win_file:
     path: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.d"
     state: directory
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
 
 - name: Create a configuration file for each Datadog check
-  win_template:
+  ansible.windows.win_template:
     src: checks.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
   with_items: "{{ agent_datadog_checks | list }}"
@@ -70,7 +70,7 @@
   notify: restart datadog-agent-win
 
 - name: Remove old configuration file for each Datadog check
-  win_file:
+  ansible.windows.win_file:
     path: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.yaml"
     state: absent
   with_items: "{{ agent_datadog_checks | list }}"
@@ -78,14 +78,14 @@
   notify: restart datadog-agent-win
 
 - name: Create custom check file for each custom check
-  win_copy:
+  ansible.windows.win_copy:
     src: "{{ datadog_custom_checks[item] }}"
     dest: "{{ agent_datadog_windows_config_root }}\\checks.d\\{{ item }}.py"
   with_items: "{{ datadog_custom_checks | list }}"
   notify: restart datadog-agent-win
 
 - name: Ensure datadog-trace-agent and datadog-process-agent are not disabled
-  win_service:
+  ansible.windows.win_service:
     name: "{{ item }}"
     start_mode: manual
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
@@ -94,21 +94,21 @@
     - datadog-process-agent
 
 - name: Create system-probe configuration file
-  win_template:
+  ansible.windows.win_template:
     src: system-probe.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\system-probe.yaml"
   when: datadog_manage_config
   notify: restart datadog-agent-win
 
 - name: Ensure datadog-agent is running
-  win_service:
+  ansible.windows.win_service:
     name: datadogagent
     state: started
     start_mode: delayed
   when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent is disabled
-  win_service:
+  ansible.windows.win_service:
     name: "{{ item }}"
     state: stopped
     start_mode: disabled
@@ -119,7 +119,7 @@
     - datadogagent
 
 - name: Create installation information file
-  template:
+  ansible.builtin.template:
     src: install_info.j2
     dest: "{{ agent_datadog_windows_config_root }}\\install_info"
     mode: "0644"

--- a/tasks/check-removed-config.yml
+++ b/tasks/check-removed-config.yml
@@ -1,10 +1,10 @@
 ---
 - name: Ensure datadog_yum_gpgkey is not used
-  fail:
+  ansible.builtin.fail:
     msg: datadog_yum_gpgkey configuration value was removed.
   when: datadog_yum_gpgkey is defined and datadog_yum_gpgkey|length > 0
 
 - name: Ensure datadog_zypper_gpgkey is not used
-  fail:
+  ansible.builtin.fail:
     msg: datadog_zypper_gpgkey configuration value was removed.
   when: datadog_zypper_gpgkey is defined and datadog_zypper_gpgkey|length > 0

--- a/tasks/facts-ansible10.yml
+++ b/tasks/facts-ansible10.yml
@@ -1,3 +1,0 @@
----
-- name: Gather Ansible Facts
-  ansible.builtin.setup: # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.

--- a/tasks/facts-ansible9.yml
+++ b/tasks/facts-ansible9.yml
@@ -1,3 +1,0 @@
----
-- name: Gather Ansible Facts
-  ansible.builtin.setup:

--- a/tasks/facts-ansible9.yml
+++ b/tasks/facts-ansible9.yml
@@ -1,3 +1,3 @@
 ---
 - name: Gather Ansible Facts
-  setup:
+  ansible.builtin.setup:

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -1,11 +1,11 @@
 ---
 - name: Enable installer
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_installer_enabled: true
   when: datadog_apm_instrumentation_enabled | length > 0 or datadog_remote_updates | bool
 
 - name: Set internal values for installer registry
-  set_fact:
+  ansible.builtin.set_fact:
     installer_registry_config:
       installer:
         registry: "{{ datadog_installer_registry }}"
@@ -13,6 +13,6 @@
   when: datadog_installer_registry or datadog_installer_auth
 
 - name: Update datadog_config including installer registry
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_config: "{{ agent_datadog_config | combine(installer_registry_config, list_merge='keep') }}"
   when: installer_registry_config and datadog_installer_enabled

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -1,10 +1,10 @@
 ---
 - name: Generate installer trace ID
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_installer_trace_id: "{{ 9999999999999999999 | random }}"
 
 - name: Start duration measurements
-  command: "date +%s%N"
+  ansible.builtin.command: "date +%s%N"
   register: datadog_installer_start_time
   changed_when: true
 
@@ -13,25 +13,25 @@
 # Doing the install here directly would always set the latest task to the used register
 # including when the task is skipped.
 - name: Include installer DNF install task
-  include_tasks: pkg-redhat/install-installer-dnf.yml
+  ansible.builtin.include_tasks: pkg-redhat/install-installer-dnf.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"] and not ansible_check_mode and ansible_pkg_mgr == "dnf"
 
 - name: Include installer DEB install task
-  include_tasks: pkg-debian/install-installer.yml
+  ansible.builtin.include_tasks: pkg-debian/install-installer.yml
   when: ansible_facts.os_family == "Debian" and not ansible_check_mode
 
 - name: Include installer Zypper install task
-  include_tasks: pkg-suse/install-installer-zypper.yml
+  ansible.builtin.include_tasks: pkg-suse/install-installer-zypper.yml
   when: ansible_facts.os_family == "Suse" and not ansible_check_mode
 
 - name: Set the datadog agent version
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_agent_major_version: "{{ datadog_agent_version.split('.', 1).0 }}"
     datadog_agent_minor_version: "{{ datadog_agent_version.split('.', 1).1 }}"
   when: datadog_agent_version
 
 - name: Bootstrap the installer
-  command: /usr/bin/datadog-bootstrap bootstrap
+  ansible.builtin.command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result
   environment:
     DATADOG_TRACE_ID: "{{ datadog_installer_trace_id }}"
@@ -57,17 +57,17 @@
   changed_when: true
 
 - name: Disable agent install if owned by installer
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: true
   when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed and datadog_installer_owns_agent.rc == 0
 
 - name: Stop duration measurements
-  command: "date +%s%N"
+  ansible.builtin.command: "date +%s%N"
   register: datadog_installer_stop_time
   changed_when: true
 
 - name: Setup telemetry body
-  set_fact:
+  ansible.builtin.set_fact:
     telemetry_body: "{{ lookup(
       'template',
       'templates/installer-telemetry.j2',
@@ -100,7 +100,7 @@
   failed_when: false
 
 - name: Setup logs body
-  set_fact:
+  ansible.builtin.set_fact:
     logs_body: "{{ lookup(
       'template',
       'templates/installer-logs.j2',
@@ -121,7 +121,7 @@
   when: not ansible_check_mode
 
 - name: Send Installer telemetry logs
-  uri:
+  ansible.builtin.uri:
     url: "https://instrumentation-telemetry-intake.{{ datadog_site | default('datadoghq.com') }}/api/v2/apmtelemetry"
     body: "{{ logs_body }}"
     method: POST
@@ -133,6 +133,6 @@
   failed_when: false
 
 - name: Propagate failures after telemetry
-  fail:
+  ansible.builtin.fail:
     msg: "Installer bootstrap failed: {{ datadog_installer_bootstrap_result.stderr }}"
   when: not ansible_check_mode and datadog_installer_bootstrap_result.failed

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -50,7 +50,7 @@
   changed_when: true
 
 - name: Check if installer owns datadog-agent package
-  command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
+  ansible.builtin.command: datadog-installer is-installed "{{ datadog_agent_flavor }}"
   failed_when: datadog_installer_owns_agent.rc != 0 and datadog_installer_owns_agent.rc != 10
   register: datadog_installer_owns_agent
   when: not ansible_check_mode and not datadog_installer_bootstrap_result.failed
@@ -88,7 +88,7 @@
   when: not ansible_check_mode
 
 - name: Send Installer telemetry traces
-  uri:
+  ansible.builtin.uri:
     url: "https://instrumentation-telemetry-intake.{{ datadog_site | default('datadoghq.com') }}/api/v2/apmtelemetry"
     body: "{{ telemetry_body }}"
     method: POST

--- a/tasks/integration.yml
+++ b/tasks/integration.yml
@@ -1,6 +1,6 @@
 ---
 - name: Validate integrations actions
-  fail:
+  ansible.builtin.fail:
     msg: "Unkown action '{{ item.value.action }}' for integration command ({{ item.key }}). Valid actions are 'install' and 'remove'"
   when: item.value.action != "install" and item.value.action != "remove"
   loop: "{{ datadog_integration | dict2items }}"
@@ -9,13 +9,13 @@
 # installed, parsing the task would fail even if the host is not Windows. By hiding the task
 # inside a conditionally included file, we can prevent this.
 - name: Include Windows Integration Tasks
-  include_tasks: integration/windows.yml
+  ansible.builtin.include_tasks: integration/windows.yml
   when: ansible_facts.os_family == "Windows"
 
 - name: Include macOS Integration Tasks
-  include_tasks: integration/macos.yml
+  ansible.builtin.include_tasks: integration/macos.yml
   when: ansible_facts.os_family == "Darwin"
 
 - name: Include Linux Integration Tasks
-  include_tasks: integration/linux.yml
+  ansible.builtin.include_tasks: integration/linux.yml
   when: ansible_facts.os_family != "Darwin" and ansible_facts.os_family != "Windows"

--- a/tasks/integration/_linux-macos-shared.yml
+++ b/tasks/integration/_linux-macos-shared.yml
@@ -1,7 +1,7 @@
 # Check current state of the integration
 
 - name: Check integration state, integration={{ item.key }}
-  command:
+  ansible.builtin.command:
     argv:
       - "{{ datadog_agent_binary_path }}"
       - integration
@@ -15,7 +15,7 @@
 # Remove integration
 
 - name: Removing integration, integration={{ item.key }}
-  command:
+  ansible.builtin.command:
     argv:
       - "{{ datadog_agent_binary_path }}"
       - integration
@@ -31,7 +31,7 @@
 # Install integration
 
 - name: Installing pinned version of integration, integration={{ item.key }}
-  command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
+  ansible.builtin.command: "{{ datadog_agent_binary_path }} integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: true
   become_user: "{{ integration_command_user }}"
   vars:

--- a/tasks/integration/_windows-integration-update.yml
+++ b/tasks/integration/_windows-integration-update.yml
@@ -1,7 +1,7 @@
 # Check current state of the integrations
 
 - name: Check integration state, integration={{ item.key }}
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration show -q {{ item.key }}"
+  ansible.windows.win_command: "\"{{ datadog_agent_binary_path }}\" integration show -q {{ item.key }}"
   register: integration_version
   failed_when: false # This task is supposed to fail when the integration is not installed
   changed_when: false
@@ -9,7 +9,7 @@
 # Remove integration
 
 - name: Removing integration, integration={{ item.key }}
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
+  ansible.windows.win_command: "\"{{ datadog_agent_binary_path }}\" integration remove {{ item.key }}"
   become: true
   become_user: "{{ integration_command_user }}"
   when:
@@ -20,7 +20,7 @@
 # Install integration
 
 - name: Installing pinned version of integration, integration={{ item.key }}
-  win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
+  ansible.windows.win_command: "\"{{ datadog_agent_binary_path }}\" integration install {{ third_party }} {{ item.key }}=={{ item.value.version }}"
   become: true
   vars:
     third_party: "{% if 'third_party' in item.value and item.value.third_party | bool %}--third-party{% endif %}"

--- a/tasks/integration/linux.yml
+++ b/tasks/integration/linux.yml
@@ -1,12 +1,12 @@
 ---
 - name: Set Agent binary path
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_linux }}"
 
 - name: Set Agent user for integration commmand
-  set_fact:
+  ansible.builtin.set_fact:
     integration_command_user: "{{ integration_command_user_linux }}"
 
 - name: Include shared integration installation and removal tasks
-  include_tasks: integration/_linux-macos-shared.yml
+  ansible.builtin.include_tasks: integration/_linux-macos-shared.yml
   loop: "{{ datadog_integration | dict2items }}"

--- a/tasks/integration/macos.yml
+++ b/tasks/integration/macos.yml
@@ -1,12 +1,12 @@
 ---
 - name: Set Agent binary path
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_macos }}"
 
 - name: Set Agent user for integration commmand
-  set_fact:
+  ansible.builtin.set_fact:
     integration_command_user: "{{ integration_command_user_macos }}"
 
 - name: Include shared integration installation and removal tasks
-  include_tasks: integration/_linux-macos-shared.yml
+  ansible.builtin.include_tasks: integration/_linux-macos-shared.yml
   loop: "{{ datadog_integration | dict2items }}"

--- a/tasks/integration/windows.yml
+++ b/tasks/integration/windows.yml
@@ -1,12 +1,12 @@
 ---
 - name: Set Agent binary path
-  set_fact:
+  ansible.builtin.set_fact:
     datadog_agent_binary_path: "{{ datadog_agent_binary_path_windows }}"
 
 - name: Set Agent user for integration commmand
-  set_fact:
+  ansible.builtin.set_fact:
     integration_command_user: "{{ integration_command_user_windows }}"
 
 - name: Include integration installation and removal tasks
-  include_tasks: integration/_windows-integration-update.yml
+  ansible.builtin.include_tasks: integration/_windows-integration-update.yml
   loop: "{{ datadog_integration | dict2items }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
-- name: Include Gather Ansible Facts task
-  ansible.builtin.include_tasks: facts-ansible10.yml
+- name: Gather Ansible Facts
+  ansible.builtin.setup: # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.
 
 - name: Initialize internal datadog_config variable
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,79 +1,79 @@
 ---
 - name: Include Gather Ansible Facts task on Ansible >= 2.10
-  include_tasks: facts-ansible10.yml
+  ansible.builtin.include_tasks: facts-ansible10.yml
   when: ansible_version.major >= 2 and ansible_version.minor >= 10
 
 - name: Include Gather Ansible Facts task on Ansible < 2.10
-  include_tasks: facts-ansible9.yml
+  ansible.builtin.include_tasks: facts-ansible9.yml
   when: ansible_version.major == 2 and ansible_version.minor < 10
 
 - name: Initialize internal datadog_config variable
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_config: "{{ datadog_config }}"
 
 - name: Check if OS is supported
-  include_tasks: os-check.yml
+  ansible.builtin.include_tasks: os-check.yml
 
 - name: Fail if API key is missing
-  fail:
+  ansible.builtin.fail:
     msg: "datadog_api_key is mandatory when using managed config"
   when: datadog_api_key is not defined and datadog_manage_config
 
 - name: Resolve datadog_tracked_checks later to defend against variable presidence issues arising from dynamically included null datadog_checks
-  include_tasks: sanitize-checks.yml
+  ansible.builtin.include_tasks: sanitize-checks.yml
 
 # Also sets agent_datadog_skip_install
 - name: Set Facts for Datadog Agent Major Version
-  include_tasks: set-parse-version.yml
+  ansible.builtin.include_tasks: set-parse-version.yml
 
 - name: Configure Datadog Installer
-  include_tasks: installer-config.yml
+  ansible.builtin.include_tasks: installer-config.yml
 
 - name: Debian Install Tasks
-  include_tasks: pkg-debian.yml
+  ansible.builtin.include_tasks: pkg-debian.yml
   when: ansible_facts.os_family == "Debian"
 
 - name: Include tasks to remove old GPG keys
-  include_tasks: _remove_rpm_keys.yml
+  ansible.builtin.include_tasks: _remove_rpm_keys.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux", "Suse"]
   loop: "{{ datadog_rpm_remove_keys }}"
 
 - name: Include tasks to check removed configuration value usage
-  include_tasks: check-removed-config.yml
+  ansible.builtin.include_tasks: check-removed-config.yml
 
 # Only Ansible >= 3.0 knows that AlmaLinux belongs to "RedHat" family
 # (and latest bugfix releases of some 2.X)
 # For Rocky it is some 4.X and >= 5.0
 - name: RedHat Install Tasks
-  include_tasks: pkg-redhat.yml
+  ansible.builtin.include_tasks: pkg-redhat.yml
   when: ansible_facts.os_family in ["RedHat", "Rocky", "AlmaLinux"]
 
 - name: Suse Install Tasks
-  include_tasks: pkg-suse.yml
+  ansible.builtin.include_tasks: pkg-suse.yml
   when: ansible_facts.os_family == "Suse"
 
 # Note we don't check agent_datadog_skip_install variable value for windows here,
 # because some tasks in pkg-windows.yml are carried out regardless of its value.
 - name: Windows Install Tasks
-  include_tasks: pkg-windows.yml
+  ansible.builtin.include_tasks: pkg-windows.yml
   when: ansible_facts.os_family == "Windows"
 
 - name: MacOS Install Tasks
-  include_tasks: pkg-macos.yml
+  ansible.builtin.include_tasks: pkg-macos.yml
   when: ansible_facts.os_family == "Darwin" and not agent_datadog_skip_install
 
 - name: Linux Configuration Tasks
-  include_tasks: agent-linux.yml
+  ansible.builtin.include_tasks: agent-linux.yml
   when: ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
 
 - name: Windows Configuration Tasks
-  include_tasks: agent-win.yml
+  ansible.builtin.include_tasks: agent-win.yml
   when: ansible_facts.os_family == "Windows"
 
 - name: MacOS Configuration Tasks
-  include_tasks: agent-macos.yml
+  ansible.builtin.include_tasks: agent-macos.yml
   when: ansible_facts.os_family == "Darwin"
 
 - name: Integrations Tasks
-  include_tasks: integration.yml
+  ansible.builtin.include_tasks: integration.yml
   when: datadog_integration is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,6 @@
 ---
-- name: Include Gather Ansible Facts task on Ansible >= 2.10
+- name: Include Gather Ansible Facts task
   ansible.builtin.include_tasks: facts-ansible10.yml
-  when: ansible_version.major >= 2 and ansible_version.minor >= 10
-
-- name: Include Gather Ansible Facts task on Ansible < 2.10
-  ansible.builtin.include_tasks: facts-ansible9.yml
-  when: ansible_version.major == 2 and ansible_version.minor < 10
 
 - name: Initialize internal datadog_config variable
   ansible.builtin.set_fact:

--- a/tasks/os-check.yml
+++ b/tasks/os-check.yml
@@ -1,5 +1,5 @@
 ---
 - name: Fail if OS is not supported
-  fail:
+  ansible.builtin.fail:
     msg: "The Datadog Ansible role does not support your OS yet. Please email support@datadoghq.com to open a feature request."
   when: ansible_facts.os_family not in ["RedHat", "Rocky", "AlmaLinux", "Debian", "Suse", "Windows", "Darwin"]

--- a/tasks/parse-version-macos.yml
+++ b/tasks/parse-version-macos.yml
@@ -1,6 +1,6 @@
 ---
 - name: Get macOS Agent version
-  shell:
+  ansible.builtin.shell:
     cmd: set -o pipefail && {{ datadog_agent_binary_path_macos }} version | grep 'Agent ' | awk '{print $2}'
     executable: /bin/bash
   register: agent_datadog_version_check_macos

--- a/tasks/parse-version-windows.yml
+++ b/tasks/parse-version-windows.yml
@@ -1,7 +1,7 @@
 ---
 # NOTE: This won't work with rc / beta builds.
 - name: Get Windows Agent version
-  win_shell: |
+  amazon.windows.win_shell: |
     $product_name = "Datadog Agent"
     $version=Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |
     Select-Object DisplayName,DisplayVersion,PSChildName -unique |

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -70,7 +70,7 @@
       Darwin: "{{ agent_datadog_agent_macos_version }}"
 
 - name: Get Linux Agent version
-  shell: "{{ agent_datadog_version_finding_cmds[ansible_facts.os_family] }}" # noqa command-instead-of-shell - We need shell because of pipes
+  ansible.builtin.shell: "{{ agent_datadog_version_finding_cmds[ansible_facts.os_family] }}" # noqa command-instead-of-shell - We need shell because of pipes
   register: agent_datadog_version_check_linux
   changed_when: false
   failed_when: false
@@ -81,11 +81,11 @@
 # parsing the task would fail even if the host is not Windows. By hiding the task inside
 # a conditionally included file, we can prevent this.
 - name: Include Windows Agent version tasks
-  include_tasks: parse-version-windows.yml
+  ansible.builtin.include_tasks: parse-version-windows.yml
   when: ansible_facts.os_family == "Windows"
 
 - name: Include macOS Agent version tasks
-  include_tasks: parse-version-macos.yml
+  ansible.builtin.include_tasks: parse-version-macos.yml
   when: ansible_facts.os_family == "Darwin"
 
 - name: Set skip install flag if version already installed (Linux)

--- a/tasks/parse-version.yml
+++ b/tasks/parse-version.yml
@@ -1,13 +1,13 @@
 ---
 - name: Parse Agent version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_version: "{{ datadog_agent_version
       | regex_search(agent_regexp, '\\g<epoch>', '\\g<major>', '\\g<minor>', '\\g<bugfix>', '\\g<suffix>', '\\g<release>') }}"
   vars:
     agent_regexp: (?:(?P<epoch>[0-9]+):)?(?P<major>[0-9]+)\.(?P<minor>[0-9]+)\.(?P<bugfix>[0-9]+)(?P<suffix>(?:~|-)[^0-9\s-]+[^-\s]*)?(?:-(?P<release>[0-9]+))?
 
 - name: Set version vars
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_epoch: "{{ agent_version.0 | default('', true) | string }}"
     agent_datadog_major: "{{ agent_version.1 | default('', true) | string }}"
     agent_datadog_minor: "{{ agent_version.2 | default('', true) | string }}"
@@ -16,33 +16,33 @@
     agent_datadog_release: "{{ agent_version.5 | default('', true) | string }}"
 
 - name: Fill empty version epoch with default
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_epoch: "1"
   when: agent_datadog_epoch | length == 0
 
 - name: Fill empty version release with default
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_release: "1"
   when: agent_datadog_release | length == 0
 
 - name: Stop play if datadog_agent_version and datadog_agent_major_version are not compatible
-  fail:
+  ansible.builtin.fail:
     msg: "The provided major version {{ agent_datadog_agent_major_version }} is not compatible with the version {{ agent_datadog_major }}
       deduced from datadog_agent_version ({{ datadog_agent_version }}). Aborting play."
   when: agent_datadog_agent_major_version | length > 0 and agent_datadog_major != agent_datadog_agent_major_version
 
 - name: Set agent_datadog_agent_major_version to deduced value from datadog_agent_version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_major_version: "{{ agent_datadog_major }}"
 
 - name: Set helper variables
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_linux_version: "{{ agent_datadog_epoch }}:{{ agent_datadog_major }}.{{ agent_datadog_minor }}.{{ agent_datadog_bugfix }}{{ agent_datadog_suffix }}-{{ agent_datadog_release }}" # noqa yaml[line-length]
     agent_datadog_rpm_version_finding_cmd: "rpm -q --qf '%{EPOCH}:%{VERSION}-%{RELEASE}' {{ datadog_agent_flavor }}"
 
 - name: Set OS-specific versions
   # NOTE: if changing these, make sure the format correspond with values in agent_datadog_version_finding_cmds below
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_debian_version: "{{ agent_datadog_agent_linux_version }}"
     agent_datadog_agent_redhat_version: "{{ agent_datadog_agent_linux_version }}"
     agent_datadog_agent_suse_version: "{{ agent_datadog_agent_linux_version }}"
@@ -50,7 +50,7 @@
     agent_datadog_agent_macos_version: "{{ agent_datadog_major }}.{{ agent_datadog_minor }}.{{ agent_datadog_bugfix }}{{ agent_datadog_suffix }}"
 
 - name: Construct commands to find Agent version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_version_finding_cmds:
       Debian: "dpkg-query --showformat '${Status} ${Version}\n' --show {{ datadog_agent_flavor }} | grep installed | awk '{print $NF}'"
       RedHat: "{{ agent_datadog_rpm_version_finding_cmd }}"
@@ -59,7 +59,7 @@
       Suse: "{{ agent_datadog_rpm_version_finding_cmd }}"
 
 - name: Create OS-specific version dict
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_os2version:
       Debian: "{{ agent_datadog_agent_debian_version }}"
       RedHat: "{{ agent_datadog_agent_redhat_version }}"
@@ -89,16 +89,16 @@
   when: ansible_facts.os_family == "Darwin"
 
 - name: Set skip install flag if version already installed (Linux)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: "{{ agent_datadog_version_check_linux.stdout | trim == agent_datadog_agent_os2version[ansible_facts.os_family] }}"
   when: ansible_facts.system is defined and ansible_facts.system == "Linux"
 
 - name: Set skip install flag if version already installed (Windows)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: "{{ agent_datadog_version_check_win.stdout | trim == agent_datadog_agent_os2version[ansible_facts.os_family] }}"
   when: ansible_facts.os_family == "Windows"
 
 - name: Set skip install flag if version already installed (macOS)
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: "{{ agent_datadog_version_check_macos.stdout | trim == agent_datadog_agent_os2version[ansible_facts.os_family] }}"
   when: ansible_facts.os_family == "Darwin"

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -28,12 +28,12 @@
   when: not ansible_check_mode and (not agent_apt_keyring_file.stat.exists or not agent_apt_keyring_file.stat.mode == "0644")
 
 - name: Install apt keys from default URLs
-  include_tasks: _apt-key-import.yml
+  ansible.builtin.include_tasks: _apt-key-import.yml
   with_items: "{{ datadog_apt_default_keys }}"
   when: datadog_apt_key_url_new is not defined and not ansible_check_mode
 
 - name: Install apt keys from custom URL
-  include_tasks: _apt-key-import.yml
+  ansible.builtin.include_tasks: _apt-key-import.yml
   with_items:
     - key: A2923DFF56EDA6E76E55E492D3A80E30382E94DE
       value: "{{ datadog_apt_key_url_new }}"
@@ -47,7 +47,7 @@
 
 - name: Ensure keyring1 exists with same contents as keyring2 for older distro versions.
     keyring1,keyring2= {{ datadog_apt_trusted_d_keyring, datadog_apt_usr_share_keyring }}
-  copy:
+  ansible.builtin.copy:
     src: "{{ datadog_apt_usr_share_keyring }}"
     dest: "{{ datadog_apt_trusted_d_keyring }}"
     mode: "0644"
@@ -56,7 +56,7 @@
     (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int < 16)) and not ansible_check_mode
 
 - name: Ensure Datadog non-https repositories and repositories not using signed-by option are deprecated
-  apt_repository:
+  ansible.builtin.apt_repository:
     repo: "{{ item }}"
     state: absent
     update_cache: true

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -1,25 +1,25 @@
 ---
 - name: Install apt-transport-https
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     name: apt-transport-https
     state: present
   when: not ansible_check_mode
 
 - name: Install gnupg
-  apt:
+  ansible.builtin.apt:
     update_cache: true
     name: gnupg
     state: present
   when: not ansible_check_mode
 
 - name: Check if keyring exists with correct mode, keyring={{ datadog_apt_usr_share_keyring }}
-  stat:
+  ansible.builtin.stat:
     path: "{{ datadog_apt_usr_share_keyring }}"
   register: agent_apt_keyring_file
 
 - name: Ensure keyring exists, keyring={{ datadog_apt_usr_share_keyring }}
-  file:
+  ansible.builtin.file:
     path: "{{ datadog_apt_usr_share_keyring }}"
     owner: root
     group: root
@@ -70,7 +70,7 @@
   when: not ansible_check_mode
 
 - name: Ensure Datadog repository is up-to-date
-  apt_repository:
+  ansible.builtin.apt_repository:
     filename: ansible_datadog_{{ item.key }}
     repo: "{{ item.value }}"
     state: "{% if item.key == agent_datadog_agent_major_version | int and datadog_apt_repo | length == 0 %}present{% else %}absent{% endif %}"
@@ -81,35 +81,35 @@
     7: "{{ datadog_agent7_apt_repo }}"
 
 - name: Initialize custom repo file deletion flag to False
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_remove_custom_repo_file: "False"
 
 - name: Check if custom repository file exists
-  stat:
+  ansible.builtin.stat:
     path: /etc/apt/sources.list.d/ansible_datadog_custom.list
   register: agent_datadog_custom_repo_file
 
 - name: Fetch custom repository file
-  slurp:
+  ansible.builtin.slurp:
     src: /etc/apt/sources.list.d/ansible_datadog_custom.list
   register: agent_datadog_custom_repo_file_contents
   when: agent_datadog_custom_repo_file.stat.exists
 
 - name: Flag custom repository file for deletion if different from current repository config
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_remove_custom_repo_file: "{{ agent_datadog_repo_file_contents != datadog_apt_repo }}"
   vars:
     agent_datadog_repo_file_contents: "{{ agent_datadog_custom_repo_file_contents['content'] | b64decode | trim }}"
   when: agent_datadog_custom_repo_file.stat.exists
 
 - name: (Custom) Remove Datadog custom repository file when not set or updated
-  file:
+  ansible.builtin.file:
     path: /etc/apt/sources.list.d/ansible_datadog_custom.list
     state: absent
   when: (datadog_apt_repo | length == 0) or agent_datadog_remove_custom_repo_file and (not ansible_check_mode)
 
 - name: (Custom) Ensure Datadog repository is up-to-date
-  apt_repository:
+  ansible.builtin.apt_repository:
     filename: ansible_datadog_custom
     repo: "{{ datadog_apt_repo }}"
     state: present
@@ -117,19 +117,19 @@
   when: (datadog_apt_repo | length > 0) and (not ansible_check_mode)
 
 - name: Include installer setup
-  include_tasks: installer-setup.yml
+  ansible.builtin.include_tasks: installer-setup.yml
   when: datadog_installer_enabled
 
 - name: Include debian pinned version install task
-  include_tasks: pkg-debian/install-pinned.yml
+  ansible.builtin.include_tasks: pkg-debian/install-pinned.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_debian_version is defined
 
 - name: Include debian latest version install task
-  include_tasks: pkg-debian/install-latest.yml
+  ansible.builtin.include_tasks: pkg-debian/install-latest.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_debian_version is not defined
 
 - name: Install latest datadog-signing-keys package
-  apt:
+  ansible.builtin.apt:
     name: datadog-signing-keys
     state: latest # noqa package-latest
     # we don't use update_cache: yes, as that was just done by the "Ensure Datadog repository is up-to-date" task above

--- a/tasks/pkg-debian/install-installer.yml
+++ b/tasks/pkg-debian/install-installer.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install Datadog installer (apt)
-  apt:
+  ansible.builtin.apt:
     name: "{{ datadog_installer_flavor }}"
     state: latest # noqa package-latest
     update_cache: true

--- a/tasks/pkg-debian/install-latest.yml
+++ b/tasks/pkg-debian/install-latest.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install latest datadog-agent package
-  apt:
+  ansible.builtin.apt:
     name: "{{ datadog_agent_flavor }}"
     state: latest # noqa package-latest
     update_cache: true

--- a/tasks/pkg-debian/install-pinned.yml
+++ b/tasks/pkg-debian/install-pinned.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install pinned datadog-agent package
-  apt:
+  ansible.builtin.apt:
     name: "{{ datadog_agent_flavor }}={{ agent_datadog_agent_debian_version }}"
     state: present
     force: "{{ datadog_agent_allow_downgrade }}"

--- a/tasks/pkg-macos.yml
+++ b/tasks/pkg-macos.yml
@@ -48,7 +48,7 @@
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 
 - name: Detach agent dmg if already mounted
-  shell: hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
+  ansible.builtin.shell: hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
   changed_when: true
 

--- a/tasks/pkg-macos.yml
+++ b/tasks/pkg-macos.yml
@@ -2,45 +2,45 @@
 # NOTE: the DMG gets installed as ansible_user, but we then configure it to run
 # under datadog_macos_user and remove the user-specific config for ansible_user
 - name: Check if the macOS user for Agent service exists
-  command: id -u "{{ datadog_macos_user }}"
+  ansible.builtin.command: id -u "{{ datadog_macos_user }}"
   register: agent_mac_user_check
   changed_when: false
   ignore_errors: true
 
 - name: Fail if the macOS user for Agent service doesn't exist
-  fail:
+  ansible.builtin.fail:
     msg: "The Datadog ansible role wasn't able to find the user : {{ datadog_macos_user }}"
   when: agent_mac_user_check.rc != 0
 
 - name: Include macos agent latest version install task
-  include_tasks: pkg-macos/macos_agent_latest.yml
+  ansible.builtin.include_tasks: pkg-macos/macos_agent_latest.yml
   when: (not agent_datadog_skip_install) and (agent_datadog_agent_macos_version is not defined)
 
 - name: Include macos agent pinned version install task
-  include_tasks: pkg-macos/macos_agent_version.yml
+  ansible.builtin.include_tasks: pkg-macos/macos_agent_version.yml
   when: (not agent_datadog_skip_install) and (agent_datadog_agent_macos_version is defined)
 
 - name: Display macOS download URL
-  debug:
+  ansible.builtin.debug:
     var: agent_dd_download_url
   when: not agent_datadog_skip_install
 
 - name: Pre-Delete temporary dmg
-  file:
+  ansible.builtin.file:
     path: /tmp/datadog-agent.dmg
     state: absent
   become: true
   when: not agent_datadog_skip_install
 
 - name: Create temporary datadog install user file
-  copy:
+  ansible.builtin.copy:
     dest: /tmp/datadog-install-user
     content: "{{ datadog_macos_user }}"
     mode: "0554"
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 
 - name: Download macOS datadog agent
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ agent_dd_download_url }}"
     dest: /tmp/datadog-agent.dmg
     mode: "0750"
@@ -53,12 +53,12 @@
   changed_when: true
 
 - name: Attach agent dmg
-  command: hdiutil attach /tmp/datadog-agent.dmg -mountpoint "/Volumes/datadog_agent"
+  ansible.builtin.command: hdiutil attach /tmp/datadog-agent.dmg -mountpoint "/Volumes/datadog_agent"
   when: (not agent_datadog_skip_install) and (not ansible_check_mode) and (agent_download_dmg_result.status_code == 200)
   changed_when: true
 
 - name: Unpack and copy Datadog Agent files
-  shell:
+  ansible.builtin.shell:
     cmd: /usr/sbin/installer -pkg "`find "/Volumes/datadog_agent" -name \*.pkg 2>/dev/null`" -target /
     chdir: /
   become: true
@@ -68,19 +68,19 @@
   notify: restart datadog-agent-macos
 
 - name: Detach mounted dmg
-  command: hdiutil detach "/Volumes/datadog_agent"
+  ansible.builtin.command: hdiutil detach "/Volumes/datadog_agent"
   when: (not agent_datadog_skip_install) and (not ansible_check_mode) and (agent_download_dmg_result.status_code == 200)
   changed_when: true
 
 - name: Delete temporary dmg
-  file:
+  ansible.builtin.file:
     path: "{{ agent_download_dmg_result.dest }}"
     state: absent
   become: true
   when: (not agent_datadog_skip_install) and (not ansible_check_mode) and (agent_download_dmg_result.status_code == 200)
 
 - name: Delete temporary datadog install user file
-  file:
+  ansible.builtin.file:
     path: /tmp/datadog-install-user
     state: absent
   become: true

--- a/tasks/pkg-macos/macos_agent_latest.yml
+++ b/tasks/pkg-macos/macos_agent_latest.yml
@@ -1,11 +1,11 @@
 ---
 - name: Set agent download filename to custom URL
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_macos_download_url }}"
   when: datadog_macos_download_url | default('', true) | length > 0
 
 - name: Set agent download filename to latest
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{% if agent_datadog_agent_major_version | int == 7 %}
       {{ datadog_macos_agent7_latest_url }} {% else %}{{ datadog_macos_agent6_latest_url }}{% endif %}"
   when: datadog_macos_download_url | default('', true) | length == 0

--- a/tasks/pkg-macos/macos_agent_version.yml
+++ b/tasks/pkg-macos/macos_agent_version.yml
@@ -1,4 +1,4 @@
 ---
 - name: Set agent download filename to a specific version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_macos_versioned_url }}-{{ agent_datadog_agent_macos_version }}-1.dmg"

--- a/tasks/pkg-redhat.yml
+++ b/tasks/pkg-redhat.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure dnf is used as package manager
-  set_fact:
+  ansible.builtin.set_fact:
     ansible_pkg_mgr: dnf
 
 - name: If yum repo configuration is enabled
@@ -9,7 +9,7 @@
     - name: Find out whether to set repo_gpgcheck or not
       # We turn off repo_gpgcheck on custom repos and on RHEL/CentOS 8.1 because
       # of https://bugzilla.redhat.com/show_bug.cgi?id=1792506
-      set_fact:
+      ansible.builtin.set_fact:
         agent_do_yum_repo_gpgcheck: >-
           {{ datadog_yum_repo_gpgcheck if datadog_yum_repo_gpgcheck != '' else (
             'no' if (
@@ -19,20 +19,20 @@
           ) }}
 
     - name: Download current RPM key
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_yum_gpgkey_current }}"
         dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
         mode: '600'
         force: true
 
     - name: Import current RPM key
-      rpm_key:
+      ansible.builtin.rpm_key:
         key: /tmp/DATADOG_RPM_KEY_CURRENT.public
         state: present
       when: not ansible_check_mode
 
     - name: Download old RPM key (Expires in 2022)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_yum_gpgkey_e09422b3 }}"
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
@@ -40,69 +40,69 @@
       when: agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
     - name: Import old RPM key (Expires in 2022)
-      rpm_key:
+      ansible.builtin.rpm_key:
         key: /tmp/DATADOG_RPM_KEY_E09422B3.public
         state: present
       when: not ansible_check_mode and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
     - name: Download new RPM key (Expires in 2024)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_yum_gpgkey_20200908 }}"
         dest: /tmp/DATADOG_RPM_KEY_20200908.public
         mode: '600'
         checksum: "sha256:{{ datadog_yum_gpgkey_20200908_sha256sum }}"
 
     - name: Import new RPM key (Expires in 2024)
-      rpm_key:
+      ansible.builtin.rpm_key:
         key: /tmp/DATADOG_RPM_KEY_20200908.public
         state: present
       when: not ansible_check_mode
 
     - name: Download new RPM key (Expires in 2028)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_yum_gpgkey_20280418 }}"
         dest: /tmp/DATADOG_RPM_KEY_20280418.public
         mode: '600'
         checksum: "sha256:{{ datadog_yum_gpgkey_20280418_sha256sum }}"
 
     - name: Import new RPM key (Expires in 2028)
-      rpm_key:
+      ansible.builtin.rpm_key:
         key: /tmp/DATADOG_RPM_KEY_20280418.public
         state: present
       when: not ansible_check_mode
 
     - name: Download future RPM key (Expires in 2033)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_yum_gpgkey_4f09d16b }}"
         dest: /tmp/DATADOG_RPM_KEY_4FA09D16B.public
         mode: '600'
         checksum: "sha256:{{ datadog_yum_gpgkey_4f09d16b_sha256sum }}"
 
     - name: Import future RPM key (Expires in 2033)
-      rpm_key:
+      ansible.builtin.rpm_key:
         key: /tmp/DATADOG_RPM_KEY_4FA09D16B.public
         state: present
       when: not ansible_check_mode
 
     - name: Set versioned includepkgs variable
-      set_fact:
+      ansible.builtin.set_fact:
         agent_datadog_includepkgs: "{{ datadog_agent_flavor }}-{{ agent_datadog_agent_redhat_version | regex_replace('^\\d+:', '') }}"
       when: agent_datadog_agent_redhat_version is defined
 
     - name: Set plain includepkgs variable
-      set_fact:
+      ansible.builtin.set_fact:
         agent_datadog_includepkgs: "{{ datadog_agent_flavor }}
          {{ agent_dd_apm_install_pkgs | default([], true) | join(' ') }}"
       when: agent_datadog_agent_redhat_version is not defined
 
     - name: Include datadog-installer to includepgks
-      set_fact:
+      ansible.builtin.set_fact:
         agent_datadog_includepkgs:
           "{{ agent_datadog_includepkgs }} {{ datadog_installer_flavor }}"
       when: datadog_installer_enabled
 
     - name: Install Datadog Agent 6 yum repo
-      yum_repository:
+      ansible.builtin.yum_repository:
         name: datadog
         description: Datadog, Inc.
         baseurl: "{{ datadog_agent6_yum_repo }}"
@@ -123,7 +123,7 @@
       when: (agent_datadog_agent_major_version | int == 6) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
     - name: Install Datadog Agent 7 yum repo
-      yum_repository:
+      ansible.builtin.yum_repository:
         name: datadog
         description: Datadog, Inc.
         baseurl: "{{ datadog_agent7_yum_repo }}"
@@ -144,7 +144,7 @@
       when: (agent_datadog_agent_major_version | int == 7) and (datadog_yum_repo | length == 0) and (not ansible_check_mode)
 
     - name: Install Datadog Custom yum repo
-      yum_repository:
+      ansible.builtin.yum_repository:
         name: datadog
         description: Datadog, Inc.
         baseurl: "{{ datadog_yum_repo }}"
@@ -165,7 +165,7 @@
       when: (datadog_yum_repo | length > 0) and (not ansible_check_mode)
 
     - name: Clean repo metadata if repo changed # noqa: command-instead-of-module no-handler
-      command: dnf clean metadata --disablerepo="*" --enablerepo=datadog
+      ansible.builtin.command: dnf clean metadata --disablerepo="*" --enablerepo=datadog
       failed_when: false # Cleaning the metadata is only needed when downgrading a major version of the Agent, don't fail because of this
       when: agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed
       changed_when: true
@@ -174,25 +174,25 @@
     # This rule assures that they are correctly imported into the local db and users won't have to manually accept
     # them if running dnf commands on the hosts.
     - name: Refresh Datadog repository cache # noqa: command-instead-of-module no-handler
-      command: dnf -y makecache --disablerepo="*" --enablerepo=datadog
+      ansible.builtin.command: dnf -y makecache --disablerepo="*" --enablerepo=datadog
       failed_when: false
       when: agent_repofile6.changed or agent_repofile7.changed or agent_repofilecustom.changed
       changed_when: true
 
     - name: Remove old yum repo files
-      yum_repository:
+      ansible.builtin.yum_repository:
         name: ansible_datadog_{{ item }}
         state: absent
       with_items: [6, 7, custom]
 
 - name: Include installer setup
-  include_tasks: installer-setup.yml
+  ansible.builtin.include_tasks: installer-setup.yml
   when: datadog_installer_enabled
 
 - name: Include redhat agent pinned version install task
-  include_tasks: pkg-redhat/install-pinned.yml
+  ansible.builtin.include_tasks: pkg-redhat/install-pinned.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_redhat_version is defined
 
 - name: Include redhat agent latest version install task
-  include_tasks: pkg-redhat/install-latest.yml
+  ansible.builtin.include_tasks: pkg-redhat/install-latest.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_redhat_version is not defined

--- a/tasks/pkg-redhat/install-installer-dnf.yml
+++ b/tasks/pkg-redhat/install-installer-dnf.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install datadog-installer package (dnf)
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ datadog_installer_flavor }}"
     update_cache: true
     state: latest # noqa package-latest

--- a/tasks/pkg-redhat/install-latest.yml
+++ b/tasks/pkg-redhat/install-latest.yml
@@ -1,6 +1,6 @@
 ---
 - name: Set installation target for latest
-  set_fact:
+  ansible.builtin.set_fact:
     # Apply a version cap if required, otherwise just target the agent package
     datadog_agent_target: >-
       {{ datadog_agent_flavor }}
@@ -9,7 +9,7 @@
       {% endif %}
 
 - name: Install latest datadog-agent package (dnf)
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ datadog_agent_target }}"
     update_cache: true
     state: latest # noqa package-latest

--- a/tasks/pkg-redhat/install-pinned.yml
+++ b/tasks/pkg-redhat/install-pinned.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install pinned datadog-agent package (dnf)
-  dnf:
+  ansible.builtin.dnf:
     name: "{{ datadog_agent_flavor }}-{{ agent_datadog_agent_redhat_version }}"
     update_cache: true
     state: present

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -1,6 +1,6 @@
 ---
 - name: Find out whether to set repo_gpgcheck or not
-  set_fact:
+  ansible.builtin.set_fact:
     agent_do_zypper_repo_gpgcheck: >-
       {{ datadog_zypper_repo_gpgcheck if datadog_zypper_repo_gpgcheck != '' else (
         'yes' if datadog_zypper_repo == '' else 'no'
@@ -10,11 +10,11 @@
   when: ansible_distribution_version|int == 11
   block:
     - name: Stat if current RPM key already exists
-      stat:
+      ansible.builtin.stat:
         path: /tmp/DATADOG_RPM_KEY_CURRENT.public
       register: agent_ddkeycurrent
     - name: Download current RPM key (SLES11)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_zypper_gpgkey_current }}"
         dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
         mode: '600'
@@ -22,7 +22,7 @@
       when: not agent_ddkeycurrent.stat.exists
 
 - name: Download current RPM key
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ datadog_zypper_gpgkey_current }}"
     dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
     force: true
@@ -30,7 +30,7 @@
   when: ansible_distribution_version|int >= 12
 
 - name: Import current RPM key
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: /tmp/DATADOG_RPM_KEY_CURRENT.public
     state: present
   when: not ansible_check_mode
@@ -39,18 +39,18 @@
   when: ansible_distribution_version|int == 11
   block:
     - name: Stat if E09422B3 key (Expires 2022) RPM key already exists
-      stat:
+      ansible.builtin.stat:
         path: /tmp/DATADOG_RPM_KEY_E09422B3.public
       register: agent_ddnewkey
     - name: Download E09422B3 key (Expires 2022) RPM key (SLES11)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_zypper_gpgkey_e09422b3 }}"
         dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
         mode: '600'
       when: not agent_ddnewkey.stat.exists and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Download E09422B3 key (Expires 2022) RPM key
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ datadog_zypper_gpgkey_e09422b3 }}"
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     checksum: sha256:{{ datadog_zypper_gpgkey_e09422b3_sha256sum }}
@@ -58,7 +58,7 @@
   when: ansible_distribution_version|int >= 12 and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Import E09422B3 key (Expires 2022) RPM key
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: /tmp/DATADOG_RPM_KEY_E09422B3.public
     state: present
   when: not ansible_check_mode and agent_datadog_minor is defined and agent_datadog_minor | int < 36
@@ -67,18 +67,18 @@
   when: ansible_distribution_version|int == 11
   block:
     - name: Stat if 20200908 key (Expires 2024) RPM key already exists
-      stat:
+      ansible.builtin.stat:
         path: /tmp/DATADOG_RPM_KEY_20200908.public
       register: agent_ddnewkey_20200908
     - name: Download 20200908 key (Expires 2024) RPM key (SLES11)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_zypper_gpgkey_20200908 }}"
         dest: /tmp/DATADOG_RPM_KEY_20200908.public
         mode: '600'
       when: not  agent_ddnewkey_20200908.stat.exists
 
 - name: Download 20200908 key (Expires 2024) RPM key
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ datadog_zypper_gpgkey_20200908 }}"
     dest: /tmp/DATADOG_RPM_KEY_20200908.public
     checksum: sha256:{{ datadog_zypper_gpgkey_20200908_sha256sum }}
@@ -86,7 +86,7 @@
   when: ansible_distribution_version|int >= 12
 
 - name: Import 20200908 key (Expires 2024) RPM key
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: /tmp/DATADOG_RPM_KEY_20200908.public
     state: present
   when: not ansible_check_mode
@@ -95,18 +95,18 @@
   when: ansible_distribution_version|int == 11
   block:
     - name: Stat if 20280418 key (Expires 2028) RPM key already exists
-      stat:
+      ansible.builtin.stat:
         path: /tmp/DATADOG_RPM_KEY_20280418.public
       register: agent_ddnewkey_20280418
     - name: Download 20280418 key (Expires 2028) RPM key (SLES11)
-      get_url:
+      ansible.builtin.get_url:
         url: "{{ datadog_zypper_gpgkey_20280418 }}"
         dest: /tmp/DATADOG_RPM_KEY_20280418.public
         mode: '600'
       when: not agent_ddnewkey_20280418.stat.exists
 
 - name: Download 20280418 key (Expires 2028) RPM key
-  get_url:
+  ansible.builtin.get_url:
     url: "{{ datadog_zypper_gpgkey_20280418 }}"
     dest: /tmp/DATADOG_RPM_KEY_20280418.public
     checksum: "sha256:{{ datadog_zypper_gpgkey_20280418_sha256sum }}"
@@ -114,14 +114,14 @@
   when: ansible_distribution_version|int >= 12
 
 - name: Import 20280418 key (Expires 2028) RPM key
-  rpm_key:
+  ansible.builtin.rpm_key:
     key: /tmp/DATADOG_RPM_KEY_20280418.public
     state: present
   when: not ansible_check_mode
 
 # ansible don't allow repo_gpgcheck to be set, we have to create the repo file manually
 - name: Install DataDog zypper repo
-  template:
+  ansible.builtin.template:
     src: zypper.repo.j2
     dest: /etc/zypp/repos.d/datadog.repo
     owner: root
@@ -131,19 +131,19 @@
   when: datadog_manage_zypper_repofile
 
 - name: Include installer setup
-  include_tasks: installer-setup.yml
+  ansible.builtin.include_tasks: installer-setup.yml
   when: datadog_installer_enabled
 
 # refresh zypper repos only if the template changed
 - name: Refresh Datadog zypper_repos # noqa: command-instead-of-module
-  command: zypper refresh datadog
+  ansible.builtin.command: zypper refresh datadog
   when: not agent_datadog_skip_install and agent_datadog_zypper_repo_template.changed and not ansible_check_mode
   changed_when: true
 
 - name: Include Suse agent pinned version install task
-  include_tasks: pkg-suse/install-pinned.yml
+  ansible.builtin.include_tasks: pkg-suse/install-pinned.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_suse_version is defined
 
 - name: Include Suse agent latest version install task
-  include_tasks: pkg-suse/install-latest.yml
+  ansible.builtin.include_tasks: pkg-suse/install-latest.yml
   when: not agent_datadog_skip_install and agent_datadog_agent_suse_version is not defined

--- a/tasks/pkg-suse/install-installer-zypper.yml
+++ b/tasks/pkg-suse/install-installer-zypper.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install latest datadog-installer package (zypper)
-  ansible.builtin.zypper:
+  community.general.zypper:
     name: "{{ datadog_installer_flavor }}"
     state: latest # noqa package-latest
   register: datadog_installer_install_result

--- a/tasks/pkg-suse/install-installer-zypper.yml
+++ b/tasks/pkg-suse/install-installer-zypper.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install latest datadog-installer package (zypper)
-  zypper:
+  ansible.builtin.zypper:
     name: "{{ datadog_installer_flavor }}"
     state: latest # noqa package-latest
   register: datadog_installer_install_result

--- a/tasks/pkg-suse/install-latest.yml
+++ b/tasks/pkg-suse/install-latest.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure Datadog agent is installed
-  zypper:
+  community.general.zypper:
     name: datadog-agent
     state: latest # noqa package-latest
   register: agent_datadog_agent_install

--- a/tasks/pkg-suse/install-pinned.yml
+++ b/tasks/pkg-suse/install-pinned.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install pinned datadog-agent package
-  zypper:
+  community.general.zypper:
     name: datadog-agent={{ agent_datadog_agent_suse_version }}
     state: present
     oldpackage: "{{ datadog_agent_allow_downgrade }}"

--- a/tasks/pkg-windows-opts.yml
+++ b/tasks/pkg-windows-opts.yml
@@ -1,23 +1,23 @@
 ---
 - name: Set agent_datadog_windows_config_root default value
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_windows_config_root: "{{ datadog_windows_config_root }}"
 
 - name: Initialize force reinstall value
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_force_reinstall: false
 
 - name: Initialize internal agent_win_install_args variable
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: "{{ win_install_args }}"
 
 - name: Set DD Username Arg
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: "{{ win_install_args }} DDAGENTUSER_NAME={{ datadog_windows_ddagentuser_name }}"
   when: datadog_windows_ddagentuser_name | default('', true) | length > 0
 
 - name: Get Windows Agent features
-  win_shell: |
+  ansible.windows.win_shell: |
     $installer = new-object -comobject WindowsInstaller.Installer
     $uninstall_key = "HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\*"
     $agent_item = (Get-ItemProperty $uninstall_key -EA 0 | Where { $_.DisplayName -like "Datadog Agent*" }).PSChildName
@@ -40,7 +40,7 @@
 # check the registry. On upgrade, the location of the config file root will
 # be set here.
 - name: Check existing config file Directory
-  win_reg_stat:
+  ansible.windows.win_reg_stat:
     path: HKLM:\SOFTWARE\Datadog\Datadog Agent
     name: ConfigRoot
   register: agent_config_root_from_registry
@@ -49,7 +49,7 @@
 # be set here.
 
 - name: Check existing installPath Directory
-  win_reg_stat:
+  ansible.windows.win_reg_stat:
     path: HKLM:\SOFTWARE\Datadog\Datadog Agent
     name: InstallPath
   register: agent_install_path_from_registry
@@ -58,13 +58,13 @@
 ## Will fail the install if the caller has set the config root to a non-standard root, and that
 ## root is different than what's already present.
 - name: Validate config path
-  fail:
+  ansible.builtin.fail:
     msg: "Incompatible configuration option {{ agent_config_root_from_registry.value }} != {{ datadog_windows_config_files_dir }}"
   when: ( (agent_config_root_from_registry.exists) and (datadog_windows_config_files_dir | length > 0 ) and (agent_config_root_from_registry.value
     | regex_replace('\\\\$','') | lower != datadog_windows_config_files_dir | lower ) )
 
 - name: Validated config path
-  debug:
+  ansible.builtin.debug:
     msg: "Allowing configuration option {{ agent_config_root_from_registry.value }} == {{ datadog_windows_config_files_dir }}"
   when: ( (agent_config_root_from_registry.exists) and (datadog_windows_config_files_dir | length > 0 ) and (agent_config_root_from_registry.value
     | regex_replace('\\\\$','') | lower == datadog_windows_config_files_dir | lower ) )
@@ -73,24 +73,24 @@
 ## Will fail the install if the caller has set the binary install path to a non-standard root, and that
 ## root is different than what's already present.
 - name: Validate install path
-  fail:
+  ansible.builtin.fail:
     msg: "Incompatible configuration option {{ agent_install_path_from_registry.value }} != {{ datadog_windows_program_files_dir }}"
   when: ( (agent_install_path_from_registry.exists) and (datadog_windows_program_files_dir | length > 0 ) and (agent_install_path_from_registry.value
     | regex_replace('\\\\$','') | lower != datadog_windows_program_files_dir | lower ) )
 
 - name: Validated install path
-  debug:
+  ansible.builtin.debug:
     msg: "Allowing configuration option {{ agent_install_path_from_registry.value }} == {{ datadog_windows_program_files_dir }}"
   when: ( (agent_install_path_from_registry.exists) and (datadog_windows_program_files_dir | length > 0 ) and (agent_install_path_from_registry.value
     | regex_replace('\\\\$','') | lower == datadog_windows_program_files_dir | lower ) )
 
 - name: Set Program Files Target Directory
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: '{{ agent_win_install_args }} PROJECTLOCATION="{{ datadog_windows_program_files_dir }}" '
   when: datadog_windows_program_files_dir | length > 0
 
 - name: Set Config Files Target Directory
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: '{{ agent_win_install_args }} APPLICATIONDATADIRECTORY="{{ datadog_windows_config_files_dir }}" '
   when: datadog_windows_config_files_dir | length > 0
 
@@ -98,24 +98,24 @@
 # presented here, then update accordingly, so that any config file modifications will be made
 # in the right place
 - name: Set config root for config Files
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_windows_config_root: "{{ datadog_windows_config_files_dir }}"
   when: ((datadog_windows_config_files_dir | length > 0) and (not agent_config_root_from_registry.exists))
 
 - name: Set config root for config files from current location
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_windows_config_root: "{{ agent_config_root_from_registry.value | regex_replace('\\\\$', '') }}"
   when: agent_config_root_from_registry.exists
 
 # Add the installation arguments to install Windows NPM.
 - name: Set Windows NPM flag
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: "{{ agent_win_install_args }} ADDLOCAL=MainApplication,NPM"
   when: agent_datadog_sysprobe_enabled
 
 # Check for potential config changes that require a reinstall:
 - name: Check NPM feature change to force a reinstallation if enabled features have changed
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: false
     agent_datadog_force_reinstall: true
   # Starting from agent 7.45 the NPM driver is installed by default and gets

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -1,47 +1,47 @@
 ---
 ## must be prior to `pkg-windows-opts.yml`, because the variable is used inside
 - name: Set windows NPM installed
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_sysprobe_enabled: "{{ network_config is defined and 'enabled' in (network_config | default({}, true)) and network_config['enabled'] }}"
 
 ## Might override agent_datadog_skip_install
 - name: Include Windows opts tasks
-  include_tasks: pkg-windows-opts.yml
+  ansible.builtin.include_tasks: pkg-windows-opts.yml
 
 - name: Download windows datadog agent 614 fix script
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"
     dest: '%TEMP%\fix_6_14.ps1'
     proxy_url: "{{ http_proxy | default(omit) }}"
   when: not agent_datadog_skip_install and datadog_apply_windows_614_fix
 
 - name: Run 6.14.0/1 PowerShell fix
-  win_shell: |
+  ansible.windows.win_shell: |
     Set-ExecutionPolicy Bypass -Scope Process -Force
     &$env:temp\fix_6_14.ps1
   when: not agent_datadog_skip_install and datadog_apply_windows_614_fix
 
 - name: Include Windows agent latest version install tasks
-  include_tasks: win_agent_latest.yml
+  ansible.builtin.include_tasks: win_agent_latest.yml
   when: (not agent_datadog_skip_install) and (agent_datadog_agent_windows_version is not defined)
 
 - name: Include Windows agent pinned version install tasks
-  include_tasks: win_agent_version.yml
+  ansible.builtin.include_tasks: win_agent_version.yml
   when: (not agent_datadog_skip_install) and (agent_datadog_agent_windows_version is defined)
 
 - name: Show URL var
-  debug:
+  ansible.builtin.debug:
     var: agent_dd_download_url
   when: not agent_datadog_skip_install
 
 - name: Pre-Delete temporary msi
-  win_file:
+  ansible.windows.win_file:
     path: '%TEMP%\ddagent.msi'
     state: absent
   when: not agent_datadog_skip_install
 
 - name: Download windows datadog agent
-  win_get_url:
+  ansible.windows.win_get_url:
     url: "{{ agent_dd_download_url }}"
     dest: '%TEMP%\ddagent.msi'
     proxy_url: "{{ http_proxy | default(omit) }}"
@@ -49,13 +49,13 @@
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 
 - name: Create Binary directory root (if not default)
-  win_file:
+  ansible.windows.win_file:
     path: "{{ datadog_windows_program_files_dir }}"
     state: directory
   when: datadog_windows_program_files_dir | length > 0
 
 - name: Set default permissions on binary directory root (if not default)
-  win_acl:
+  ansible.windows.win_acl:
     path: "{{ datadog_windows_program_files_dir }}"
     inherit: ContainerInherit,ObjectInherit
     user: "BUILTIN\\USERS"
@@ -66,31 +66,31 @@
   when: datadog_windows_program_files_dir | length > 0
 
 - name: Show installation flags
-  debug:
+  ansible.builtin.debug:
     msg: "{{ agent_win_install_args }}{% if datadog_windows_ddagentuser_password | default('', true) | length > 0 %} DDAGENTUSER_PASSWORD=<REDACTED>{% endif %}"
 
 # We set DD Password Arg here to prevent it from being printed in any kind of debug logs/messages prior usage
 - name: Set DD Password Arg
-  set_fact:
+  ansible.builtin.set_fact:
     agent_win_install_args: "{{ agent_win_install_args }} DDAGENTUSER_PASSWORD={{ datadog_windows_ddagentuser_password }}"
   when: datadog_windows_ddagentuser_password | default('', true) | length > 0
   no_log: true
 
 - name: Uninstall agent to update optional features
-  win_package:
+  ansible.windows.win_package:
     path: "{{ agent_download_msi_result.dest }}"
     state: absent
   when: not agent_datadog_skip_install and agent_datadog_force_reinstall
 
 - name: Install downloaded agent
-  win_package:
+  ansible.windows.win_package:
     path: "{{ agent_download_msi_result.dest }}"
     arguments: "{{ agent_win_install_args }}"
   register: agent_datadog_agent_install
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 
 - name: Delete temporary msi
-  win_file:
+  ansible.windows.win_file:
     path: "{{ agent_download_msi_result.dest }}"
     state: absent
   when: (not agent_datadog_skip_install) and (not ansible_check_mode) and (agent_download_msi_result.status_code == 200)

--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -1,13 +1,13 @@
 ---
 - name: Defend against defined but null datadog_checks variable
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_checks: "{{ datadog_checks | default({}, true) }}"
 
 - name: Resolve agent_datadog_tracked_checks
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_tracked_checks: "{{ agent_datadog_checks | list + datadog_additional_checks | default([], true) }}"
 
 - name: Check that agent_datadog_checks is a mapping
-  assert:
+  ansible.builtin.assert:
     that:
       - agent_datadog_checks is mapping

--- a/tasks/set-parse-version.yml
+++ b/tasks/set-parse-version.yml
@@ -1,17 +1,17 @@
 ---
 - name: Convert datadog_agent_major_version to string
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_major_version: "{{ datadog_agent_major_version | default('', true) | string }}"
 
 - name: Initialize skip install flag to false
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_skip_install: false
 
 - name: Include parse version tasks
-  include_tasks: parse-version.yml
+  ansible.builtin.include_tasks: parse-version.yml
   when: datadog_agent_version | default('', true) | length > 0
 
 - name: Set Agent default major version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_datadog_agent_major_version: "7"
   when: agent_datadog_agent_major_version | length == 0

--- a/tasks/win_agent_latest.yml
+++ b/tasks/win_agent_latest.yml
@@ -1,11 +1,11 @@
 ---
 - name: (Custom) Set agent download filename to latest
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_windows_download_url }}"
   when: datadog_windows_download_url | default('', true) | length > 0
 
 - name: Set agent download filename to latest
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{% if agent_datadog_agent_major_version
       | int == 7 %}{{ datadog_windows_agent7_latest_url }} {% else %}{{ datadog_windows_agent6_latest_url }}{% endif %}"
   when: datadog_windows_download_url | default('', true) | length == 0

--- a/tasks/win_agent_version.yml
+++ b/tasks/win_agent_version.yml
@@ -1,9 +1,9 @@
 ---
 - name: Check agent pinned version on Windows
-  fail:
+  ansible.builtin.fail:
     msg: "The Agent versions you pinned (6.14.0 or 6.14.1) have been blacklisted, please use 6.14.2 instead. See https://dtdg.co/win-614-fix."
   when: datadog_agent_version == "6.14.0" or datadog_agent_version == "6.14.1"
 
 - name: Set agent download filename to a specific version
-  set_fact:
+  ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_windows_versioned_url }}-{{ agent_datadog_agent_windows_version }}.msi"


### PR DESCRIPTION
* bump `ansible-lint` version to [25.1.2 ](https://github.com/DataDog/ansible-datadog/commit/0097d1ede89141b7945b6aa570759f10c647bd96)
* edit ansible lint [script](https://github.com/DataDog/ansible-datadog/commit/1d3260eaf546f8798f853ecb49ad901be0e17edb) to be compatible with new ansible lint version, which requires python versions > 3.9
* fix FQCN lint errors 
     * https://github.com/DataDog/ansible-datadog/commit/4293c0bdc17fc28d283c57e1200e1b43c2f2ff9b
     * https://github.com/DataDog/ansible-datadog/commit/2da44fea18b7e05280c2b897b4a1c119dc4a0fba
* remove support for ansible-core <v2.10 https://github.com/DataDog/ansible-datadog/pull/644/commits/f2cd66b79727563f1782e5c0276850fbaef64935