### PR TITLE
Add IDEs settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ post_tasks/
 # OSX github datastore
 **/.DS_Store
 
+# IDEs
+.vscode/
+.idea/
+.cursor/
+.zed/


### PR DESCRIPTION
IDEs can store project-level settings in local dirs, they should not be committed.