### PR TITLE
Adjust misleading macOS Agent version documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,12 +328,12 @@ To override the default behavior, set this variable to something other than an e
 
 When the variable `datadog_macos_download_url` is not set, the official macOS DMG package corresponding to the `datadog_agent_major_version` is used:
 
-| Agent version         | Default macOS DMG package URL                                   |
-|-----------------------|-----------------------------------------------------------------|
-| 6                     | https://install.datadoghq.com/datadog-agent-6-latest.dmg        |
-| 7.69-                 | https://install.datadoghq.com/datadog-agent-7-latest.dmg        |
-| 7.70+ (Intel Mac)     | https://install.datadoghq.com/datadog-agent-7-latest.x86_64.dmg |
-| 7.70+ (Apple Silicon) | https://install.datadoghq.com/datadog-agent-7-latest.arm64.dmg  |
+| Agent version | Default macOS DMG package URL                                                         |
+|---------------|---------------------------------------------------------------------------------------|
+| 6             | https://install.datadoghq.com/datadog-agent-6-latest.dmg                              |
+| 7             | https://install.datadoghq.com/datadog-agent-7-latest.dmg (7.69-)                      |
+|               | https://install.datadoghq.com/datadog-agent-7-latest.x86_64.dmg (7.70+, Intel Mac)    |
+|               | https://install.datadoghq.com/datadog-agent-7-latest.arm64.dmg (7.70+, Apple Silicon) |
 
 To override the default behavior, set this variable to something other than an empty string.
 


### PR DESCRIPTION
After merging #664, I realized the change I introduced to a table could be misinterpreted as suggesting that users should set `datadog_agent_major_version` to values like `7.69-` or `7.70+`, when in fact only `6` or `7` are valid inputs:

> When the variable `datadog_macos_download_url` is not set, the official macOS DMG package corresponding to the `datadog_agent_major_version` is used:
>
> | Agent version         | Default macOS DMG package URL                                   |
> |-----------------------|-----------------------------------------------------------------|
> | 6                     | https://install.datadoghq.com/datadog-agent-6-latest.dmg        |
> | 7.69-                 | https://install.datadoghq.com/datadog-agent-7-latest.dmg        |
> | 7.70+ (Intel Mac)     | https://install.datadoghq.com/datadog-agent-7-latest.x86_64.dmg |
> | 7.70+ (Apple Silicon) | https://install.datadoghq.com/datadog-agent-7-latest.arm64.dmg  |

Close to its [former state](https://github.com/DataDog/ansible-datadog/blob/e8eb1616e897639c52260cc801439d5bbe7c43df/README.md#macos), the proposed table aims at preventing confusion by separating user-provided configuration values from automatic resolution logic (where version ranges like `7.69-` or `7.70+` are informational only):

> | Agent version | Default macOS DMG package URL                                                         |
> |---------------|---------------------------------------------------------------------------------------|
> | 6             | https://install.datadoghq.com/datadog-agent-6-latest.dmg                              |
> | 7             | https://install.datadoghq.com/datadog-agent-7-latest.dmg (7.69-)                      |
> |               | https://install.datadoghq.com/datadog-agent-7-latest.x86_64.dmg (7.70+, Intel Mac)    |
> |               | https://install.datadoghq.com/datadog-agent-7-latest.arm64.dmg (7.70+, Apple Silicon) |