### PR TITLE
Only gather facts and services if not done already

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -268,3 +268,4 @@ datadog_ansible_facts_subset:
   - '!all'
   - '!any'
   - min
+  - env

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -263,3 +263,8 @@ datadog_macos_logs_dir: "/opt/datadog-agent/logs"
 datadog_macos_run_dir: "/opt/datadog-agent/run"
 
 datadog_installer_enabled: false
+
+datadog_ansible_facts_subset:
+  - '!all'
+  - '!any'
+  - min

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -1,6 +1,9 @@
 ---
 - name: Populate service facts
   ansible.builtin.service_facts:
+  when:
+    - ansible_facts.services is undefined
+
 - name: Set before 6/7.40.0 flag
   ansible.builtin.set_fact:
     agent_datadog_before_7400: "{{ agent_datadog_major is defined and agent_datadog_minor is defined and agent_datadog_major

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 - name: Gather Ansible Facts
-  ansible.builtin.setup: # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.
+  ansible.builtin.setup:
+    gather_subset: "{{ datadog_ansible_facts_subset }}" # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.
+  when:
+    - ansible_facts is undefined
+    - ansible_facts.system is undefined
 
 - name: Initialize internal datadog_config variable
   ansible.builtin.set_fact:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,8 @@
 ---
 - name: Gather Ansible Facts
   ansible.builtin.setup:
-    gather_subset: "{{ datadog_ansible_facts_subset }}" # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.
+    gather_subset: "{{ datadog_ansible_facts_subset }}"
+    # If the full prefix isn't specified in Ansible 2.10+, we might end up running `ansible.windows.setup` instead.
   when:
     - ansible_facts is undefined
     - ansible_facts.system is undefined


### PR DESCRIPTION
Heja there!

Currently ansible.builtin.setup and ansible.builtin.service_facts are always called. Both can take quite a time on some machines and even if they are quick in scenarios with a lot of machines (>3000) they might add a substantial amount of time maybe not needed. 
I our case we already do both tasks to preprocess some things and given that it's fairly easy to only execute them if realy needed we wanted to offer that PR here.

Also you currently always request the whole fact set. I looked over the code ("ansible_facts.*") and all facts used are already available with the "min" subset. Requesting just the minimal subset partially can save multiple seconds of execution time.

Edit: just some quick measurements on my local machine against one of my hosts:

```
Monday 26 May 2025  08:00:35 +0000 (0:00:06.246)       0:01:16.060 ************
datadog.dd.agent : Populate service facts ------------------------------- 2.34s
datadog.dd.agent : Gather Ansible Facts --------------------------------- 0.88s

Monday 26 May 2025  08:13:29 +0000 (0:00:00.625)       0:01:05.396 ************ 
datadog.dd.agent : Populate service facts ------------------------------- 2.35s
datadog.dd.agent : Gather Ansible Facts --------------------------------- 0.90s

Monday 26 May 2025  08:21:33 +0000 (0:00:00.627)       0:01:01.280 ************ 
not showing up as they are skipped

Monday 26 May 2025  08:27:36 +0000 (0:00:00.647)       0:00:59.929 ************
not showing up as they are skipped
```

As I said, not much for a single execution but in +3000 Hosts even on an AAP it sums up to minutes saved.

