### PR TITLE
fixed typo in fix-parse-version-windows.yml

### DIFF
--- a/tasks/parse-version-windows.yml
+++ b/tasks/parse-version-windows.yml
@@ -1,7 +1,7 @@
 ---
 # NOTE: This won't work with rc / beta builds.
 - name: Get Windows Agent version
-  amazon.windows.win_shell: |
+  ansible.windows.win_shell: |
     $product_name = "Datadog Agent"
     $version=Get-ItemProperty HKLM:\Software\Microsoft\Windows\CurrentVersion\Uninstall\* |
     Select-Object DisplayName,DisplayVersion,PSChildName -unique |


### PR DESCRIPTION
Using this module to help install Datadog on new servers. 

Co worker was trying to use it today and found it was giving an error  on "Include Windows Agent Version Tasks". I went though the code and found that in that task it was using the module `amazon.windows.win_shell` it should be `ansible.windows.win_shell` so I fixed that.