### PR TITLE
[ABLD-27] Prepare deployment of Agent v7.70+ for macOS (arm64/x86_64)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,6 +186,7 @@ jobs:
       xcode: 16.2.0
     steps:
       - checkout
+      #TODO(regis): remove Rosetta 2 translation for Agent v7.70+
       - run:
           name: Install Rosetta 2
           command: printf 'A\n' | sudo softwareupdate --install-rosetta

--- a/README.md
+++ b/README.md
@@ -328,10 +328,12 @@ To override the default behavior, set this variable to something other than an e
 
 When the variable `datadog_macos_download_url` is not set, the official macOS DMG package corresponding to the `datadog_agent_major_version` is used:
 
-| Agent version | Default macOS DMG package URL                                |
-|---------------|--------------------------------------------------------------|
-| 6             | https://install.datadoghq.com/datadog-agent-6-latest.dmg |
-| 7             | https://install.datadoghq.com/datadog-agent-7-latest.dmg |
+| Agent version         | Default macOS DMG package URL                                   |
+|-----------------------|-----------------------------------------------------------------|
+| 6                     | https://install.datadoghq.com/datadog-agent-6-latest.dmg        |
+| 7.69-                 | https://install.datadoghq.com/datadog-agent-7-latest.dmg        |
+| 7.70+ (Intel Mac)     | https://install.datadoghq.com/datadog-agent-7-latest.x86_64.dmg |
+| 7.70+ (Apple Silicon) | https://install.datadoghq.com/datadog-agent-7-latest.arm64.dmg  |
 
 To override the default behavior, set this variable to something other than an empty string.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -249,6 +249,7 @@ datadog_macos_download_url: ""
 # These variables are for internal use only, do not modify them.
 datadog_macos_agent6_latest_url: "https://install.datadoghq.com/datadog-agent-6-latest.dmg"
 datadog_macos_agent7_latest_url: "https://install.datadoghq.com/datadog-agent-7-latest.dmg"
+datadog_macos_agent7_latest_arch_url: "https://install.datadoghq.com/datadog-agent-7-latest.{{ ansible_facts.architecture }}.dmg"
 
 # If datadog_agent_version is set, the role will use the following url prefix instead, and append the version number to it
 # in order to get the full url to the dmg package.

--- a/tasks/pkg-macos/macos_agent_latest.yml
+++ b/tasks/pkg-macos/macos_agent_latest.yml
@@ -4,8 +4,28 @@
     agent_dd_download_url: "{{ datadog_macos_download_url }}"
   when: datadog_macos_download_url | default('', true) | length > 0
 
+- name: Check architecture-specific URL for latest Agent 7
+  ansible.builtin.uri:
+    url: "{{ datadog_macos_agent7_latest_arch_url }}"
+    method: HEAD
+    follow_redirects: all
+    retries: 2
+  register: datadog_macos_agent7_latest_arch_check
+  ignore_errors: true
+  when:
+    - datadog_macos_download_url | default('', true) | length == 0
+    - agent_datadog_agent_major_version | int >= 7
+
 - name: Set agent download filename to latest
   ansible.builtin.set_fact:
-    agent_dd_download_url: "{% if agent_datadog_agent_major_version | int == 7 %}
-      {{ datadog_macos_agent7_latest_url }} {% else %}{{ datadog_macos_agent6_latest_url }}{% endif %}"
+    agent_dd_download_url: >-
+      {%- if agent_datadog_agent_major_version | int < 7 -%}
+      {{ datadog_macos_agent6_latest_url }}
+      {%- else -%}
+      {%- if datadog_macos_agent7_latest_arch_check is defined and datadog_macos_agent7_latest_arch_check.status == 200 -%}
+      {{ datadog_macos_agent7_latest_arch_url }}
+      {%- else -%}
+      {{ datadog_macos_agent7_latest_url }}
+      {%- endif -%}
+      {%- endif -%}
   when: datadog_macos_download_url | default('', true) | length == 0

--- a/tasks/pkg-macos/macos_agent_latest.yml
+++ b/tasks/pkg-macos/macos_agent_latest.yml
@@ -7,11 +7,13 @@
 - name: Check architecture-specific URL for latest Agent 7
   ansible.builtin.uri:
     url: "{{ datadog_macos_agent7_latest_arch_url }}"
