### PR TITLE
Fix broken conditionals for compatibility with Ansible 2.19 / Ansible 12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,7 +427,15 @@ workflows:
               agent_version: ["6", "7"]
               os: ["rocky8"]
               python: ["python3"]
-  
+
+      - test_install_downgrade:
+          matrix:
+            parameters:
+              ansible_version: ["12_0"]
+              agent_version: ["6", "7"]
+              os: ["rocky9", "debian"]
+              python: ["python3.11"]
+
       # Newer debian images only have Pythpn 3 installed
       - test_install_downgrade:
           matrix:
@@ -446,8 +454,14 @@ workflows:
               os: ["debian"]
               python: ["python3"]
 
-      # We want to check that the dnf path works with CentOS 8
-      # Newer CentOS images only have Pythpn 3 installed
+      - test_install_no_manage_config:
+          matrix:
+            parameters:
+              ansible_version: ["12_0"]
+              agent_version: ["6", "7"]
+              os: ["debian"]
+              python: ["python3.11"]
+
       - test_install:
           matrix:
             parameters:
@@ -456,6 +470,15 @@ workflows:
               jinja2_native: ["true", "false"]
               os: ["rocky8"]
               python: ["python3"]
+
+      - test_install:
+          matrix:
+            parameters:
+              ansible_version: ["12_0"]
+              agent_version: ["6", "7"]
+              jinja2_native: ["true", "false"]
+              os: ["rocky9", "suse", "amazonlinux2023"]
+              python: ["python3.11"]
 
       # Newer suse images only have Python 3 installed
       - test_install:
@@ -477,19 +500,19 @@ workflows:
       - test_install_macos:
           matrix:
             parameters:
-              ansible_version: ["2.10", "3.4", "4.10"]
+              ansible_version: ["2.10", "3.4", "4.10", "12.0"]
               agent_version: ["6_macos", "7_macos"]
               python: ["python3"]
 
       - test_apm_injection:
           matrix:
             parameters:
-              ansible_version: ["6.7.0"]
+              ansible_version: ["6.7.0", "12.0.0 "]
 
       - test_apm_injection_all:
           matrix:
             parameters:
-              ansible_version: ["6.7.0"]
+              ansible_version: ["6.7.0", "12.0.0"]
 
       - test_installer:
          matrix:
@@ -498,10 +521,23 @@ workflows:
               os: ["debian", "rocky8", "amazonlinux2023"]
               apm_enabled: ["host", ""]
 
+      - test_installer:
+         matrix:
+           parameters:
+              ansible_version: ["12_0"]
+              os: ["debian", "rocky9", "amazonlinux2023"]
+              apm_enabled: ["host", ""]
+
       - test_installer_suse:
          matrix:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
+              apm_enabled: ["host", ""]
+
+      - test_installer_suse:
+         matrix:
+           parameters:
+              ansible_version: ["12_0"]
               apm_enabled: ["host", ""]
 
       - test_installer_air_gapped_rhel:
@@ -509,6 +545,13 @@ workflows:
            parameters:
               ansible_version: ["2_10", "3_4", "4_10"]
               os: ["rocky8", "amazonlinux2023"]
+              apm_enabled: ["host", ""]
+
+      - test_installer_air_gapped_rhel:
+         matrix:
+           parameters:
+              ansible_version: ["12_0"]
+              os: ["rocky9", "amazonlinux2023"]
               apm_enabled: ["host", ""]
 
       - test_installer_over_pinned
@@ -519,3 +562,10 @@ workflows:
               ansible_version: ["4_10"]
               os: [ "amazonlinux2023"]
               python: ["python3"]
+
+      - test_incorrect_rhel6_detect:
+         matrix:
+           parameters:
+              ansible_version: ["12_0"]
+              os: [ "amazonlinux2023"]
+              python: ["python3.11"]

--- a/tasks/_apt-key-import.yml
+++ b/tasks/_apt-key-import.yml
@@ -38,12 +38,12 @@
 
 - name: Set local helper variable for determining key import (when not {{ datadog_apt_key_current_name }})
   ansible.builtin.set_fact:
-    agent_key_needs_import: "{{ 'false' if agent_key_exists_result.rc == 0 else 'true' }}"
+    agent_key_needs_import: "{{ false if agent_key_exists_result.rc == 0 else true }}"
   when: agent_key_fingerprint != datadog_apt_key_current_name
 
 - name: Set local helper variable for determining key import (when {{ datadog_apt_key_current_name }})
   ansible.builtin.set_fact:
-    agent_key_needs_import: "true"
+    agent_key_needs_import: true
   when: agent_key_fingerprint == datadog_apt_key_current_name
 
 - name: Create temporary directory for key manipulation

--- a/tasks/agent-macos.yml
+++ b/tasks/agent-macos.yml
@@ -17,7 +17,7 @@
 # out of the ABOVE task preventing us from having to run 2 similar commands.
 - name: Extract JSON user data as variable object
   ansible.builtin.set_fact:
-    agent_macos_user_data: "{{ agent_macos_user_output.stdout }}"
+    agent_macos_user_data: "{{ agent_macos_user_output.stdout | from_json }}"
 
 - name: Load user group data
   ansible.builtin.shell:

--- a/tasks/installer-config.yml
+++ b/tasks/installer-config.yml
@@ -12,9 +12,15 @@
         auth: "{{ datadog_installer_auth }}"
         version: "{{ datadog_installer_version }}"
         apm_inject_version: "{{ datadog_apm_inject_version }}"
-  when: datadog_installer_registry or datadog_installer_auth or datadog_installer_version or datadog_apm_inject_version
+  when: >
+    datadog_installer_registry | length > 0 or
+    datadog_installer_auth | length > 0 or
+    datadog_installer_version | length > 0 or
+    datadog_apm_inject_version | length > 0
 
 - name: Update datadog_config including installer registry
   ansible.builtin.set_fact:
     agent_datadog_config: "{{ agent_datadog_config | combine(installer_registry_config, list_merge='keep') }}"
-  when: installer_registry_config and datadog_installer_enabled
+  when: >
+    installer_registry_config is defined and
+    datadog_installer_enabled

--- a/tasks/installer-setup.yml
+++ b/tasks/installer-setup.yml
@@ -28,7 +28,7 @@
   ansible.builtin.set_fact:
     datadog_agent_major_version: "{{ datadog_agent_version.split('.', 1).0 }}"
     datadog_agent_minor_version: "{{ datadog_agent_version.split('.', 1).1 }}"
-  when: datadog_agent_version
+  when: datadog_agent_version | length > 0
 
 # We use this step to not render "empty" environment variables when not set.
 - name: Build Datadog installer environment variables


### PR DESCRIPTION
- Fixes #669: adds compatibility for ansible-core 2.19 and Ansible community 12.0
- Added docker images to `datadog/docker-library` with ansible 12.0 for rocky9, suse, debian, and amazonlinux2023
- Added images to integration tests
https://datadoghq.atlassian.net/browse/AGENTONB-2514