### PR TITLE
Add feature to override the Datadog installer default package version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -535,7 +535,7 @@ workflows:
               installer_version: ["7.63"]
               dd_site: ["datadoghq.com", "ddog-gov.com"]
               installer_registry: ["install.datadoghq.com"]
-              yum_repo: ["https://yum.datadoghq.com/"]
+              yum_repo: ["https://yum.datadoghq.com/stable/7/x86_64"]
               yum_repo_config_enabled: ["true", "false"]
 
       - test_installer_over_pinned

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,16 +348,6 @@ jobs:
         type: string
       remote_updates:
         type: string
-      installer_version:
-        type: string
-      dd_site:
-        type: string
-      installer_registry:
-        type: string
-      yum_repo:
-        type: string
-      yum_repo_config_enabled:
-        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
@@ -373,11 +363,6 @@ jobs:
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer_air_gapped.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
           -e datadog_remote_updates="<<parameters.remote_updates>>"
-          -e datadog_installer_version="<<parameters.installer_version>>"
-          -e datadog_site="<<parameters.dd_site>>"
-          -e datadog_installer_registry="<<parameters.installer_registry>>"
-          -e datadog_yum_repo="<<parameters.yum_repo>>"
-          -e datadog_yum_repo_config_enabled="<<parameters.yum_repo_config_enabled>>"
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
@@ -532,11 +517,6 @@ workflows:
               os: ["rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
-              installer_version: ["7.63"]
-              dd_site: ["datadoghq.com", "ddog-gov.com"]
-              installer_registry: ["install.datadoghq.com"]
-              yum_repo: ["https://yum.datadoghq.com/stable/7/x86_64"]
-              yum_repo_config_enabled: ["true"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -332,7 +332,7 @@ jobs:
                 exit 1;
               fi'
   
-  test_installer_air_gapped:
+  test_installer_air_gapped_rhel:
     parameters:
       ansible_version:
         type: string
@@ -350,6 +350,14 @@ jobs:
         type: string
       installer_version:
         type: string
+      dd_site:
+        type: string
+      installer_registry:
+        type: string
+      yum_repo:
+        type: string
+      yum_repo_config_enabled:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
@@ -361,11 +369,15 @@ jobs:
       - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
       - run: mkdir -p /etc/systemd/system/
       - run: >
-          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -v
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer_air_gapped.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
           -e datadog_remote_updates="<<parameters.remote_updates>>"
           -e datadog_installer_version="<<parameters.installer_version>>"
+          -e datadog_site="<<parameters.dd_site>>"
+          -e datadog_installer_registry="<<parameters.installer_registry>>"
+          -e datadog_yum_repo="<<parameters.yum_repo>>"
+          -e datadog_yum_repo_config_enabled="<<parameters.yum_repo_config_enabled>>"
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
@@ -513,14 +525,18 @@ workflows:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
 
-      - test_installer_air_gapped:
+      - test_installer_air_gapped_rhel:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
-              os: ["debian", "rocky8", "amazonlinux2023"]
+              os: ["rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
-              installer_version: ["7.62", "7.63", "latest"]
+              installer_version: ["7.63", "latest"]
+              dd_site: ["datadoghq.com", "ddog-gov.com"]
+              installer_registry: ["install.datadoghq.com", "gcr.io/datadoghq"]
+              yum_repo: ["https://yum.datadoghq.com/"]
+              yum_repo_config_enabled: ["true", "false"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -536,7 +536,7 @@ workflows:
               dd_site: ["datadoghq.com", "ddog-gov.com"]
               installer_registry: ["install.datadoghq.com"]
               yum_repo: ["https://yum.datadoghq.com/stable/7/x86_64"]
-              yum_repo_config_enabled: ["true", "false"]
+              yum_repo_config_enabled: ["true"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -348,6 +348,8 @@ jobs:
         type: string
       remote_updates:
         type: string
+      installer_version:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
@@ -363,6 +365,7 @@ jobs:
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer_air_gapped.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
           -e datadog_remote_updates="<<parameters.remote_updates>>"
+          -e datadog_installer_version="<<parameters.installer_version>>"
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
@@ -457,7 +460,7 @@ workflows:
       - test_install:
           matrix:
             parameters:
-              ensible_version: ["2_10", "3_4", "4_10", "9_4"]
+              ansible_version: ["2_10", "3_4", "4_10", "9_4"]
               agent_version: ["6", "7"]
               jinja2_native: ["true", "false"]
               os: ["rocky8"]
@@ -517,6 +520,7 @@ workflows:
               os: ["debian", "rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
+              installer_version: ["7.62", "7.63", "latest"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -457,7 +457,7 @@ workflows:
       - test_install:
           matrix:
             parameters:
-              ansible_version: ["2_10", "3_4", "4_10", "9_4"]
+              ensible_version: ["2_10", "3_4", "4_10", "9_4"]
               agent_version: ["6", "7"]
               jinja2_native: ["true", "false"]
               os: ["rocky8"]
@@ -516,6 +516,7 @@ workflows:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: ["debian", "rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
+              remote_updates: ["true", "false"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -331,6 +331,58 @@ jobs:
                 echo "The agent should NOT have been installed by the distribution";
                 exit 1;
               fi'
+  
+  test_installer_air_gapped:
+    parameters:
+      ansible_version:
+        type: string
+      jinja2_native:
+        type: string
+        default: "false"
+      os:
+        type: string
+      inventory:
+        type: string
+        default: "ci.ini"
+      apm_enabled:
+        type: string
+      remote_updates:
+        type: string
+    docker:
+      - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
+    steps:
+      - checkout
+        # datadog-installer will bailout if there's no systemctl binary, and won't attempt to
+        # create the systemd folder to store its units
+        # Since we're running the tests in a docker container without systemd, we can "help" it
+        # proceed by pretending systemd is there
+      - run: printf "#!/bin/bash\n\nexit 0" > /usr/bin/systemctl && chmod +x /usr/bin/systemctl
+      - run: mkdir -p /etc/systemd/system/
+      - run: >
+          ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
+          -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer_air_gapped.yaml"
+          -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
+          -e datadog_remote_updates="<<parameters.remote_updates>>"
+      - run: >
+          bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
+              datadog-installer version;
+            elif command -v datadog-installer; then
+              echo datadog-installer should not be installed;
+              exit 2;
+            else
+              echo datadog-installer is not installed as expected;
+            fi
+            if [ "<<parameters.remote_updates>>" = "true" ]; then
+              if [ -d /opt/datadog-agent ]; then
+                echo "The agent should NOT have been installed by the distribution";
+                exit 1;
+              fi
+            else
+              if [ ! -d /opt/datadog-agent ]; then
+                echo "The agent should have been installed by the distribution";
+                exit 1;
+              fi
+            fi'
 
   test_installer_over_pinned:
     docker:
@@ -457,6 +509,13 @@ workflows:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
+
+      - test_installer_air_gapped:
+         matrix:
+           parameters:
+              ansible_version: ["2_10", "3_4", "4_10"]
+              os: ["debian", "rocky8", "amazonlinux2023"]
+              apm_enabled: ["host", ""]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -532,9 +532,9 @@ workflows:
               os: ["rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
               remote_updates: ["true", "false"]
-              installer_version: ["7.63", "latest"]
+              installer_version: ["7.63"]
               dd_site: ["datadoghq.com", "ddog-gov.com"]
-              installer_registry: ["install.datadoghq.com", "gcr.io/datadoghq"]
+              installer_registry: ["install.datadoghq.com"]
               yum_repo: ["https://yum.datadoghq.com/"]
               yum_repo_config_enabled: ["true", "false"]
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The API key is required and its absence causes the role to fail. If you want to 
 
 ### Air-gapped environments
 
-To install Datadog in an air-gapped environment using a specific registry and images, use the Datadog Ansible collection along with the `datadog_installer_registry`, `datadog_installer_auth`, and `agent_datadog_config` variables. 
+To install Datadog in an air-gapped environment using a specific registry and images, use the Datadog Ansible collection along with the `datadog_installer_registry`, `datadog_installer_auth`, `datadog_installer_version`, and `agent_datadog_config` variables.
 
 **Note**: `agent_datadog_config` overrides the `installer_registry_config` setting.
 
@@ -66,6 +66,7 @@ name: Datadog Agent Install
     name: datadog.dd.agent
   vars:
     datadog_installer_registry: "my.local.registry"
+    datadog_installer_version: "7.63"
     datadog_yum_repo: "my.local.repo"
     datadog_api_key: "MY_DATADOG_API_KEY"
     datadog_site: "MY_DATADOG_SITE"

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ name: Datadog Agent Install
     name: datadog.dd.agent
   vars:
     datadog_installer_registry: "my.local.registry"
-    datadog_installer_version: "7.63"
+    datadog_installer_version: 7.63
     datadog_yum_repo: "my.local.repo"
     datadog_api_key: "MY_DATADOG_API_KEY"
     datadog_site: "MY_DATADOG_SITE"

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -9,7 +9,6 @@
     datadog_yum_repo_config_enabled: true
     datadog_enabled: false
     datadog_skip_running_check: true
-    datadog_agent_version: 7.64.3
     datadog_installer_registry: "install.datadoghq.com"
     datadog_installer_version: 7.63
     datadog_apm_instrumentation_enabled: host

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -10,6 +10,6 @@
     datadog_enabled: false
     datadog_skip_running_check: true
     datadog_installer_registry: "install.datadoghq.com"
-    datadog_installer_version: 7.63
+    datadog_installer_version: 7.62
     datadog_apm_instrumentation_enabled: host
     datadog_apm_instrumentation_libraries: ["java"]

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -1,0 +1,17 @@
+---
+
+- hosts: all
+  roles:
+    - { role: '/root/project/'}
+  vars:
+    datadog_site: "ddog-gov.com"
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_yum_repo: "https://yum.datadoghq.com/"
+    datadog_yum_repo_config_enabled: true
+    datadog_enabled: false
+    datadog_skip_running_check: true
+    datadog_agent_version: '7.64.3'
+    datadog_installer_registry: "install.datadoghq.com"
+    datadog_installer_version: '7.63'
+    datadog_apm_instrumentation_enabled: host
+    datadog_apm_instrumentation_libraries: [ "java" ]

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -1,8 +1,7 @@
 ---
-
 - hosts: all
   roles:
-    - { role: '/root/project/'}
+    - { role: "/root/project/" }
   vars:
     datadog_site: "ddog-gov.com"
     datadog_api_key: "11111111111111111111111111111111"
@@ -10,8 +9,8 @@
     datadog_yum_repo_config_enabled: true
     datadog_enabled: false
     datadog_skip_running_check: true
-    datadog_agent_version: '7.64.3'
+    datadog_agent_version: 7.64.3
     datadog_installer_registry: "install.datadoghq.com"
-    datadog_installer_version: '7.63'
+    datadog_installer_version: 7.63
     datadog_apm_instrumentation_enabled: host
-    datadog_apm_instrumentation_libraries: [ "java" ]
+    datadog_apm_instrumentation_libraries: ["java"]

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -5,7 +5,7 @@
   vars:
     datadog_site: "ddog-gov.com"
     datadog_api_key: "11111111111111111111111111111111"
-    datadog_yum_repo: "https://yum.datadoghq.com/"
+    datadog_yum_repo: "https://yum.datadoghq.com/stable/7/x86_64/"
     datadog_yum_repo_config_enabled: true
     datadog_enabled: false
     datadog_skip_running_check: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -196,9 +196,10 @@ datadog_apm_telemetry_endpoint: "https://instrumentation-telemetry-intake.{{ dat
 # Enable remote updates through datadog-installer
 datadog_remote_updates: false
 
-# Registry & auth for the datadog installer
+# Registry, auth, and version for the datadog installer
 datadog_installer_registry: ""
 datadog_installer_auth: ""
+datadog_installer_version: ""
 installer_registry_config: {}
 
 #

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -10,7 +10,8 @@
       installer:
         registry: "{{ datadog_installer_registry }}"
         auth: "{{ datadog_installer_auth }}"
-  when: datadog_installer_registry or datadog_installer_auth
+        version: "{{ datadog_installer_version }}"
+  when: datadog_installer_registry or datadog_installer_auth or datadog_installer_version
 
 - name: Update datadog_config including installer registry
   ansible.builtin.set_fact:

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -43,6 +43,7 @@
     DD_APM_INSTRUMENTATION_LIBRARIES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
     DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE: "{{ datadog_installer_auth }}"
     DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE: "{{ datadog_installer_registry }}"
+    DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER: "{{ datadog_installer_version | default('latest') }}"
     DD_AGENT_MAJOR_VERSION: "{{ datadog_agent_major_version | default('') }}"
     DD_AGENT_MINOR_VERSION: "{{ datadog_agent_minor_version | default('') }}"
   ignore_errors: true


### PR DESCRIPTION
I have added a feature to override the Datadog installer default package version (mainly for Air-gapped environments).

These changes are for air-gapped environments with a custom/private registry with the installer images tagged only with a specific "version".

Currently, the ansible role does not have the ability to override the installer default package version.

**CHANGES:**

- Created a new default variable named "**ansible_installer_version**" to set the installer version explicitly.
- Added the environment variable "**DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER**" to the "Bootstrap the installer" task and set it to "ansible_installer_version".
- Added version to the "installer_registry_config"
- Updated README and usage examples under the "Air-gapped environments" section
- Added CircleCI test to validate the installer version and installation of the Datadog installer packages for air-gapped environments

For more background information, see #651