-    method: HEAD
+    method: GET
     follow_redirects: all
-    retries: 2
+    return_content: false
+    status_code: 200
   register: datadog_macos_agent7_latest_arch_check
-  ignore_errors: true
+  failed_when: false
+  retries: 2
   when:
     - datadog_macos_download_url | default('', true) | length == 0
     - agent_datadog_agent_major_version | int >= 7
@@ -20,12 +22,9 @@
   ansible.builtin.set_fact:
     agent_dd_download_url: >-
       {%- if agent_datadog_agent_major_version | int < 7 -%}
-      {{ datadog_macos_agent6_latest_url }}
-      {%- else -%}
+      {{ datadog_macos_agent6_latest_url }}{%- else -%}
       {%- if datadog_macos_agent7_latest_arch_check is defined and datadog_macos_agent7_latest_arch_check.status == 200 -%}
-      {{ datadog_macos_agent7_latest_arch_url }}
-      {%- else -%}
-      {{ datadog_macos_agent7_latest_url }}
-      {%- endif -%}
+      {{ datadog_macos_agent7_latest_arch_url }}{%- else -%}
+      {{ datadog_macos_agent7_latest_url }}{%- endif -%}
       {%- endif -%}
   when: datadog_macos_download_url | default('', true) | length == 0

--- a/tasks/pkg-macos/macos_agent_version.yml
+++ b/tasks/pkg-macos/macos_agent_version.yml
@@ -3,4 +3,7 @@
   ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_macos_versioned_url }}-{{ agent_datadog_agent_macos_version }}-1{{ maybe_arch }}.dmg"
   vars:
-    maybe_arch: "{{ '.' + (datadog_agent_macos_architecture | default(ansible_facts.architecture)) if agent_datadog_agent_macos_version is version('7.70', '>=') else '' }}"
+    maybe_arch: >-
+      {{ '.' + (datadog_agent_macos_architecture | default(ansible_facts.architecture))
+      if agent_datadog_agent_macos_version is version('7.70', '>=')
+      else '' }}

--- a/tasks/pkg-macos/macos_agent_version.yml
+++ b/tasks/pkg-macos/macos_agent_version.yml
@@ -3,4 +3,4 @@
   ansible.builtin.set_fact:
     agent_dd_download_url: "{{ datadog_macos_versioned_url }}-{{ agent_datadog_agent_macos_version }}-1{{ maybe_arch }}.dmg"
   vars:
-    maybe_arch: "{{ '.' + datadog_agent_macos_architecture if agent_datadog_agent_macos_version is version('7.70', '>=') else '' }}"
+    maybe_arch: "{{ '.' + (datadog_agent_macos_architecture | default(ansible_facts.architecture)) if agent_datadog_agent_macos_version is version('7.70', '>=') else '' }}"

--- a/tasks/pkg-macos/macos_agent_version.yml
+++ b/tasks/pkg-macos/macos_agent_version.yml
@@ -1,4 +1,6 @@
 ---
 - name: Set agent download filename to a specific version
   ansible.builtin.set_fact:
-    agent_dd_download_url: "{{ datadog_macos_versioned_url }}-{{ agent_datadog_agent_macos_version }}-1.dmg"
+    agent_dd_download_url: "{{ datadog_macos_versioned_url }}-{{ agent_datadog_agent_macos_version }}-1{{ maybe_arch }}.dmg"
+  vars:
+    maybe_arch: "{{ '.' + datadog_agent_macos_architecture if agent_datadog_agent_macos_version is version('7.70', '>=') else '' }}"


### PR DESCRIPTION
This change is meant to take into account how agent deliverables for macOS embed architecture qualifiers (name & metadata) starting from version 7.70 and some of the practical implications.

A word of caution: I'm far from being fluent with `ansible`, let alone with the local setup and conventions, so the change is unlikely to work out of the box nor to be exhaustive.

Following upstream changes might be of interest to reviewers:
- architecture qualifiers:
  - DataDog/omnibus-ruby#240
  - DataDog/agent-release-management#364
- new build for AArch64/ARM64:
  - DataDog/datadog-agent#37676
  - DataDog/agent-release-management#365