### PR TITLE
Add FQCN checks to ansible-lint

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,6 +1,8 @@
 ---
 enable_list:
   - empty-string-compare
+  - fqcn-builtins
+  - fqcn[action]
 
 warn_list:
   - var_naming

--- a/ci_test/ansible_lint.sh
+++ b/ci_test/ansible_lint.sh
@@ -71,6 +71,9 @@ popd
 # installed as its dependency
 pip install -r requirements-ansible-lint.txt
 
+# Install required collections for linting
+ansible-galaxy collection install ansible.windows community.general
+
 # lint the ansible-role alone
 ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=.ansible/ --exclude=.venv/
 


### PR DESCRIPTION
add FQCN naming checks and installs required checks in the `ansible-lint.sh` script. This should allow us to detect any issues with module naming that we missed before