### PR TITLE
Disable logging of sentitive integration configs

### DIFF
--- a/tasks/sanitize-checks.yml
+++ b/tasks/sanitize-checks.yml
@@ -2,6 +2,7 @@
 - name: Defend against defined but null datadog_checks variable
   ansible.builtin.set_fact:
     agent_datadog_checks: "{{ datadog_checks | default({}, true) }}"
+  no_log: true
 
 - name: Resolve agent_datadog_tracked_checks
   ansible.builtin.set_fact:


### PR DESCRIPTION
When running the Datadog role with verbosity on, the contents of datadog_checks is logged to output here. Integration configs can contain passwords and should not be logged.

FIX: Do not log this var when verbosity is enabled