### PR TITLE
Support to override datadog-apm-inject version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
 
             if [ -n "<<parameters.apm_enabled>>" ]; then
               echo "Checking if datadog-apm-inject is installed...";
-              if ! sudo datadog-installer is-installed datadog-apm-inject; then
+              if ! datadog-installer is-installed datadog-apm-inject; then
                 echo "datadog-apm-inject is NOT installed as expected";
                 exit 3;
               else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,6 +372,17 @@ jobs:
             else
               echo datadog-installer is not installed as expected;
             fi
+
+            if [ -n "<<parameters.apm_enabled>>" ]; then
+              echo "Checking if datadog-apm-inject is installed...";
+              if ! sudo datadog-installer is-installed datadog-apm-inject; then
+                echo "datadog-apm-inject is NOT installed as expected";
+                exit 3;
+              else
+                echo "datadog-apm-inject is installed";
+              fi
+            fi
+
             if [ "<<parameters.remote_updates>>" = "true" ]; then
               if [ -d /opt/datadog-agent ]; then
                 echo "The agent should NOT have been installed by the distribution";

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The API key is required and its absence causes the role to fail. If you want to 
 
 ### Air-gapped environments
 
-To install Datadog in an air-gapped environment using a specific registry and images, use the Datadog Ansible collection along with the `datadog_installer_registry`, `datadog_installer_auth`, `datadog_installer_version`, and `agent_datadog_config` variables.
+To install Datadog in an air-gapped environment using a specific registry and mirrored images, use the Datadog Ansible collection along with the `datadog_installer_registry`, `datadog_installer_auth`, and `agent_datadog_config` variables. While Datadog recommends fetching `latest`, `datadog_installer_version` and `datadog_apm_inject_version` can be provided to pin versions.
 
 **Note**: `agent_datadog_config` overrides the `installer_registry_config` setting.
 
@@ -67,6 +67,7 @@ name: Datadog Agent Install
   vars:
     datadog_installer_registry: "my.local.registry"
     datadog_installer_version: 7.63
+    datadog_apm_inject_version: 0.38
     datadog_yum_repo: "my.local.repo"
     datadog_api_key: "MY_DATADOG_API_KEY"
     datadog_site: "MY_DATADOG_SITE"

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -11,5 +11,6 @@
     datadog_skip_running_check: true
     datadog_installer_registry: "install.datadoghq.com"
     datadog_installer_version: 7.62
+    datadog_apm_inject_version: 0.38.0
     datadog_apm_instrumentation_enabled: host
     datadog_apm_instrumentation_libraries: ["java"]

--- a/ci_test/install_installer_air_gapped.yaml
+++ b/ci_test/install_installer_air_gapped.yaml
@@ -11,6 +11,6 @@
     datadog_skip_running_check: true
     datadog_installer_registry: "install.datadoghq.com"
     datadog_installer_version: 7.62
-    datadog_apm_inject_version: 0.38.0
+    datadog_apm_inject_version: 0.38
     datadog_apm_instrumentation_enabled: host
     datadog_apm_instrumentation_libraries: ["java"]

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -202,6 +202,9 @@ datadog_installer_auth: ""
 datadog_installer_version: ""
 installer_registry_config: {}
 
+# Version for the datadog apm inject package
+datadog_apm_inject_version: ""
+
 #
 # Internal variables
 # The following variables are for internal use only, do not modify them.

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -11,7 +11,8 @@
         registry: "{{ datadog_installer_registry }}"
         auth: "{{ datadog_installer_auth }}"
         version: "{{ datadog_installer_version }}"
-  when: datadog_installer_registry or datadog_installer_auth or datadog_installer_version
+        apm_inject_version: "{{ datadog_apm_inject_version }}"
+  when: datadog_installer_registry or datadog_installer_auth or datadog_installer_version or datadog_apm_inject_version
 
 - name: Update datadog_config including installer registry
   ansible.builtin.set_fact:

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -44,6 +44,7 @@
     DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE: "{{ datadog_installer_auth }}"
     DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE: "{{ datadog_installer_registry }}"
     DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER: "{{ datadog_installer_version | default('latest') }}"
+    DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT: "{{ datadog_apm_inject_version | default('latest') }}"
     DD_AGENT_MAJOR_VERSION: "{{ datadog_agent_major_version | default('') }}"
     DD_AGENT_MINOR_VERSION: "{{ datadog_agent_minor_version | default('') }}"
   ignore_errors: true


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/ansible-datadog/pull/652, the `datadog-apm-inject` package is also defaulting to `latest`, so we need to be able to override it to close https://github.com/DataDog/ansible-datadog/issues/651: https://github.com/DataDog/datadog-agent/blob/d2e24cc71bb2c442861e9a27cb97af2777936580/pkg/fleet/installer/default_packages.go#L148-L154