### PR TITLE
Remove Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "bundler"
-    directory: "/"
-    schedule:
-      interval: "monthly"


### PR DESCRIPTION
As part of #incident-51602-public, we are temporarily disabling all automated dependency updaters to reduce exposure to potential zero-day vulnerabilities in recent releases.

This PR removes the Dependabot/Renovate configuration from this repository until further notice.

⚠️ Do not merge if your repository is managed by ADMS.

Please refer to #incident-51602-public for updates and to confirm when it is safe to re-enable.