### PR TITLE
Add infrastructure_mode variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|
 | `datadog_apm_instrumentation_libraries`     | List of APM libraries to install if `host` or `docker` injection is enabled (defaults to `["java", "js", "dotnet", "python", "ruby"]`). You can find the available values in [Inject Libraries Locally][21].|
 | `datadog_remote_updates`                    | Enable remote installation and updates through the datadog-installer.|
+| `datadog_infrastructure_mode`               | Override the default `infrastructure_mode`.|
 
 ### Integrations
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -196,6 +196,9 @@ datadog_apm_telemetry_endpoint: "https://instrumentation-telemetry-intake.{{ dat
 # Enable remote updates through datadog-installer
 datadog_remote_updates: false
 
+# Set infrastructure monitoring mode (optional)
+# datadog_infrastructure_mode: ""
+
 # Registry, auth, and version for the datadog installer
 datadog_installer_registry: ""
 datadog_installer_auth: ""

--- a/templates/datadog.yaml.j2
+++ b/templates/datadog.yaml.j2
@@ -14,6 +14,11 @@ dd_url: {{ datadog_url }}
 api_key: {{ datadog_api_key }}
 {% endif %}
 
+{% if (agent_datadog_config is not defined or agent_datadog_config["infrastructure_mode"] is not defined)
+   and datadog_infrastructure_mode is defined -%}
+infrastructure_mode: {{ datadog_infrastructure_mode }}
+{% endif %}
+
 {% if datadog_remote_updates is defined -%}
 remote_updates: {{ datadog_remote_updates }}
 {% endif -%}


### PR DESCRIPTION
Add the ability to set `infrastructure_mode` using a variable:

```yaml
  vars:
    datadog_infrastructure_mode: basic
```

https://datadoghq.atlassian.net/browse/AGENTONB-2587