### PR TITLE
[CI] Fix installer tests after 7.66.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -279,7 +279,7 @@ jobs:
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
-            elif command -v datadog-installer; then
+            elif [ -x "/opt/datadog-packages/datadog-installer" ]; then
               echo datadog-installer should not be installed;
               exit 2;
             else
@@ -366,7 +366,7 @@ jobs:
       - run: >
           bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
               datadog-installer version;
-            elif command -v datadog-installer; then
+            elif [ -x "/opt/datadog-packages/datadog-installer" ]; then
               echo datadog-installer should not be installed;
               exit 2;
             else


### PR DESCRIPTION
* Starting in Agent v7.66.0, the installer binary was added to `/usr/bin` post-installation -- meaning that the `datadog-installer` automatically gets added to `$PATH`
* This led to failures in the installer tests because the path is always recognized even when the installer wasn't supposed to be installed. 
* Changed the installer tests to verify if `/opt/datadog-packages/datadog-installer` exists on the disk instead