### PR TITLE
Allow configuring the SSI install script download location to ensure it can be executed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -270,6 +270,45 @@ jobs:
             sudo datadog-installer is-installed datadog-apm-library-$tracer;
           done'
 
+  test_apm_injection_custom_dir:
+    parameters:
+      ansible_version:
+        type: string
+
+    machine:
+      image: ubuntu-2204:2023.10.1 # includes docker and docker-compose
+
+    steps:
+      - checkout
+      # these repos have expired GPG keys and make APT fail (and we don't need them)
+      - run: sudo rm /etc/apt/sources.list.d/*
+      - run: pip3 install ansible==<<parameters.ansible_version>>
+      - run: ansible-playbook --become -i ./ci_test/inventory/ci.ini "./ci_test/install_agent_7_apm_custom_dir.yaml"
+      - run: sudo datadog-agent status || true
+      - run: ps aux | grep -v grep | grep datadog-agent
+      # Verify that SSI was installed with custom directory
+      - run: >
+          bash -c '
+          # Check that datadog-installer is present
+          sudo datadog-installer --version || exit 1
+          # Check that APM libraries were installed
+          sudo datadog-installer is-installed datadog-apm-library-python || exit 1
+          sudo datadog-installer is-installed datadog-apm-library-java || exit 1
+          '
+      # Verify the custom directory was used and cleaned up
+      - run: |
+          if [ -d /opt/datadog-ssi-scripts ]; then
+            echo "Custom SSI script directory exists"
+            if [ -f /opt/datadog-ssi-scripts/install-ssi.sh ]; then
+              echo "ERROR: SSI script was not cleaned up"
+              exit 1
+            fi
+            echo "SSI script was properly cleaned up"
+          else
+            echo "Custom SSI script directory was not created"
+            exit 1
+          fi
+
   test_incorrect_rhel6_detect:
     # Ensure some RHEL derivatives aren't incorrectly detected as RHEL 6
     docker:
@@ -387,6 +426,11 @@ workflows:
               ansible_version: ["6.7.0", "12.0.0 "]
 
       - test_apm_injection_all:
+          matrix:
+            parameters:
+              ansible_version: ["6.7.0", "12.0.0"]
+
+      - test_apm_injection_custom_dir:
           matrix:
             parameters:
               ansible_version: ["6.7.0", "12.0.0"]

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_macos_download_url`                | Override the URL to download the DMG installer from (macOS only).|
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|
 | `datadog_apm_instrumentation_libraries`     | List of APM libraries to install if `host` or `docker` injection is enabled (defaults to `["java", "js", "dotnet", "python", "ruby"]`). You can find the available values in [Inject Libraries Locally][21].|
+| `datadog_ssi_script_dir`                    | Directory where the Single Step Instrumentation (SSI) script will be downloaded and executed. Defaults to `/var/run/datadog-ssi`. Override this if the default location has noexec mount restrictions.|
 | `datadog_remote_updates`                    | Enable remote installation and updates through the datadog-installer.|
 | `datadog_infrastructure_mode`               | Override the default `infrastructure_mode`.|
 

--- a/ci_test/install_agent_7_apm_custom_dir.yaml
+++ b/ci_test/install_agent_7_apm_custom_dir.yaml
@@ -1,0 +1,12 @@
+---
+
+- hosts: all
+  roles:
+    - { role: "/home/circleci/project/" }
+  vars:
+    datadog_api_key: "11111111111111111111111111111111"
+    datadog_agent_major_version: 7
+    datadog_apm_instrumentation_enabled: "host"
+    datadog_apm_instrumentation_libraries: ["python", "java"]
+    # Test custom SSI script directory
+    datadog_ssi_script_dir: "/opt/datadog-ssi-scripts"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -202,6 +202,11 @@ datadog_apm_inject_version: ""
 # https://docs.datadoghq.com/tracing/trace_collection/library_injection_local
 datadog_apm_instrumentation_libraries: []
 
+# Directory where the Single Step Instrumentation (SSI) script will be downloaded and executed.
+# Default uses /var/run which is typically writable and allows execution.
+# Override this if /var/run is not suitable in your environment.
+datadog_ssi_script_dir: "/var/run/datadog-ssi"
+
 # Enable remote updates through datadog-installer
 datadog_remote_updates: false
 

--- a/tasks/apm-single-step-instrumentation.yml
+++ b/tasks/apm-single-step-instrumentation.yml
@@ -28,9 +28,9 @@
       }}
 
 # Create the directory for the datadog-installer script
-- name: Create /tmp/datadog-installer directory
+- name: Create directory for SSI script
   ansible.builtin.file:
-    path: /tmp/datadog-installer
+    path: "{{ datadog_ssi_script_dir }}"
     state: directory
     mode: "0755"
 
@@ -38,7 +38,7 @@
 - name: Download datadog-installer install-ssi.sh script
   ansible.builtin.get_url:
     url: "{{ datadog_installer_install_ssi_script_url }}"
-    dest: /tmp/datadog-installer/install-ssi.sh
+    dest: "{{ datadog_ssi_script_dir }}/install-ssi.sh"
     mode: "0750"
     # Always overwrite the file to ensure we have the latest version.
     force: true
@@ -46,7 +46,14 @@
 
 - name: Run datadog-installer install-ssi.sh script
   ansible.builtin.command:
-    cmd: /tmp/datadog-installer/install-ssi.sh
+    cmd: "{{ datadog_ssi_script_dir }}/install-ssi.sh"
   environment: "{{ datadog_apm_single_step_instrumentation_environment }}"
   when: install_ssi_script_result.status_code == 200
   changed_when: true
+
+# Clean up the script after execution for security
+- name: Clean up SSI script after execution
+  ansible.builtin.file:
+    path: "{{ datadog_ssi_script_dir }}/install-ssi.sh"
+    state: absent
+  when: install_ssi_script_result.status_code == 200


### PR DESCRIPTION
Instead of hard-coding to `/tmp/datadog-installer/`, let's use `/var/run` by default and provides users ability to override it in case `noexec` is set on the default location. The script only needs to run once and deleted, its location does not matter.

Alternatively, we could download and execute directly without saving it