### PR TITLE
Remove `community.general.zypper` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ Note that the install instructions in this document describe installation of the
   ```shell
   ansible-galaxy collection install ansible.windows
   ```
-- Requires the `community.general` collection to be installed:
-
-  ```shell
-  ansible-galaxy collection install community.general
-  ```
-
 ### Installation
 
 Install the [Datadog role][1] from Ansible Galaxy on your Ansible server:

--- a/ci_test/ansible_lint.sh
+++ b/ci_test/ansible_lint.sh
@@ -72,7 +72,7 @@ popd
 pip install -r requirements-ansible-lint.txt
 
 # Install required collections for linting
-ansible-galaxy collection install ansible.windows community.general
+ansible-galaxy collection install ansible.windows
 
 # lint the ansible-role alone
 ansible-lint -v --exclude=galaxy.yml --exclude=ci_test/ --exclude=manual_tests/ --exclude=.circleci/ --exclude=ansible_collections/ --exclude=.ansible/ --exclude=.venv/

--- a/tasks/pkg-suse/install-installer-zypper.yml
+++ b/tasks/pkg-suse/install-installer-zypper.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install latest datadog-installer package (zypper)
-  community.general.zypper:
+  ansible.builtin.package:
     name: "{{ datadog_installer_flavor }}"
     state: latest # noqa package-latest
   register: datadog_installer_install_result

--- a/tasks/pkg-suse/install-latest.yml
+++ b/tasks/pkg-suse/install-latest.yml
@@ -1,6 +1,6 @@
 ---
 - name: Ensure Datadog agent is installed
-  community.general.zypper:
+  ansible.builtin.package:
     name: datadog-agent
     state: latest # noqa package-latest
   register: agent_datadog_agent_install

--- a/tasks/pkg-suse/install-pinned.yml
+++ b/tasks/pkg-suse/install-pinned.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install pinned datadog-agent package
-  community.general.zypper:
+  ansible.builtin.package:
     name: datadog-agent={{ agent_datadog_agent_suse_version }}
     state: present
     oldpackage: "{{ datadog_agent_allow_downgrade }}"


### PR DESCRIPTION
Removes `community.general.zypper` module from ansible role (and thus collection) to be compatible with Ansible Automation Hub, which doesn't allow use of community modules.

> `ansible.builtin.package` calls behind the module for the package manager used by the operating system discovered by the module `ansible.builtin.setup`. If `ansible.builtin.setup` was not yet run, `ansible.builtin.package` will run it.