### PR TITLE
Remove centos 6/7 from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,18 @@ On Debian Stretch, the `apt_key` module used by the role requires an additional 
     datadog_api_key: "<YOUR_DD_API_KEY>"
 ```
 
+### CentOS 6/7 with Python 3 interpreter and Ansible 2.10.x or below
+
+**DEPRECATED: This section only applies to Ansible role versions 4 or below. Starting with version 5, this role no longer supports CentOS 6/7 and requires Ansible Core 2.10 or higher.**
+
+The `yum` Python module, which is used in this role to install the Agent on CentOS-based hosts, is only available on Python 2 if Ansible 2.10.x or below is used. In such cases, the `dnf` package manager would have to be used instead.
+
+However, `dnf` and the `dnf` Python module are not installed by default on CentOS-based hosts before CentOS 8. In this case, it is not possible to install the Agent when a Python 3 interpreter is used.
+
+This role fails early when this situation is detected to indicate that Ansible 2.11+ or a Python 2 interpreter is needed when installing the Agent on CentOS / RHEL < 8.
+
+To bypass this early failure detection (for instance, if `dnf` and the `python3-dnf` package are available on your host), set the `datadog_ignore_old_centos_python3_error` variable to `true`.
+
 ### Windows
 
 Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, installation of these versions is blocked (starting with version `3.3.0` of this role).

--- a/README.md
+++ b/README.md
@@ -597,16 +597,6 @@ On Debian Stretch, the `apt_key` module used by the role requires an additional 
     datadog_api_key: "<YOUR_DD_API_KEY>"
 ```
 
-### CentOS 6/7 with Python 3 interpreter and Ansible 2.10.x or below
-
-The `yum` Python module, which is used in this role to install the Agent on CentOS-based hosts, is only available on Python 2 if Ansible 2.10.x or below is used. In such cases, the `dnf` package manager would have to be used instead.
-
-However, `dnf` and the `dnf` Python module are not installed by default on CentOS-based hosts before CentOS 8. In this case, it is not possible to install the Agent when a Python 3 interpreter is used.
-
-This role fails early when this situation is detected to indicate that Ansible 2.11+ or a Python 2 interpreter is needed when installing the Agent on CentOS / RHEL < 8.
-
-To bypass this early failure detection (for instance, if `dnf` and the `python3-dnf` package are available on your host), set the `datadog_ignore_old_centos_python3_error` variable to `true`.
-
 ### Windows
 
 Due to a critical bug in Agent versions `6.14.0` and `6.14.1` on Windows, installation of these versions is blocked (starting with version `3.3.0` of this role).

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -116,13 +116,6 @@ datadog_yum_gpgkey_20280418_sha256sum: "d309232f05bcfb5df7fce1a22b09204762541350
 datadog_yum_gpgkey_4f09d16b: "https://s3.amazonaws.com/public-signing-keys/DATADOG_RPM_KEY_4F09D16B.public"
 datadog_yum_gpgkey_4f09d16b_sha256sum: "a4dc0e09751cf0e01da7b4095e432f6330c11b1fef41cacd1f2c8981596eaf2b"
 
-# By default, we fail early & print a helpful message if an older Ansible version and Python 3
-# interpreter is used on CentOS < 8. The 'yum' module is only available on Python 2, and the 'python3-dnf'
-# package is not available before CentOS 8.
-# If set to true, this option removes this check and allows the install to proceed. Useful in specific setups
-# where an old CentOS host using a Python 3 interpreter does have 'dnf' (eg. through backports).
-datadog_ignore_old_centos_python3_error: false
-
 # By default, the role uses the official zypper Datadog repository for the chosen major version
 # Use the datadog_zypper_repo variable to override the repository used.
 datadog_zypper_repo: ""


### PR DESCRIPTION
Documentation for CentOS6/7 is no longer needed in the README as support for it was removed in ansible role 5.0.0