### PR TITLE
[AGENTONB-2490] Support `remote_updates` through embedded installer

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -499,7 +499,6 @@ workflows:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: ["rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
-              remote_updates: ["true", "false"]
 
       - test_installer_over_pinned
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -259,8 +259,6 @@ jobs:
         default: "ci.ini"
       apm_enabled:
         type: string
-      remote_updates:
-        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
@@ -275,26 +273,14 @@ jobs:
           ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
-          -e datadog_remote_updates="<<parameters.remote_updates>>"
       - run: >
-          bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
+          bash -c 'if [ -n "<<parameters.apm_enabled>>" ]; then
               datadog-installer version;
             elif [ -x "/opt/datadog-packages/datadog-installer" ]; then
               echo datadog-installer should not be installed;
               exit 2;
             else
               echo datadog-installer is not installed as expected;
-            fi
-            if [ "<<parameters.remote_updates>>" = "true" ]; then
-              if [ -d /opt/datadog-agent ]; then
-                echo "The agent should NOT have been installed by the distribution";
-                exit 1;
-              fi
-            else
-              if [ ! -d /opt/datadog-agent ]; then
-                echo "The agent should have been installed by the distribution";
-                exit 1;
-              fi
             fi'
 
   test_installer_suse:
@@ -307,6 +293,8 @@ jobs:
       inventory:
         type: string
         default: "ci.ini"
+      apm_enabled:
+        type: string
     docker:
       - image: datadog/docker-library:ansible_suse_<<parameters.ansible_version>>
     steps:
@@ -320,17 +308,16 @@ jobs:
       - run: >
           ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer.yaml"
-          -e datadog_remote_updates="true"
+          -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
       - run: >
-          bash -c 'datadog-installer version;
-              if [ ! -d /opt/datadog-packages/datadog-agent ]; then
-                echo "The agent should have been installed by the installer";
-                exit 1;
-              fi
-              if [ -d /opt/datadog-agent ]; then
-                echo "The agent should NOT have been installed by the distribution";
-                exit 1;
-              fi'
+          bash -c 'if [ -n "<<parameters.apm_enabled>>" ]; then
+              datadog-installer version;
+            elif [ -x "/opt/datadog-packages/datadog-installer" ]; then
+              echo datadog-installer should not be installed;
+              exit 2;
+            else
+              echo datadog-installer is not installed as expected;
+            fi'
   
   test_installer_air_gapped_rhel:
     parameters:
@@ -346,8 +333,6 @@ jobs:
         default: "ci.ini"
       apm_enabled:
         type: string
-      remote_updates:
-        type: string
     docker:
       - image: datadog/docker-library:ansible_<<parameters.os>>_<<parameters.ansible_version>>
     steps:
@@ -362,9 +347,8 @@ jobs:
           ANSIBLE_JINJA2_NATIVE="<<parameters.jinja2_native>>" ansible-playbook -v
           -i ./ci_test/inventory/<<parameters.inventory>> "./ci_test/install_installer_air_gapped.yaml"
           -e datadog_apm_instrumentation_enabled="<<parameters.apm_enabled>>"
-          -e datadog_remote_updates="<<parameters.remote_updates>>"
       - run: >
-          bash -c 'if [ -n "<<parameters.apm_enabled>>" ] || [ "<<parameters.remote_updates>>" = "true" ]; then
+          bash -c 'if [ -n "<<parameters.apm_enabled>>" ]; then
               datadog-installer version;
             elif [ -x "/opt/datadog-packages/datadog-installer" ]; then
               echo datadog-installer should not be installed;
@@ -380,18 +364,6 @@ jobs:
                 exit 3;
               else
                 echo "datadog-apm-inject is installed";
-              fi
-            fi
-
-            if [ "<<parameters.remote_updates>>" = "true" ]; then
-              if [ -d /opt/datadog-agent ]; then
-                echo "The agent should NOT have been installed by the distribution";
-                exit 1;
-              fi
-            else
-              if [ ! -d /opt/datadog-agent ]; then
-                echo "The agent should have been installed by the distribution";
-                exit 1;
               fi
             fi'
 
@@ -514,12 +486,12 @@ workflows:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: ["debian", "rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
-              remote_updates: ["true", "false"]
 
       - test_installer_suse:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
+              apm_enabled: ["host", ""]
 
       - test_installer_air_gapped_rhel:
          matrix:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,8 +220,19 @@ jobs:
       - run: cd /tmp/system-tests/lib-injection/build/docker/python/dd-lib-python-init-test-django && sudo docker build -t system-tests/local .
       - run: sudo docker run -d --name test-app-python -p 5985:18080 system-tests/local:latest
       - run: curl --retry 10 --retry-max-time 30 --retry-all-errors localhost:5985
-      # verify that the emitted trace is in trace-agent log
-      - run: timeout 70 grep -m 1 "lang:python" <(tail -F /var/log/datadog/trace-agent.log)
+      # verify that the emitted traces are received by checking agent status
+      - run: |
+          for i in {1..14}; do
+            echo "Checking for traces (attempt $i/14)..."
+            if sudo datadog-agent status "apm agent" --json | jq -e '.apmStats.ratebyservice | keys | length > 0' >/dev/null 2>&1; then
+              echo "✅ Traces found in agent status!"
+              sudo datadog-agent status "apm agent" --json | jq '.apmStats.ratebyservice'
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "❌ No traces found after 70 seconds"
+          exit 1
 
   test_apm_injection_all:
     parameters:

--- a/ci_test/install_agent_7_apm_python.yaml
+++ b/ci_test/install_agent_7_apm_python.yaml
@@ -7,4 +7,4 @@
     datadog_api_key: "11111111111111111111111111111111"
     datadog_agent_major_version: 7
     datadog_apm_instrumentation_enabled: "all"
-    datadog_apm_instrumentation_languages: ["python"]
+    datadog_apm_instrumentation_libraries: ["python"]

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -16,7 +16,8 @@
     name: datadog-agent
     state: restarted
     use: service
-  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin" and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
+  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
+    and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
 
 - name: restart datadog-installer  # noqa name[casing]
   ansible.builtin.service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -7,12 +7,16 @@
   when: datadog_enabled and agent_datadog_sysprobe_enabled and not ansible_check_mode and
     not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
+- name: Gather service facts
+  ansible.builtin.service_facts:
+  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
+
 - name: restart datadog-agent # noqa name[casing]
   ansible.builtin.service:
     name: datadog-agent
     state: restarted
     use: service
-  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
+  when: datadog_enabled and not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin" and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
 
 - name: restart datadog-installer  # noqa name[casing]
   ansible.builtin.service:

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -23,8 +23,8 @@
     name: datadog-installer
     state: restarted
     use: service
-  # The installer currently only setup its systemd unit when remote updates are enabled
-  when: datadog_enabled and datadog_installer_enabled and datadog_remote_updates and
+  # The installer currently only setup its systemd unit when APM instrumentation is enabled
+  when: datadog_enabled and datadog_installer_enabled and
     not ansible_check_mode and not ansible_facts.os_family == "Windows" and not ansible_facts.os_family == "Darwin"
 
 # We can't add the Windows Agent service restart handler directly here because that makes the role require

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -102,7 +102,8 @@
     state: started
     enabled: true
     use: service
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+    and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
   ansible.builtin.service:

--- a/tasks/agent-linux.yml
+++ b/tasks/agent-linux.yml
@@ -102,7 +102,7 @@
     state: started
     enabled: true
     use: service
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and (ansible_facts.services['datadog-agent-exp.service'] is not defined or ansible_facts.services['datadog-agent-exp.service'].state != "running")
 
 - name: Ensure datadog-agent-sysprobe is running if enabled and installed
   ansible.builtin.service:

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -2,7 +2,7 @@
 - name: Enable installer
   ansible.builtin.set_fact:
     datadog_installer_enabled: true
-  when: datadog_apm_instrumentation_enabled | length > 0 or datadog_remote_updates | bool
+  when: datadog_apm_instrumentation_enabled | length > 0
 
 - name: Set internal values for installer registry
   ansible.builtin.set_fact:


### PR DESCRIPTION
* Do not install deprecated installer (deb/rpm) if `datadog_remote_updates` is set to `true`: since `7.69`, `remote_updates` simply needs to be in `datadog.yaml` and installer will take over
* During an upgrade from Fleet (`datadog-agent-exp` service is running), when running the playbook, do not restart/ensure Agent service is running, as during the experiment phase, the Agent service is stopped.
* Remove/update tests that would check for installer with remote_updates

For completeness, a test should be added to verify an ansible playbook runs does not restart the service during an upgrade, e.g. by using `datadog-installer install-experiment` to simulate an upgrade but that will be done in a future.
For now, I tested manually and ensured it indeed does not restart during an upgrade, and resumes afterwards, and that installer is not installed anymore with `datadog_remote_updates`

**Note: if you previously had `datadog_remote_updates` in your playbook, the old installer package (deb/rpm) will need to be removed manually with `apt remove datadog-installer` or equivalent, before re-running the playbook and waiting for an hour. This is to ensure the old installer is not reporting anymore.**

**For new installations (hosts that never had the old installer standalone deb/rpm package), simply setting `datadog_remote_updates` will make the host eligible for upgrade.**