### PR TITLE
Update Windows tasks 

### DIFF
--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -4,48 +4,9 @@
 # However, this is here because this is a "handler-like" task that is dynamically
 # included by a handler task in handlers/main.yml.
 
-- name: Stop dependent Datadog services
-  ansible.windows.win_service:
-    name: "{{ item }}"
-    state: stopped
-  loop:
-    - datadog-process-agent
-    - datadog-trace-agent
-    - datadog-system-probe
-    - datadog-security-agent
-  failed_when: false
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
-
-- name: Stop main Datadog agent service
+- name: Restart Windows datadogagent service
   ansible.windows.win_service:
     name: datadogagent
-    state: stopped
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
-
-- name: Wait for services to stop
-  ansible.builtin.pause:
-    seconds: 3
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
-
-- name: Start main Datadog agent service
-  ansible.windows.win_service:
-    name: datadogagent
-    state: started
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
-
-- name: Wait for main service to be ready
-  ansible.builtin.pause:
-    seconds: 5
-  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
-
-- name: Start dependent Datadog services
-  ansible.windows.win_service:
-    name: "{{ item }}"
-    state: started
-  loop:
-    - datadog-process-agent
-    - datadog-trace-agent
-    - datadog-system-probe
-    - datadog-security-agent
-  failed_when: false
+    state: restarted
+    force_dependent_services: true
   when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -3,9 +3,49 @@
 # our role, Ansible only loads the contents of handlers/main.yml as handlers.
 # However, this is here because this is a "handler-like" task that is dynamically
 # included by a handler task in handlers/main.yml.
-- name: Restart Windows datadogagent service
+
+- name: Stop dependent Datadog services
+  ansible.windows.win_service:
+    name: "{{ item }}"
+    state: stopped
+  loop:
+    - datadog-process-agent
+    - datadog-trace-agent
+    - datadog-system-probe
+    - datadog-security-agent
+  failed_when: false
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+
+- name: Stop main Datadog agent service
   ansible.windows.win_service:
     name: datadogagent
-    state: restarted
-    force_dependent_services: true
+    state: stopped
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+
+- name: Wait for services to stop
+  ansible.builtin.pause:
+    seconds: 3
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+
+- name: Start main Datadog agent service
+  ansible.windows.win_service:
+    name: datadogagent
+    state: started
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+
+- name: Wait for main service to be ready
+  ansible.builtin.pause:
+    seconds: 5
+  when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"
+
+- name: Start dependent Datadog services
+  ansible.windows.win_service:
+    name: "{{ item }}"
+    state: started
+  loop:
+    - datadog-process-agent
+    - datadog-trace-agent
+    - datadog-system-probe
+    - datadog-security-agent
+  failed_when: false
   when: datadog_enabled and not ansible_check_mode and ansible_facts.os_family == "Windows"

--- a/handlers/main-win.yml
+++ b/handlers/main-win.yml
@@ -3,7 +3,6 @@
 # our role, Ansible only loads the contents of handlers/main.yml as handlers.
 # However, this is here because this is a "handler-like" task that is dynamically
 # included by a handler task in handlers/main.yml.
-
 - name: Restart Windows datadogagent service
   ansible.windows.win_service:
     name: datadogagent

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -1,8 +1,15 @@
 ---
-- name: Create main Datadog agent configuration file
-  ansible.windows.win_template:
-    # FIXME: should have permissions set to only be readable by ddagentuser
+- name: Generate Datadog config locally
+  ansible.builtin.template:
     src: datadog.yaml.j2
+    dest: "/tmp/datadog.yaml"
+  delegate_to: localhost
+  become: false
+  when: datadog_manage_config
+
+- name: Copy generated config to Windows
+  ansible.windows.win_copy:
+    src: "/tmp/datadog.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\datadog.yaml"
   when: datadog_manage_config
   notify: restart datadog-agent-win
@@ -61,9 +68,18 @@
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
 
-- name: Create a configuration file for each Datadog check
-  ansible.windows.win_template:
+- name: Generate check configuration files locally
+  ansible.builtin.template:
     src: checks.yaml.j2
+    dest: "/tmp/{{ item }}_conf.yaml"
+  with_items: "{{ agent_datadog_checks | list }}"
+  delegate_to: localhost
+  become: false
+  when: datadog_manage_config
+
+- name: Copy check configuration files to Windows
+  ansible.windows.win_copy:
+    src: "/tmp/{{ item }}_conf.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
@@ -93,19 +109,43 @@
     - datadog-trace-agent
     - datadog-process-agent
 
-- name: Create system-probe configuration file
-  ansible.windows.win_template:
+- name: Generate system-probe config locally
+  ansible.builtin.template:
     src: system-probe.yaml.j2
