### PR TITLE
[CI] Disable appstream install as its not used

### DIFF
--- a/tasks/pkg-redhat/install-installer-dnf.yml
+++ b/tasks/pkg-redhat/install-installer-dnf.yml
@@ -4,6 +4,7 @@
     name: "{{ datadog_installer_flavor }}"
     update_cache: true
     state: latest # noqa package-latest
+    disablerepo: "appstream"
   register: datadog_installer_install_result
   # Since we want to send telemetry including when the installation failed,
   # we need to explicitely ignore failures and skip dependent task when one

--- a/tasks/pkg-redhat/install-latest.yml
+++ b/tasks/pkg-redhat/install-latest.yml
@@ -13,6 +13,7 @@
     name: "{{ datadog_agent_target }}"
     update_cache: true
     state: latest # noqa package-latest
+    disablerepo: "appstream"
   register: agent_datadog_agent_install
   when: not ansible_check_mode
   notify: restart datadog-agent

--- a/tasks/pkg-redhat/install-pinned.yml
+++ b/tasks/pkg-redhat/install-pinned.yml
@@ -5,6 +5,7 @@
     update_cache: true
     state: present
     allow_downgrade: "{{ datadog_agent_allow_downgrade }}"
+    disablerepo: "appstream"
   register: agent_datadog_agent_install
   when: not ansible_check_mode
   notify: restart datadog-agent


### PR DESCRIPTION
- mirror infra shutdown in Centos 8 (EOL) led to CI failures when installing the `appstream` repository, since the mirror urls are being moved to `vault.centos.org` and the original url doesn't work anymore
- but `appstream` is not needed to install the agent or installer, so we can remove it from the installation step. 