### PR TITLE
chore: replace injected facts 'ansible_' with dictionary 'ansible_facts'

### DIFF
--- a/tasks/pkg-debian.yml
+++ b/tasks/pkg-debian.yml
@@ -52,8 +52,8 @@
     dest: "{{ datadog_apt_trusted_d_keyring }}"
     mode: "0644"
     remote_src: true
-  when: ((ansible_distribution == 'Debian' and ansible_distribution_major_version|int < 9) or
-    (ansible_distribution == 'Ubuntu' and ansible_distribution_major_version | int < 16)) and not ansible_check_mode
+  when: ((ansible_facts['distribution'] == 'Debian' and ansible_facts['distribution_major_version']|int < 9) or
+    (ansible_facts['distribution'] == 'Ubuntu' and ansible_facts['distribution_major_version'] | int < 16)) and not ansible_check_mode
 
 - name: Ensure Datadog non-https repositories and repositories not using signed-by option are deprecated
   ansible.builtin.apt_repository:

--- a/tasks/pkg-suse.yml
+++ b/tasks/pkg-suse.yml
@@ -7,7 +7,7 @@
       ) }}
 
 - name: Check and download RPM Key(SLES11) # Work around due to SNI check for SLES11
-  when: ansible_distribution_version|int == 11
+  when: ansible_facts['distribution_version']|int == 11
   block:
     - name: Stat if current RPM key already exists
       ansible.builtin.stat:
@@ -27,7 +27,7 @@
     dest: /tmp/DATADOG_RPM_KEY_CURRENT.public
     force: true
     mode: '600'
-  when: ansible_distribution_version|int >= 12
+  when: ansible_facts['distribution_version']|int >= 12
 
 - name: Import current RPM key
   ansible.builtin.rpm_key:
@@ -36,7 +36,7 @@
   when: not ansible_check_mode
 
 - name: Check and download E09422B3 key # Work around due to SNI check for SLES11
-  when: ansible_distribution_version|int == 11
+  when: ansible_facts['distribution_version']|int == 11
   block:
     - name: Stat if E09422B3 key (Expires 2022) RPM key already exists
       ansible.builtin.stat:
@@ -55,7 +55,7 @@
     dest: /tmp/DATADOG_RPM_KEY_E09422B3.public
     checksum: sha256:{{ datadog_zypper_gpgkey_e09422b3_sha256sum }}
     mode: '600'
-  when: ansible_distribution_version|int >= 12 and agent_datadog_minor is defined and agent_datadog_minor | int < 36
+  when: ansible_facts['distribution_version']|int >= 12 and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Import E09422B3 key (Expires 2022) RPM key
   ansible.builtin.rpm_key:
@@ -64,7 +64,7 @@
   when: not ansible_check_mode and agent_datadog_minor is defined and agent_datadog_minor | int < 36
 
 - name: Check and download 20200908 key # Work around due to SNI check for SLES11
-  when: ansible_distribution_version|int == 11
+  when: ansible_facts['distribution_version']|int == 11
   block:
     - name: Stat if 20200908 key (Expires 2024) RPM key already exists
       ansible.builtin.stat:
@@ -83,7 +83,7 @@
     dest: /tmp/DATADOG_RPM_KEY_20200908.public
     checksum: sha256:{{ datadog_zypper_gpgkey_20200908_sha256sum }}
     mode: '600'
-  when: ansible_distribution_version|int >= 12
+  when: ansible_facts['distribution_version']|int >= 12
 
 - name: Import 20200908 key (Expires 2024) RPM key
   ansible.builtin.rpm_key:
@@ -92,7 +92,7 @@
   when: not ansible_check_mode
 
 - name: Check and download 20280418 key # Work around due to SNI check for SLES11
-  when: ansible_distribution_version|int == 11
+  when: ansible_facts['distribution_version']|int == 11
   block:
     - name: Stat if 20280418 key (Expires 2028) RPM key already exists
       ansible.builtin.stat:
@@ -111,7 +111,7 @@
     dest: /tmp/DATADOG_RPM_KEY_20280418.public
     checksum: "sha256:{{ datadog_zypper_gpgkey_20280418_sha256sum }}"
     mode: '600'
-  when: ansible_distribution_version|int >= 12
+  when: ansible_facts['distribution_version']|int >= 12
 
 - name: Import 20280418 key (Expires 2028) RPM key
   ansible.builtin.rpm_key:

--- a/templates/zypper.repo.j2
+++ b/templates/zypper.repo.j2
@@ -16,7 +16,7 @@ type=rpm-md
 gpgcheck={{ datadog_zypper_gpgcheck|int }}
 repo_gpgcheck={{ agent_do_zypper_repo_gpgcheck|int }}
 {# zypper in SUSE < 15 will not parse (SUSE 11) or respect (SUSE 12 - 14) mutliple entries in gpgkey #}
-{% if ansible_distribution_version|int < 15 %}
+{% if ansible_facts['distribution_version']|int < 15 %}
 gpgkey={{ datadog_zypper_gpgkey_current }}
 {% else %}
 gpgkey={{ datadog_zypper_gpgkey_current }}


### PR DESCRIPTION
Follow up of #304

I at least still got some warnings:
```
53     mode: "0644"
54     remote_src: true
55   when: ((ansible_distribution == 'Debian' and ansible_distribution_major_version|int < 9) or
           ^ column 9
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.
```