### PR TITLE
[installer] Provide bootstrap environment variables only if not empty strings

### DIFF
--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -30,23 +30,39 @@
     datadog_agent_minor_version: "{{ datadog_agent_version.split('.', 1).1 }}"
   when: datadog_agent_version
 
+# We use this step to not render DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER and DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT if they are not set
+- name: Build Datadog installer environment variables
+  ansible.builtin.set_fact:
+    datadog_installer_bootstrap_environment: >
+      {{
+        {
+          key: value for key, value in {
+            'DATADOG_TRACE_ID': datadog_installer_trace_id,
+            'DATADOG_PARENT_ID': datadog_installer_trace_id,
+            'DD_SITE': datadog_site | default('datadoghq.com'),
+            'DD_API_KEY': datadog_api_key,
+            'DD_REMOTE_UPDATES': 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '',
+            'DD_APM_INSTRUMENTATION_ENABLED': datadog_apm_instrumentation_enabled,
+            'DD_APM_INSTRUMENTATION_LIBRARIES': datadog_apm_instrumentation_libraries | join(','),
+            'DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE': datadog_installer_auth,
+            'DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE': datadog_installer_registry,
+            'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER': datadog_installer_version,
+            'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT': datadog_apm_inject_version,
+            'DD_AGENT_MAJOR_VERSION': datadog_agent_major_version,
+            'DD_AGENT_MINOR_VERSION': datadog_agent_minor_version
+          }.items() if value not in ['']
+        }
+      }}
+
+- name: (TEMP) Log the Datadog installer environment
+  ansible.builtin.shell: |
+    echo "Datadog installer environment:"
+    echo '{{ datadog_installer_bootstrap_environment | to_nice_json | replace("'", "'\\''") }}'
+
 - name: Bootstrap the installer
   ansible.builtin.command: /usr/bin/datadog-bootstrap bootstrap
   register: datadog_installer_bootstrap_result
-  environment:
-    DATADOG_TRACE_ID: "{{ datadog_installer_trace_id }}"
-    DATADOG_PARENT_ID: "{{ datadog_installer_trace_id }}"
-    DD_SITE: "{{ datadog_site | default('datadoghq.com') }}"
-    DD_API_KEY: "{{ datadog_api_key }}"
-    DD_REMOTE_UPDATES: "{{ 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '' }}"
-    DD_APM_INSTRUMENTATION_ENABLED: "{{ datadog_apm_instrumentation_enabled }}"
-    DD_APM_INSTRUMENTATION_LIBRARIES: "{{ datadog_apm_instrumentation_libraries | join(',') }}"
-    DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE: "{{ datadog_installer_auth }}"
-    DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE: "{{ datadog_installer_registry }}"
-    DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER: "{{ datadog_installer_version | default('latest') }}"
-    DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT: "{{ datadog_apm_inject_version | default('latest') }}"
-    DD_AGENT_MAJOR_VERSION: "{{ datadog_agent_major_version | default('') }}"
-    DD_AGENT_MINOR_VERSION: "{{ datadog_agent_minor_version | default('') }}"
+  environment: "{{ datadog_installer_bootstrap_environment }}"
   ignore_errors: true
   when: not ansible_check_mode and not datadog_installer_install_result.failed
   changed_when: true

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -54,10 +54,13 @@
         }
       }}
 
-- name: (TEMP) Log the Datadog installer environment
-  ansible.builtin.shell: |
-    echo "Datadog installer environment:"
-    echo '{{ datadog_installer_bootstrap_environment | to_nice_json | replace("'", "'\\''") }}'
+- name: Dump Datadog installer environment to temp file
+  ansible.builtin.copy:
+    content: "{{ datadog_installer_bootstrap_environment | to_nice_json }}"
+    dest: "/tmp/datadog_installer_env.json"
+
+- name: Print Datadog installer environment from file
+  ansible.builtin.command: cat /tmp/datadog_installer_env.json
 
 - name: Bootstrap the installer
   ansible.builtin.command: /usr/bin/datadog-bootstrap bootstrap

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -62,6 +62,12 @@
 
 - name: Print Datadog installer environment from file
   ansible.builtin.command: cat /tmp/datadog_installer_env.json