+    dest: "/tmp/system-probe.yaml"
+  delegate_to: localhost
+  become: false
+  when: datadog_manage_config
+
+- name: Copy system-probe config to Windows
+  ansible.windows.win_copy:
+    src: "/tmp/system-probe.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\system-probe.yaml"
   when: datadog_manage_config
   notify: restart datadog-agent-win
+
+- name: Check if datadog-agent service exists
+  ansible.windows.win_service:
+    name: datadogagent
+  register: datadog_service_info
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
 
 - name: Ensure datadog-agent is running
   ansible.windows.win_service:
     name: datadogagent
     state: started
     start_mode: delayed
-  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and datadog_service_info.exists
+  failed_when: false
+  register: datadog_start_result
+
+- name: Wait and retry if service failed to start
+  ansible.windows.win_service:
+    name: datadogagent
+    state: started
+  when: not datadog_skip_running_check and datadog_enabled and not ansible_check_mode and datadog_service_info.exists and datadog_start_result.failed
+  delay: 10
+  retries: 3
 
 - name: Ensure datadog-agent is disabled
   ansible.windows.win_service:
@@ -118,8 +158,35 @@
     - datadog-process-agent
     - datadogagent
 
-- name: Create installation information file
+- name: Generate installation information file locally
   ansible.builtin.template:
     src: install_info.j2
+    dest: "/tmp/install_info"
+  delegate_to: localhost
+  become: false
+
+- name: Copy installation information file to Windows
+  ansible.windows.win_copy:
+    src: "/tmp/install_info"
     dest: "{{ agent_datadog_windows_config_root }}\\install_info"
-    mode: "0644"
+
+- name: Clean up temporary config files
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: absent
+  delegate_to: localhost
+  become: false
+  with_items:
+    - "/tmp/datadog.yaml"
+    - "/tmp/system-probe.yaml"
+    - "/tmp/install_info"
+  failed_when: false
+
+- name: Clean up temporary check config files
+  ansible.builtin.file:
+    path: "/tmp/{{ item }}_conf.yaml"
+    state: absent
+  delegate_to: localhost
+  become: false
+  with_items: "{{ agent_datadog_checks | list }}"
+  failed_when: false

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -3,6 +3,7 @@
   ansible.builtin.template:
     src: datadog.yaml.j2
     dest: "/tmp/datadog.yaml"
+    mode: "0600"
   delegate_to: localhost
   become: false
   when: datadog_manage_config
@@ -72,6 +73,7 @@
   ansible.builtin.template:
     src: checks.yaml.j2
     dest: "/tmp/{{ item }}_conf.yaml"
+    mode: "0600"
   with_items: "{{ agent_datadog_checks | list }}"
   delegate_to: localhost
   become: false
@@ -113,6 +115,7 @@
   ansible.builtin.template:
     src: system-probe.yaml.j2
     dest: "/tmp/system-probe.yaml"
+    mode: "0600"
   delegate_to: localhost
   become: false
   when: datadog_manage_config
@@ -162,6 +165,7 @@
   ansible.builtin.template:
     src: install_info.j2
     dest: "/tmp/install_info"
+    mode: "0600"
   delegate_to: localhost
   become: false
 

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -3,6 +3,7 @@
   ansible.builtin.template:
     src: datadog.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\datadog.yaml"
+    mode: '0644'
   when: datadog_manage_config
   notify: restart datadog-agent-win
 
@@ -64,6 +65,7 @@
   ansible.builtin.template:
     src: checks.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
+    mode: '0644'
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
   notify: restart datadog-agent-win
@@ -96,6 +98,7 @@
   ansible.builtin.template:
     src: system-probe.yaml.j2
     dest: "{{ agent_datadog_windows_config_root }}\\system-probe.yaml"
+    mode: '0644'
   when: datadog_manage_config
   notify: restart datadog-agent-win
 
@@ -137,3 +140,4 @@
   ansible.builtin.template:
     src: install_info.j2
     dest: "{{ agent_datadog_windows_config_root }}\\install_info"
+    mode: '0644'

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -1,16 +1,7 @@
 ---
-- name: Generate Datadog config locally
+- name: Create main Datadog agent configuration file
   ansible.builtin.template:
     src: datadog.yaml.j2
-    dest: "/tmp/datadog.yaml"
-    mode: "0600"
-  delegate_to: localhost
-  become: false
-  when: datadog_manage_config
-
-- name: Copy generated config to Windows
-  ansible.windows.win_copy:
-    src: "/tmp/datadog.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\datadog.yaml"
   when: datadog_manage_config
   notify: restart datadog-agent-win
@@ -69,19 +60,9 @@
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
 
