### PR TITLE
macOS: lift Rosetta 2 translation for Agent 7 in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -186,10 +186,13 @@ jobs:
       xcode: 16.2.0
     steps:
       - checkout
-      #TODO(regis): remove Rosetta 2 translation for Agent v7.70+
-      - run:
-          name: Install Rosetta 2
-          command: printf 'A\n' | sudo softwareupdate --install-rosetta
+      - when:
+          condition:
+            equal: [ "6_macos", << parameters.agent_version >> ]
+          steps:
+            - run:
+                name: Install Rosetta 2
+                command: printf 'A\n' | sudo softwareupdate --install-rosetta
       - run:
           name: Install Python3
           command: brew install python@3.11


### PR DESCRIPTION
The Rosetta 2 translation is no longer required for running Agent 7 in CI, since Agent 7.70+ is built "natively" for each of the 2 supported macOS architectures (`x86_64`, and now `arm64`).