### PR TITLE
[AGENTONB-2495][Windows] Provide users a way to skip and force reinstall of Datadog Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_windows_ddagentuser_password`      | The password used to create the user and/or register the service (Windows only).|
 | `datadog_apply_windows_614_fix`             | Whether or not to download and apply file referenced by `datadog_windows_614_fix_script_url` (Windows only). See https://dtdg.co/win-614-fix for more details. You can set this to `false` assuming your hosts aren't running Datadog Agent 6.14.\*.|
 | `datadog_windows_skip_install`              | Set to `true` to force the role to skip Windows Agent installation even if the role detects that installation is required (Windows only).|
-| `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent regardless of the automatic feature detection logic (Windows only).|
+| `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent. This option takes precedence over `datadog_windows_skip_install` (Windows only). |
 | `datadog_macos_user`                        | The name of the user to run Agent under. The user has to exist, it won't be created automatically. Defaults to `ansible_user` (macOS only).|
 | `datadog_macos_download_url`                | Override the URL to download the DMG installer from (macOS only).|
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_windows_ddagentuser_password`      | The password used to create the user and/or register the service (Windows only).|
 | `datadog_apply_windows_614_fix`             | Whether or not to download and apply file referenced by `datadog_windows_614_fix_script_url` (Windows only). See https://dtdg.co/win-614-fix for more details. You can set this to `false` assuming your hosts aren't running Datadog Agent 6.14.\*.|
 | `datadog_windows_skip_install`              | Set to `true` to force the role to skip Windows Agent installation even if the role detects that installation is required (Windows only).|
-| `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent. This option takes precedence over `datadog_windows_skip_install` (Windows only). |
+| `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent. This option takes precedence over `datadog_windows_skip_install` (Windows only).|
 | `datadog_macos_user`                        | The name of the user to run Agent under. The user has to exist, it won't be created automatically. Defaults to `ansible_user` (macOS only).|
 | `datadog_macos_download_url`                | Override the URL to download the DMG installer from (macOS only).|
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ These variables provide additional configuration during the installation of the 
 | `datadog_windows_ddagentuser_name`          | The name of Windows user to create/use, in the format `<domain>\<user>` (Windows only).|
 | `datadog_windows_ddagentuser_password`      | The password used to create the user and/or register the service (Windows only).|
 | `datadog_apply_windows_614_fix`             | Whether or not to download and apply file referenced by `datadog_windows_614_fix_script_url` (Windows only). See https://dtdg.co/win-614-fix for more details. You can set this to `false` assuming your hosts aren't running Datadog Agent 6.14.\*.|
