### PR TITLE
remove pycache directory during upgrades

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -29,6 +29,13 @@
 - name: Configure Datadog Installer
   ansible.builtin.include_tasks: installer-config.yml
 
+- name: Remove /opt/datadog-agent/python-scripts/__pycache__
+  ansible.builtin.file:
+    path: /opt/datadog-agent/python-scripts/__pycache__
+    state: absent
+  when: not agent_datadog_skip_install and ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
+  ignore_errors: true
+
 - name: Debian Install Tasks
   ansible.builtin.include_tasks: pkg-debian.yml
   when: ansible_facts.os_family == "Debian"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,7 +34,8 @@
     path: /opt/datadog-agent/python-scripts/__pycache__
     state: absent
   when: not agent_datadog_skip_install and ansible_facts.os_family != "Windows" and ansible_facts.os_family != "Darwin"
-  ignore_errors: true
+  failed_when: false
+  changed_when: false
 
 - name: Debian Install Tasks
   ansible.builtin.include_tasks: pkg-debian.yml

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -116,6 +116,12 @@
     update_cache: true
   when: (datadog_apt_repo | length > 0) and (not ansible_check_mode)
 
+- name: Remove /opt/datadog-agent/python-scripts/__pycache__
+  ansible.builtin.file:
+    path: /opt/datadog-agent/python-scripts/__pycache__
+    state: absent
+  when: not agent_datadog_skip_install
+
 - name: Include installer setup
   ansible.builtin.include_tasks: installer-setup.yml
   when: datadog_installer_enabled

--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -116,12 +116,6 @@
     update_cache: true
   when: (datadog_apt_repo | length > 0) and (not ansible_check_mode)
 
-- name: Remove /opt/datadog-agent/python-scripts/__pycache__
-  ansible.builtin.file:
-    path: /opt/datadog-agent/python-scripts/__pycache__
-    state: absent
-  when: not agent_datadog_skip_install
-
 - name: Include installer setup
   ansible.builtin.include_tasks: installer-setup.yml
   when: datadog_installer_enabled


### PR DESCRIPTION
This PR removes `/opt/datadog-agent/python-scripts/__pycache__` similarly to other installation methods.