### PR TITLE
Followup: use previous default for SSI script download location

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -203,9 +203,9 @@ datadog_apm_inject_version: ""
 datadog_apm_instrumentation_libraries: []
 
 # Directory where the Single Step Instrumentation (SSI) script will be downloaded and executed.
-# Default uses /var/run which is typically writable and allows execution.
-# Override this if /var/run is not suitable in your environment.
-datadog_ssi_script_dir: "/var/run/datadog-ssi"
+# Default uses /tmp/datadog-installer.
+# Override this if /tmp/datadog-installer is not suitable in your environment.
+datadog_ssi_script_dir: "/tmp/datadog-installer"
 
 # Enable remote updates through datadog-installer
 datadog_remote_updates: false


### PR DESCRIPTION
In https://github.com/DataDog/ansible-datadog/pull/694, we provided a way to configure the installation location of the script for SSI. However, the new default `/var/run/datadog-ssi` is not really suitable in terms of permissions, so let's use the previous default `/tmp/datadog-installer` that is world-writable and users can still modify it if they prefer