+  register: datadog_env_cat_result
+  changed_when: false
+
+- name: Show cat output
+  ansible.builtin.debug:
+    msg: "{{ datadog_env_cat_result.stdout }}"
 
 - name: Bootstrap the installer
   ansible.builtin.command: /usr/bin/datadog-bootstrap bootstrap

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -36,22 +36,23 @@
     datadog_installer_bootstrap_environment: >
       {{
         {
-          key: value for key, value in {
-            'DATADOG_TRACE_ID': datadog_installer_trace_id,
-            'DATADOG_PARENT_ID': datadog_installer_trace_id,
-            'DD_SITE': datadog_site | default('datadoghq.com'),
-            'DD_API_KEY': datadog_api_key,
-            'DD_REMOTE_UPDATES': 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '',
-            'DD_APM_INSTRUMENTATION_ENABLED': datadog_apm_instrumentation_enabled,
-            'DD_APM_INSTRUMENTATION_LIBRARIES': datadog_apm_instrumentation_libraries | join(','),
-            'DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE': datadog_installer_auth,
-            'DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE': datadog_installer_registry,
-            'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER': datadog_installer_version,
-            'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT': datadog_apm_inject_version,
-            'DD_AGENT_MAJOR_VERSION': datadog_agent_major_version,
-            'DD_AGENT_MINOR_VERSION': datadog_agent_minor_version
-          }.items() if value not in ['']
+          'DATADOG_TRACE_ID': datadog_installer_trace_id,
+          'DATADOG_PARENT_ID': datadog_installer_trace_id,
+          'DD_SITE': datadog_site | default('datadoghq.com'),
+          'DD_API_KEY': datadog_api_key,
+          'DD_REMOTE_UPDATES': 'true' if datadog_remote_updates is defined and datadog_remote_updates | bool else '',
+          'DD_APM_INSTRUMENTATION_ENABLED': datadog_apm_instrumentation_enabled,
+          'DD_APM_INSTRUMENTATION_LIBRARIES': datadog_apm_instrumentation_libraries | join(','),
+          'DD_INSTALLER_REGISTRY_AUTH_INSTALLER_PACKAGE': datadog_installer_auth,
+          'DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE': datadog_installer_registry,
+          'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER': datadog_installer_version,
+          'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT': datadog_apm_inject_version,
+          'DD_AGENT_MAJOR_VERSION': datadog_agent_major_version,
+          'DD_AGENT_MINOR_VERSION': datadog_agent_minor_version
         }
+        | dict2items
+        | rejectattr('value', 'equalto', '')
+        | items2dict
       }}
 
 - name: Dump Datadog installer environment to temp file

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -30,7 +30,7 @@
     datadog_agent_minor_version: "{{ datadog_agent_version.split('.', 1).1 }}"
   when: datadog_agent_version
 
-# We use this step to not render DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER and DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT if they are not set
+# We use this step to not render "empty" environment variables when not set.
 - name: Build Datadog installer environment variables
   ansible.builtin.set_fact:
     datadog_installer_bootstrap_environment: >
@@ -54,20 +54,6 @@
         | rejectattr('value', 'equalto', '')
         | items2dict
       }}
-
-- name: Dump Datadog installer environment to temp file
-  ansible.builtin.copy:
-    content: "{{ datadog_installer_bootstrap_environment | to_nice_json }}"
-    dest: "/tmp/datadog_installer_env.json"
-
-- name: Print Datadog installer environment from file
-  ansible.builtin.command: cat /tmp/datadog_installer_env.json
-  register: datadog_env_cat_result
-  changed_when: false
-
-- name: Show cat output
-  ansible.builtin.debug:
-    msg: "{{ datadog_env_cat_result.stdout }}"
 
 - name: Bootstrap the installer
   ansible.builtin.command: /usr/bin/datadog-bootstrap bootstrap

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -47,8 +47,8 @@
           'DD_INSTALLER_REGISTRY_URL_INSTALLER_PACKAGE': datadog_installer_registry,
           'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER': datadog_installer_version,
           'DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT': datadog_apm_inject_version,
-          'DD_AGENT_MAJOR_VERSION': datadog_agent_major_version,
-          'DD_AGENT_MINOR_VERSION': datadog_agent_minor_version
+          'DD_AGENT_MAJOR_VERSION': datadog_agent_major_version | default(''),
+          'DD_AGENT_MINOR_VERSION': datadog_agent_minor_version | default(''),
         }
         | dict2items
         | rejectattr('value', 'equalto', '')


### PR DESCRIPTION
### What does this PR do
We render environment variables for bootstrapping in a prior step to bootstrapping, filtering out empty strings, e.g. if `datadog_installer_version` is not set (as is default https://github.com/DataDog/ansible-datadog/blob/5a7dea7132a8e51ba75d602efed07492df53f537/defaults/main.yml#L202), do not add `DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER` to the bootstrapping command.

### Motivation

#incident-38697: we break `datadog-agent` E2E by always providing `DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_INSTALLER` and `DD_INSTALLER_DEFAULT_PKG_VERSION_DATADOG_APM_INJECT`

### QA
tests + was rendering the env var map in https://github.com/DataDog/ansible-datadog/pull/655/commits/57db4d5d1a826b1e64b97b706e4a7a257b0aab1f