### PR TITLE
Force dependent services to stop/restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ These variables provide additional configuration during the installation of the 
 | `datadog_apply_windows_614_fix`             | Whether or not to download and apply file referenced by `datadog_windows_614_fix_script_url` (Windows only). See https://dtdg.co/win-614-fix for more details. You can set this to `false` assuming your hosts aren't running Datadog Agent 6.14.\*.|
 | `datadog_windows_skip_install`              | Set to `true` to force the role to skip Windows Agent installation even if the role detects that installation is required (Windows only).|
 | `datadog_windows_force_reinstall`           | Set to `true` to force the role to reinstall the Windows Agent. This option takes precedence over `datadog_windows_skip_install` (Windows only).|
+| `datadog_windows_force_dependent_services`  | Set to `true` to force dependent Windows services to stop or restart (Windows only).|
 | `datadog_macos_user`                        | The name of the user to run Agent under. The user has to exist, it won't be created automatically. Defaults to `ansible_user` (macOS only).|
 | `datadog_macos_download_url`                | Override the URL to download the DMG installer from (macOS only).|
 | `datadog_apm_instrumentation_enabled`       | Configure APM instrumentation. Possible values are: <br/> - `host`: Both the Agent and your services are running on a host. <br/> - `docker`: The Agent and your services are running in separate Docker containers on the same host.<br/>- `all`: Supports all the previous scenarios for `host` and `docker` at the same time.|

--- a/tasks/agent-win.yml
+++ b/tasks/agent-win.yml
@@ -141,6 +141,7 @@
     name: "{{ item }}"
     state: stopped
     start_mode: disabled
+    force_dependent_services: "{{ datadog_windows_force_dependent_services | default(false) | bool }}"
   when: not datadog_skip_running_check and not datadog_enabled and not datadog_remote_update_in_progress
   with_list:
     - datadog-trace-agent


### PR DESCRIPTION
When running the official Datadog Ansible role on Windows machines, tasks that attempt to stop or modify the core datadogagent service fail if sub-agents (such as the trace agent or process agent) are running. Because datadogagent acts as a parent service with active Windows service dependencies (datadog-process-agent, datadog-trace-agent, etc.), Ansible's underlying Windows service module throws an unhandled exception:  ```Cannot stop service 'Datadog Agent (datadogagent)' because it has dependent services. It can only be stopped if the Force flag is set.```

The pull adds ```force_dependent_services``` to the Windows service tasks to properly cascade stop commands to dependent sub-agents without throwing exceptions.