-- name: Generate check configuration files locally
+- name: Create a configuration file for each Datadog check
   ansible.builtin.template:
     src: checks.yaml.j2
-    dest: "/tmp/{{ item }}_conf.yaml"
-    mode: "0600"
-  with_items: "{{ agent_datadog_checks | list }}"
-  delegate_to: localhost
-  become: false
-  when: datadog_manage_config
-
-- name: Copy check configuration files to Windows
-  ansible.windows.win_copy:
-    src: "/tmp/{{ item }}_conf.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\conf.d\\{{ item }}.d\\conf.yaml"
   with_items: "{{ agent_datadog_checks | list }}"
   when: datadog_manage_config
@@ -111,18 +92,9 @@
     - datadog-trace-agent
     - datadog-process-agent
 
-- name: Generate system-probe config locally
+- name: Create system-probe configuration file
   ansible.builtin.template:
     src: system-probe.yaml.j2
-    dest: "/tmp/system-probe.yaml"
-    mode: "0600"
-  delegate_to: localhost
-  become: false
-  when: datadog_manage_config
-
-- name: Copy system-probe config to Windows
-  ansible.windows.win_copy:
-    src: "/tmp/system-probe.yaml"
     dest: "{{ agent_datadog_windows_config_root }}\\system-probe.yaml"
   when: datadog_manage_config
   notify: restart datadog-agent-win
@@ -161,36 +133,7 @@
     - datadog-process-agent
     - datadogagent
 
-- name: Generate installation information file locally
+- name: Create installation information file
   ansible.builtin.template:
     src: install_info.j2
-    dest: "/tmp/install_info"
-    mode: "0600"
-  delegate_to: localhost
-  become: false
-
-- name: Copy installation information file to Windows
-  ansible.windows.win_copy:
-    src: "/tmp/install_info"
     dest: "{{ agent_datadog_windows_config_root }}\\install_info"
-
-- name: Clean up temporary config files
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  delegate_to: localhost
-  become: false
-  with_items:
-    - "/tmp/datadog.yaml"
-    - "/tmp/system-probe.yaml"
-    - "/tmp/install_info"
-  failed_when: false
-
-- name: Clean up temporary check config files
-  ansible.builtin.file:
-    path: "/tmp/{{ item }}_conf.yaml"
-    state: absent
-  delegate_to: localhost
-  become: false
-  with_items: "{{ agent_datadog_checks | list }}"
-  failed_when: false

--- a/templates/datadog.conf.j2
+++ b/templates/datadog.conf.j2
@@ -2,20 +2,20 @@
 
 [Main]
 
-{% if agent_datadog_config["dd_url"] is not defined -%}
+{% if agent_datadog_config is not defined or agent_datadog_config["dd_url"] is not defined -%}
   dd_url: {{ datadog_url | default('https://app.datadoghq.com') }}
 {% endif %}
 
-{% if agent_datadog_config["api_key"] is not defined -%}
+{% if agent_datadog_config is not defined or agent_datadog_config["api_key"] is not defined -%}
   api_key: {{ datadog_api_key }}
 {% endif %}
 
-{% if agent_datadog_config["use_mount"] is not defined -%}
+{% if agent_datadog_config is not defined or agent_datadog_config["use_mount"] is not defined -%}
   use_mount: {{ datadog_use_mount | default('no') }}
 {% endif %}
 
 {# These variables are free-style, passed through a hash -#}
-{% if agent_datadog_config -%}
+{% if agent_datadog_config is defined and agent_datadog_config -%}
 {% for key, value in agent_datadog_config | dictsort -%}
 {{ key }}: {{ value }}
 {% endfor -%}

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -1,16 +1,16 @@
 # {{ ansible_managed }}
 
 {% if datadog_site is defined
-   and agent_datadog_config["site"] is not defined -%}
+   and (agent_datadog_config is not defined or agent_datadog_config["site"] is not defined) -%}
 site: {{ datadog_site }}
 {% endif %}
 
-{% if agent_datadog_config["dd_url"] is not defined
+{% if (agent_datadog_config is not defined or agent_datadog_config["dd_url"] is not defined)
    and datadog_url is defined -%}
 dd_url: {{ datadog_url }}
 {% endif %}
 
-{% if agent_datadog_config["api_key"] is not defined -%}
+{% if agent_datadog_config is not defined or agent_datadog_config["api_key"] is not defined -%}
 api_key: {{ datadog_api_key }}
 {% endif %}
 


### PR DESCRIPTION
Updating Windows tasks and tests:
- Fix templating issues by copying configs to local files to avoid using `win_template`. `win_template` isn't broken but Ansible 12's stricter [template](https://docs.ansible.com/ansible/devel/porting_guides/porting_guide_12.html) changes led to failures while testing
- Broken conditionals in templates 