+| `datadog_windows_skip_install`              | Set to `true` to force the role to skip Windows Agent installation even if the role detects that installation is required (Windows only).|
+| `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent regardless of the automatic feature detection logic (Windows only).|
 | `datadog_macos_user`                        | The name of the user to run Agent under. The user has to exist, it won't be created automatically. Defaults to `ansible_user` (macOS only).|
 | `datadog_macos_download_url`                | Override the URL to download the DMG installer from (macOS only).|
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -161,6 +161,14 @@ datadog_windows_614_fix_script_url: "https://s3.amazonaws.com/ddagent-windows-st
 # whether or not to download and apply the above fix
 datadog_apply_windows_614_fix: true
 
+# Force the role to skip reinstall steps on Windows, even if the Agent
+# isn't detected yet.
+datadog_windows_skip_install: false
+
+# Force the role to reinstall the Agent on Windows regardless of the
+# automatic feature checks. This can be used to downgrade the Agent on Windows.
+datadog_windows_force_reinstall: false
+
 # Override to change the name of the windows user to create
 datadog_windows_ddagentuser_name: ""
 # Override to change the password of the created windows user.

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -16,6 +16,7 @@
 - name: Force Agent reinstall when requested
   ansible.builtin.set_fact:
     agent_datadog_force_reinstall: true
+    agent_datadog_skip_install: false
   when: datadog_windows_force_reinstall | bool
 
 - name: Download windows datadog agent 614 fix script
@@ -58,6 +59,37 @@
   register: agent_download_msi_result
   when: (not agent_datadog_skip_install) and (not ansible_check_mode)
 
+- name: Look up installed Datadog Agent product ids when forcing reinstall
+  ansible.windows.win_shell: |
+    $productName = "Datadog Agent"
+    $uninstallRoots = @(
+      "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall",
+      "HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall"
+    )
+    $productIds = foreach ($root in $uninstallRoots) {
+      if (-not (Test-Path $root)) {
+        continue
+      }
+      Get-ItemProperty "$root\*" -ErrorAction SilentlyContinue |
+        Where-Object { $_.DisplayName -clike $productName } |
+        Select-Object -ExpandProperty PSChildName
+    }
+    $productIds | Sort-Object -Unique
+  register: agent_datadog_installed_product_ids_result
+  changed_when: false
+  check_mode: false
+  when:
+    - not agent_datadog_skip_install
+    - agent_datadog_force_reinstall
+
+- name: Cache installed product ids when available
+  ansible.builtin.set_fact:
+    agent_datadog_windows_installed_product_ids: "{{ agent_datadog_installed_product_ids_result.stdout_lines | select('match', '.+') | list }}"
+  when:
+    - not agent_datadog_skip_install
+    - agent_datadog_force_reinstall
+    - agent_datadog_installed_product_ids_result.stdout_lines | length > 0
+
 - name: Create Binary directory root (if not default)
   ansible.windows.win_file:
     path: "{{ datadog_windows_program_files_dir }}"
@@ -86,11 +118,16 @@
   when: datadog_windows_ddagentuser_password | default('', true) | length > 0
   no_log: true
 
-- name: Uninstall agent to update optional features
+- name: Uninstall installed Datadog Agent to update optional features or downgrade or because requested
   ansible.windows.win_package:
-    path: "{{ agent_download_msi_result.dest }}"
+    product_id: "{{ item }}"
     state: absent
-  when: not agent_datadog_skip_install and agent_datadog_force_reinstall
+  loop: "{{ agent_datadog_windows_installed_product_ids }}"
+  when:
+    - not agent_datadog_skip_install
+    - agent_datadog_force_reinstall
+    - agent_datadog_windows_installed_product_ids is defined
+    - agent_datadog_windows_installed_product_ids | length > 0
 
 - name: Install downloaded agent
   ansible.windows.win_package:

--- a/tasks/pkg-windows.yml
+++ b/tasks/pkg-windows.yml
@@ -8,6 +8,16 @@
 - name: Include Windows opts tasks
   ansible.builtin.include_tasks: pkg-windows-opts.yml
 
+- name: Force skip install when requested
+  ansible.builtin.set_fact:
+    agent_datadog_skip_install: true
+  when: datadog_windows_skip_install | bool
+
+- name: Force Agent reinstall when requested
+  ansible.builtin.set_fact:
+    agent_datadog_force_reinstall: true
+  when: datadog_windows_force_reinstall | bool
+
 - name: Download windows datadog agent 614 fix script
   ansible.windows.win_get_url:
     url: "{{ datadog_windows_614_fix_script_url }}"


### PR DESCRIPTION
### What does this PR do

Introduces for Windows two new parameters publicly available:
* `datadog_windows_skip_install`: skip install-related tasks 
* `datadog_windows_force_reinstall`: force reinstallation:
    * Currently, we do not allow downgrades, only same version change to enable NPM. This PR allows to now downgrade by having the role uninstall the installed version before installing the new one, going over the MSI limitation when providing the parameter

### Motivation

Currently, we have internal facts:
* `agent_datadog_skip_install`: skip install if we detect the desired version is already installed. On Windows, unlike Linux, not specifying a version always re-installs latest since we can't know unlike on Linux when using package managers
* `agent_datadog_force_reinstall`: force reinstall if NPM is enabled https://github.com/DataDog/ansible-datadog/blob/8218ea5696054ed8d5f521e9804d00a0fe74fa5c/tasks/pkg-windows-opts.yml#L117-L120

Now, this logic can be overridden explicitly by users providing these values in their playbook.

### QA

Already tested on Windows:
* `datadog_windows_skip_install`: on a bare VM (no Agent installed), use a playbook with `datadog_windows_skip_install: true` and ensure the Agent doesn't get installed, it will error out later since `C:\ProgramData\Datadog` does not exist
    * Then, install the Agent by removing the variable, and re-add it, ensure the latest does not get re-downloaded
    
    | Without `datadog_windows_skip_install` | With `datadog_windows_skip_install` |
    |----------|------|
    | <img width="1496" height="503" alt="image" src="https://github.com/user-attachments/assets/a0a9cd07-dc0a-4944-a194-7d1e1242224b" /> | <img width="1512" height="684" alt="image" src="https://github.com/user-attachments/assets/0234d34d-dc23-4b74-97f8-5836b680a5fc" /> |
    
* `datadog_windows_force_reinstall`: provide `datadog_windows_force_reinstall: true` and `datadog_agent_version` and ensure the same version gets re-installed / provide a lower `datadog_agent_version` and it should downgrade instead of erroring. Example below starting from `7.72.2` and trying to downgrade to `7.70.1`

| Without `datadog_windows_force_reinstall` | With `datadog_windows_force_reinstall` |
|----------|------|
| <img width="1512" height="684" alt="image" src="https://github.com/user-attachments/assets/521f1bd6-db69-45bd-8361-27b692bdb65e" /> | <img width="1512" height="684" alt="image" src="https://github.com/user-attachments/assets/36dc3ece-2c84-477a-8083-bd5e7a8f2963" /> |